### PR TITLE
Add spring-ai-agent-utils-bom module and update docs to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ spring-ai-agent-utils/
 ├── spring-ai-agent-utils-common/   # Shared subagent SPI (interfaces & records)
 ├── spring-ai-agent-utils/          # Core library (tools, skills, Claude subagents)
 ├── spring-ai-agent-utils-a2a/      # A2A protocol subagent implementation
+├── spring-ai-agent-utils-bom/      # Bill of Materials for version management
 │
 └── examples/
     ├── code-agent-demo/            # Full-featured AI coding assistant
@@ -67,6 +68,7 @@ While these tools can be used standalone, truly agentic behavior emerges when th
 | [**spring-ai-agent-utils**](spring-ai-agent-utils/README.md) | Core library - tools, skills, Claude subagents, and full API reference |
 | [**spring-ai-agent-utils-common**](spring-ai-agent-utils-common/README.md) | Shared subagent SPI (SubagentDefinition, SubagentResolver, SubagentExecutor, SubagentType) |
 | [**spring-ai-agent-utils-a2a**](spring-ai-agent-utils-a2a/README.md) | A2A protocol subagent for remote agent orchestration |
+| [**spring-ai-agent-utils-bom**](spring-ai-agent-utils-bom/pom.xml) | Bill of Materials for consistent version management across all modules |
 | [**Examples**](#examples) | Working demos showcasing different use cases |
 
 
@@ -74,11 +76,36 @@ While these tools can be used standalone, truly agentic behavior emerges when th
 
 **1. Add dependency:**
 
+Use the BOM to manage versions consistently across all modules:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agent-utils-bom</artifactId>
+            <version>0.5.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-agent-utils</artifactId>
+    </dependency>
+</dependencies>
+```
+
+Or add the core library directly:
+
 ```xml
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-agent-utils</artifactId>
-    <version>0.4.2</version>
+    <version>0.5.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <module>spring-ai-agent-utils-common</module>
         <module>spring-ai-agent-utils</module>
         <module>spring-ai-agent-utils-a2a</module>
+        <module>spring-ai-agent-utils-bom</module>
         <module>examples</module>
     </modules>
 

--- a/spring-ai-agent-utils-bom/pom.xml
+++ b/spring-ai-agent-utils-bom/pom.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025-2025 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springaicommunity</groupId>
+		<artifactId>spring-ai-agent-utils-parent</artifactId>
+		<version>0.5.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-ai-agent-utils-bom</artifactId>
+	<version>0.5.0-SNAPSHOT</version>
+
+	<packaging>pom</packaging>
+
+	<name>Spring AI Agent Utilities BOM</name>
+	<description>Bill of Materials POM (BOM) for the Spring AI Agent Utilities modules</description>
+
+    <url>https://github.com/spring-ai-community/spring-ai-agent-utils</url>
+
+    <scm>
+        <url>https://github.com/spring-ai-community/spring-ai-agent-utils</url>
+        <connection>git://github.com/spring-ai-community/spring-ai-agent-utils.git</connection>
+        <developerConnection>git@github.com:spring-ai-community/spring-ai-agent-utils.git</developerConnection>
+    </scm>
+
+    <organization>
+        <name>Spring AI Community</name>
+        <url>https://github.com/spring-ai-community</url>
+    </organization>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Christian Tzolov</name>
+        </developer>
+    </developers>
+
+    <issueManagement>
+        <system>Github Issues</system>
+        <url>https://github.com/spring-ai-community/spring-ai-agent-utils/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>Github Actions</system>
+        <url>https://github.com/spring-ai-community/spring-ai-agent-utils/actions</url>
+    </ciManagement>
+
+	<properties>
+		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+		<maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+
+			<dependency>
+				<groupId>org.springaicommunity</groupId>
+				<artifactId>spring-ai-agent-utils-common</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springaicommunity</groupId>
+				<artifactId>spring-ai-agent-utils</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.springaicommunity</groupId>
+				<artifactId>spring-ai-agent-utils-a2a</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+		</dependencies>
+
+	</dependencyManagement>
+
+	<repositories>
+		<repository>
+			<name>Central Portal Snapshots</name>
+			<id>central-portal-snapshots</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+		<repository>
+			<id>maven-central</id>
+			<url>https://repo.maven.apache.org/maven2/</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-milestones</id>
+			<name>Spring Milestones</name>
+			<url>https://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>${flatten-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+						<configuration>
+							<updatePomFile>true</updatePomFile>
+							<flattenMode>ossrh</flattenMode>
+							<pomElements>
+								<distributionManagement>remove</distributionManagement>
+								<dependencyManagement>keep</dependencyManagement>
+								<repositories>remove</repositories>
+								<scm>keep</scm>
+								<url>keep</url>
+								<organization>resolve</organization>
+							</pomElements>
+						</configuration>
+					</execution>
+					<execution>
+						<id>clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>${maven-deploy-plugin.version}</version>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-ai-agent-utils/README.md
+++ b/spring-ai-agent-utils/README.md
@@ -38,12 +38,34 @@ While these tools can be used standalone, truly agentic behavior emerges when th
 
 ## Installation
 
-**Maven:**
+**Maven (recommended — using the BOM):**
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springaicommunity</groupId>
+            <artifactId>spring-ai-agent-utils-bom</artifactId>
+            <version>0.5.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+
+<dependencies>
+    <dependency>
+        <groupId>org.springaicommunity</groupId>
+        <artifactId>spring-ai-agent-utils</artifactId>
+    </dependency>
+</dependencies>
+```
+
+**Maven (direct):**
 ```xml
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-agent-utils</artifactId>
-    <version>0.4.2</version>
+    <version>0.5.0</version>
 </dependency>
 ```
 
@@ -511,6 +533,7 @@ Apache License 2.0
 
 - [**spring-ai-agent-utils-common**](../spring-ai-agent-utils-common/README.md) - Shared subagent SPI (SubagentDefinition, SubagentResolver, SubagentExecutor, SubagentType)
 - [**spring-ai-agent-utils-a2a**](../spring-ai-agent-utils-a2a/README.md) - A2A protocol subagent implementation for remote agent orchestration
+- [**spring-ai-agent-utils-bom**](../spring-ai-agent-utils-bom/pom.xml) - Bill of Materials for consistent version management across all modules
 
 ## Links
 

--- a/spring-ai-agent-utils/docs/migration-0.5.md
+++ b/spring-ai-agent-utils/docs/migration-0.5.md
@@ -9,6 +9,7 @@ The single `spring-ai-agent-utils` module has been split into three:
 | `spring-ai-agent-utils-common` | Shared subagent SPI (interfaces & records) |
 | `spring-ai-agent-utils` | Core library (tools, skills, Claude subagents) |
 | `spring-ai-agent-utils-a2a` | A2A protocol subagent implementation |
+| `spring-ai-agent-utils-bom` | Bill of Materials for version management |
 
 Add `spring-ai-agent-utils-common` as a transitive dependency (pulled in automatically by the core module). Add `spring-ai-agent-utils-a2a` only if you use A2A subagents:
 


### PR DESCRIPTION
- Add BOM module to root pom.xml modules list
- Update README.md and spring-ai-agent-utils/README.md with BOM usage instructions, recommending it as the preferred installation method
- Add BOM to module table in migration-0.5.md