### PR TITLE
Fix Windows absolute path resolution in ClaudeSubagentResolver

### DIFF
--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentResolver.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentResolver.java
@@ -15,6 +15,7 @@
 */
 package org.springaicommunity.agent.tools.task.claude;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -46,7 +47,10 @@ public class ClaudeSubagentResolver implements SubagentResolver {
 				"ClaudeSubagentResolver can resolve only subagents of kind: " + ClaudeSubagentDefinition.KIND);
 
 		try {
-			String uri = (subagentRef.uri().startsWith("/"))? "file:" + subagentRef.uri() : subagentRef.uri();
+			String uri = subagentRef.uri();
+			if (new File(uri).isAbsolute()) {
+				uri = "file:" + uri;
+			}
 			var resource = new DefaultResourceLoader().getResource(uri);
 			String markdown = resource.getContentAsString(StandardCharsets.UTF_8);
 			MarkdownParser parser = new MarkdownParser(markdown);


### PR DESCRIPTION
Fixes #33

## Problem
The `ClaudeSubagentResolver.resolve()` method only checked if the URI starts with `/` to determine if it's an absolute file path. This approach fails on Windows where absolute paths start with a drive letter (e.g., `D:/path/to/file.md`), causing a `FileNotFoundException`.
## Solution
Use `File.isAbsolute()` instead of `startsWith("/")` to detect absolute paths. This provides cross-platform compatibility for both Windows and Unix systems.