### PR TITLE
feat: add SkillProvider SPI for pluggable skill backends

### DIFF
--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/skill/SkillDescriptor.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/skill/SkillDescriptor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.common.skill;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Describes a skill's identity and metadata for tool registration.
+ *
+ * <p>
+ * Skill descriptors are used at build time to generate the tool description XML that
+ * tells the LLM which skills are available. The actual skill content is fetched lazily
+ * via {@link SkillProvider#getSkillContent(String)}.
+ *
+ * @author Daniel Volovik
+ */
+public interface SkillDescriptor {
+
+	/** Returns the unique name of this skill. */
+	String getName();
+
+	/** Returns the metadata (front-matter) for this skill. */
+	Map<String, Object> getMetadata();
+
+	/** Formats this skill's metadata as an XML block for the tool description. */
+	default String toXml() {
+		String frontMatterXml = getMetadata().entrySet()
+			.stream()
+			.map(e -> "  <%s>%s</%s>".formatted(e.getKey(), e.getValue(), e.getKey()))
+			.collect(Collectors.joining("\n"));
+
+		return "<skill>\n%s\n</skill>".formatted(frontMatterXml);
+	}
+
+}

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/skill/SkillProvider.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/skill/SkillProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.common.skill;
+
+import java.util.List;
+
+/**
+ * Service provider interface for pluggable skill backends.
+ *
+ * <p>
+ * Implementations provide skill discovery and content retrieval from any backing store
+ * (filesystem, database, API, etc.). The {@link #getSkillDescriptors()} method is called
+ * at build time to enumerate available skills for the tool description, while
+ * {@link #getSkillContent(String)} is called at invocation time when the LLM requests a
+ * specific skill.
+ *
+ * @author Daniel Volovik
+ * @see SkillDescriptor
+ */
+public interface SkillProvider {
+
+	/** Returns descriptors for all skills this provider can serve. */
+	List<SkillDescriptor> getSkillDescriptors();
+
+	/**
+	 * Resolves the full content for a skill by name.
+	 * @param skillName the name of the skill to retrieve
+	 * @return the skill content, or {@code null} if this provider does not have the
+	 * requested skill
+	 */
+	String getSkillContent(String skillName);
+
+}

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/skill/package-info.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/skill/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * SPI interfaces for pluggable skill backends.
+ */
+package org.springaicommunity.agent.common.skill;

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/SkillsTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/SkillsTool.java
@@ -16,12 +16,14 @@
 package org.springaicommunity.agent.tools;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springaicommunity.agent.common.skill.SkillDescriptor;
+import org.springaicommunity.agent.common.skill.SkillProvider;
+import org.springaicommunity.agent.tools.skill.FileSystemSkillProvider;
 import org.springaicommunity.agent.utils.Skills;
 
 import org.springframework.ai.tool.ToolCallback;
@@ -65,18 +67,19 @@ public class SkillsTool {
 
 	public static class SkillsFunction implements Function<SkillsInput, String> {
 
-		private Map<String, Skill> skillsMap;
+		private final List<SkillProvider> providers;
 
-		public SkillsFunction(Map<String, Skill> skillsMap) {
-			this.skillsMap = skillsMap;
+		public SkillsFunction(List<SkillProvider> providers) {
+			this.providers = providers;
 		}
 
 		@Override
 		public String apply(SkillsInput input) {
-			Skill skill = this.skillsMap.get(input.command());
-
-			if (skill != null) {
-				return "Base directory for this skill: %s\n\n%s".formatted(skill.basePath(), skill.content());
+			for (SkillProvider provider : this.providers) {
+				String content = provider.getSkillContent(input.command());
+				if (content != null) {
+					return content;
+				}
 			}
 
 			return "Skill not found: " + input.command();
@@ -91,6 +94,8 @@ public class SkillsTool {
 	public static class Builder {
 
 		private List<Skill> skills = new ArrayList<>();
+
+		private List<SkillProvider> providers = new ArrayList<>();
 
 		private String toolDescriptionTemplate = TOOL_DESCRIPTION_TEMPLATE;
 
@@ -125,12 +130,33 @@ public class SkillsTool {
 			return this;
 		}
 
+		/**
+		 * Adds a custom {@link SkillProvider} for pluggable skill backends.
+		 * @param provider the skill provider to add
+		 * @return this builder
+		 */
+		public Builder addSkillProvider(SkillProvider provider) {
+			this.providers.add(provider);
+			return this;
+		}
+
 		public ToolCallback build() {
-			Assert.notEmpty(this.skills, "At least one skill must be configured");
+			// Wrap any statically-loaded filesystem skills into a provider
+			if (!this.skills.isEmpty()) {
+				this.providers.add(0, FileSystemSkillProvider.fromSkills(this.skills));
+			}
 
-			String skillsXml = this.skills.stream().map(s -> s.toXml()).collect(Collectors.joining("\n"));
+			Assert.notEmpty(this.providers, "At least one skill or skill provider must be configured");
 
-			return FunctionToolCallback.builder("Skill", new SkillsFunction(toSkillsMap(this.skills)))
+			List<SkillDescriptor> allDescriptors = this.providers.stream()
+				.flatMap(p -> p.getSkillDescriptors().stream())
+				.toList();
+
+			String skillsXml = allDescriptors.stream()
+				.map(SkillDescriptor::toXml)
+				.collect(Collectors.joining("\n"));
+
+			return FunctionToolCallback.builder("Skill", new SkillsFunction(this.providers))
 				.description(this.toolDescriptionTemplate.formatted(skillsXml))
 				.inputType(SkillsInput.class)
 				.build();
@@ -156,18 +182,5 @@ public class SkillsTool {
 
 			return "<skill>\n%s\n</skill>".formatted(frontMatterXml);
 		}
-
 	}
-
-	private static Map<String, Skill> toSkillsMap(List<Skill> skills) {
-
-		Map<String, Skill> skillsMap = new HashMap<>();
-
-		for (Skill skill : skills) {
-			skillsMap.put(skill.name(), skill);
-		}
-
-		return skillsMap;
-	}
-
 }

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/skill/FileSystemSkillProvider.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/skill/FileSystemSkillProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.skill;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springaicommunity.agent.common.skill.SkillDescriptor;
+import org.springaicommunity.agent.common.skill.SkillProvider;
+import org.springaicommunity.agent.tools.SkillsTool.Skill;
+import org.springaicommunity.agent.utils.Skills;
+
+import org.springframework.core.io.Resource;
+
+/**
+ * A {@link SkillProvider} implementation that loads skills from the filesystem, classpath
+ * resources, or JAR files using the existing {@link Skills} utility.
+ *
+ * @author Daniel Volovik
+ */
+public class FileSystemSkillProvider implements SkillProvider {
+
+	private final Map<String, Skill> skillsMap;
+
+	private FileSystemSkillProvider(List<Skill> skills) {
+		this.skillsMap = new HashMap<>();
+		for (Skill skill : skills) {
+			this.skillsMap.put(skill.name(), skill);
+		}
+	}
+
+	/**
+	 * Creates a provider from pre-loaded {@link Skill} objects.
+	 * @param skills the skills to serve
+	 * @return a new provider instance
+	 */
+	public static FileSystemSkillProvider fromSkills(List<Skill> skills) {
+		return new FileSystemSkillProvider(skills);
+	}
+
+	/**
+	 * Creates a provider that loads skills from a filesystem directory.
+	 * @param directory the root directory to scan for SKILL.md files
+	 * @return a new provider instance
+	 */
+	public static FileSystemSkillProvider fromDirectory(String directory) {
+		return new FileSystemSkillProvider(Skills.loadDirectory(directory));
+	}
+
+	/**
+	 * Creates a provider that loads skills from Spring {@link Resource} references.
+	 * @param resources the resources to load skills from
+	 * @return a new provider instance
+	 */
+	public static FileSystemSkillProvider fromResources(List<Resource> resources) {
+		return new FileSystemSkillProvider(Skills.loadResources(resources));
+	}
+
+	/**
+	 * Creates a provider that loads skills from a single Spring {@link Resource}.
+	 * @param resource the resource to load skills from
+	 * @return a new provider instance
+	 */
+	public static FileSystemSkillProvider fromResource(Resource resource) {
+		return new FileSystemSkillProvider(Skills.loadResource(resource));
+	}
+
+	@Override
+	public List<SkillDescriptor> getSkillDescriptors() {
+		return this.skillsMap.values()
+			.stream()
+			.map(skill -> (SkillDescriptor) new FileSystemSkillDescriptor(skill.name(), skill.frontMatter()))
+			.toList();
+	}
+
+	@Override
+	public String getSkillContent(String skillName) {
+		Skill skill = this.skillsMap.get(skillName);
+		if (skill == null) {
+			return null;
+		}
+		return "Base directory for this skill: %s\n\n%s".formatted(skill.basePath(), skill.content());
+	}
+
+	private record FileSystemSkillDescriptor(String name, Map<String, Object> metadata)
+			implements SkillDescriptor {
+
+		@Override
+		public String getName() {
+			return this.name;
+		}
+
+		@Override
+		public Map<String, Object> getMetadata() {
+			return this.metadata;
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/skill/package-info.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/skill/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Built-in {@link org.springaicommunity.agent.common.skill.SkillProvider} implementations.
+ */
+package org.springaicommunity.agent.tools.skill;

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SkillsToolProviderTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SkillsToolProviderTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springaicommunity.agent.common.skill.SkillDescriptor;
+import org.springaicommunity.agent.common.skill.SkillProvider;
+
+import org.springframework.ai.tool.ToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link SkillsTool} with custom {@link SkillProvider} implementations.
+ *
+ * @author Daniel Volovik
+ */
+@DisplayName("SkillsTool Provider Tests")
+class SkillsToolProviderTest {
+
+	@Test
+	@DisplayName("should build with custom provider")
+	void shouldBuildWithCustomProvider() {
+		SkillProvider provider = new StubSkillProvider("my-skill", "A custom skill", "Custom skill content");
+
+		ToolCallback callback = SkillsTool.builder().addSkillProvider(provider).build();
+
+		assertThat(callback).isNotNull();
+		assertThat(callback.getToolDefinition().description()).contains("my-skill");
+	}
+
+	@Test
+	@DisplayName("should resolve content from custom provider")
+	void shouldResolveContentFromCustomProvider() {
+		SkillProvider provider = new StubSkillProvider("my-skill", "A custom skill", "Custom skill content");
+
+		ToolCallback callback = SkillsTool.builder().addSkillProvider(provider).build();
+
+		String result = callback.call("{\"command\":\"my-skill\"}");
+		assertThat(result).contains("Custom skill content");
+	}
+
+	@Test
+	@DisplayName("should return not found for unknown skill from provider")
+	void shouldReturnNotFoundForUnknownSkill() {
+		SkillProvider provider = new StubSkillProvider("my-skill", "A custom skill", "Custom skill content");
+
+		ToolCallback callback = SkillsTool.builder().addSkillProvider(provider).build();
+
+		String result = callback.call("{\"command\":\"nonexistent\"}");
+		assertThat(result).contains("Skill not found: nonexistent");
+	}
+
+	@Test
+	@DisplayName("should combine filesystem skills with custom provider")
+	void shouldCombineFilesystemWithCustomProvider(@TempDir Path tempDir) throws IOException {
+		Path skillDir = tempDir.resolve("fs-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"),
+				"---\nname: fs-skill\ndescription: Filesystem skill\n---\n\nFS content.", StandardCharsets.UTF_8);
+
+		SkillProvider customProvider = new StubSkillProvider("custom-skill", "Custom skill", "Custom content");
+
+		ToolCallback callback = SkillsTool.builder()
+			.addSkillsDirectory(tempDir.toString())
+			.addSkillProvider(customProvider)
+			.build();
+
+		assertThat(callback).isNotNull();
+		String description = callback.getToolDefinition().description();
+		assertThat(description).contains("fs-skill");
+		assertThat(description).contains("custom-skill");
+
+		// Both skills should be resolvable
+		assertThat(callback.call("{\"command\":\"fs-skill\"}")).contains("FS content.");
+		assertThat(callback.call("{\"command\":\"custom-skill\"}")).contains("Custom content");
+	}
+
+	@Test
+	@DisplayName("should call provider on each invocation for dynamic content")
+	void shouldCallProviderDynamicallyOnEachInvocation() {
+		AtomicInteger counter = new AtomicInteger(0);
+		SkillProvider dynamicProvider = new SkillProvider() {
+			@Override
+			public List<SkillDescriptor> getSkillDescriptors() {
+				return List.of(new SimpleDescriptor("counter-skill", "Counts invocations"));
+			}
+
+			@Override
+			public String getSkillContent(String skillName) {
+				if ("counter-skill".equals(skillName)) {
+					return "Invocation #" + counter.incrementAndGet();
+				}
+				return null;
+			}
+		};
+
+		ToolCallback callback = SkillsTool.builder().addSkillProvider(dynamicProvider).build();
+
+		assertThat(callback.call("{\"command\":\"counter-skill\"}")).contains("Invocation #1");
+		assertThat(callback.call("{\"command\":\"counter-skill\"}")).contains("Invocation #2");
+		assertThat(callback.call("{\"command\":\"counter-skill\"}")).contains("Invocation #3");
+	}
+
+	@Test
+	@DisplayName("should throw when no skills or providers configured")
+	void shouldThrowWhenNoSkillsOrProviders() {
+		assertThatThrownBy(() -> SkillsTool.builder().build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("At least one skill or skill provider must be configured");
+	}
+
+	@Test
+	@DisplayName("should resolve from first matching provider")
+	void shouldResolveFromFirstMatchingProvider() {
+		SkillProvider provider1 = new StubSkillProvider("shared-skill", "From provider 1", "Content from provider 1");
+		SkillProvider provider2 = new StubSkillProvider("shared-skill", "From provider 2", "Content from provider 2");
+
+		ToolCallback callback = SkillsTool.builder()
+			.addSkillProvider(provider1)
+			.addSkillProvider(provider2)
+			.build();
+
+		// First provider wins
+		assertThat(callback.call("{\"command\":\"shared-skill\"}")).contains("Content from provider 1");
+	}
+
+	/**
+	 * Stub SkillProvider for testing.
+	 */
+	private static class StubSkillProvider implements SkillProvider {
+
+		private final String name;
+
+		private final String description;
+
+		private final String content;
+
+		StubSkillProvider(String name, String description, String content) {
+			this.name = name;
+			this.description = description;
+			this.content = content;
+		}
+
+		@Override
+		public List<SkillDescriptor> getSkillDescriptors() {
+			return List.of(new SimpleDescriptor(this.name, this.description));
+		}
+
+		@Override
+		public String getSkillContent(String skillName) {
+			if (this.name.equals(skillName)) {
+				return this.content;
+			}
+			return null;
+		}
+
+	}
+
+	private record SimpleDescriptor(String name, String description) implements SkillDescriptor {
+
+		@Override
+		public String getName() {
+			return this.name;
+		}
+
+		@Override
+		public Map<String, Object> getMetadata() {
+			return Map.of("name", this.name, "description", this.description);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SkillsToolTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SkillsToolTest.java
@@ -132,7 +132,7 @@ class SkillsToolTest {
 		void shouldThrowWhenNoSkillsConfigured(@TempDir Path tempDir) {
 			assertThatThrownBy(() -> SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build())
 				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("At least one skill must be configured");
+				.hasMessageContaining("At least one skill or skill provider must be configured");
 		}
 
 	}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/skill/FileSystemSkillProviderTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/skill/FileSystemSkillProviderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.skill;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springaicommunity.agent.common.skill.SkillDescriptor;
+
+import org.springframework.core.io.FileSystemResource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link FileSystemSkillProvider}.
+ *
+ * @author Daniel Volovik
+ */
+@DisplayName("FileSystemSkillProvider Tests")
+class FileSystemSkillProviderTest {
+
+	private static final String SKILL_MD = """
+			---
+			name: test-skill
+			description: A test skill
+			---
+
+			This is the test skill content.
+			""";
+
+	private static final String SKILL_MD_2 = """
+			---
+			name: another-skill
+			description: Another test skill
+			---
+
+			This is another skill content.
+			""";
+
+	@Test
+	@DisplayName("should load skills from directory and return descriptors")
+	void shouldLoadFromDirectory(@TempDir Path tempDir) throws IOException {
+		Path skillDir = tempDir.resolve("my-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		FileSystemSkillProvider provider = FileSystemSkillProvider.fromDirectory(tempDir.toString());
+
+		List<SkillDescriptor> descriptors = provider.getSkillDescriptors();
+		assertThat(descriptors).hasSize(1);
+		assertThat(descriptors.get(0).getName()).isEqualTo("test-skill");
+		assertThat(descriptors.get(0).getMetadata()).containsEntry("name", "test-skill");
+		assertThat(descriptors.get(0).getMetadata()).containsEntry("description", "A test skill");
+	}
+
+	@Test
+	@DisplayName("should return content with base directory prefix")
+	void shouldReturnContentWithBaseDirectory(@TempDir Path tempDir) throws IOException {
+		Path skillDir = tempDir.resolve("my-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		FileSystemSkillProvider provider = FileSystemSkillProvider.fromDirectory(tempDir.toString());
+
+		String content = provider.getSkillContent("test-skill");
+		assertThat(content).contains("Base directory for this skill:");
+		assertThat(content).contains(skillDir.toString());
+		assertThat(content).contains("This is the test skill content.");
+	}
+
+	@Test
+	@DisplayName("should return null for unknown skill")
+	void shouldReturnNullForUnknownSkill(@TempDir Path tempDir) throws IOException {
+		Path skillDir = tempDir.resolve("my-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		FileSystemSkillProvider provider = FileSystemSkillProvider.fromDirectory(tempDir.toString());
+
+		assertThat(provider.getSkillContent("nonexistent")).isNull();
+	}
+
+	@Test
+	@DisplayName("should load multiple skills")
+	void shouldLoadMultipleSkills(@TempDir Path tempDir) throws IOException {
+		Path skillDir1 = tempDir.resolve("skill-one");
+		Files.createDirectories(skillDir1);
+		Files.writeString(skillDir1.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		Path skillDir2 = tempDir.resolve("skill-two");
+		Files.createDirectories(skillDir2);
+		Files.writeString(skillDir2.resolve("SKILL.md"), SKILL_MD_2, StandardCharsets.UTF_8);
+
+		FileSystemSkillProvider provider = FileSystemSkillProvider.fromDirectory(tempDir.toString());
+
+		List<SkillDescriptor> descriptors = provider.getSkillDescriptors();
+		assertThat(descriptors).hasSize(2);
+		assertThat(descriptors).extracting(SkillDescriptor::getName)
+			.containsExactlyInAnyOrder("test-skill", "another-skill");
+	}
+
+	@Test
+	@DisplayName("should load skills from resource")
+	void shouldLoadFromResource(@TempDir Path tempDir) throws IOException {
+		Path skillDir = tempDir.resolve("my-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		FileSystemSkillProvider provider = FileSystemSkillProvider
+			.fromResource(new FileSystemResource(tempDir.toFile()));
+
+		assertThat(provider.getSkillDescriptors()).hasSize(1);
+		assertThat(provider.getSkillContent("test-skill")).contains("This is the test skill content.");
+	}
+
+	@Test
+	@DisplayName("toXml should format metadata correctly")
+	void shouldFormatXmlCorrectly(@TempDir Path tempDir) throws IOException {
+		Path skillDir = tempDir.resolve("my-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		FileSystemSkillProvider provider = FileSystemSkillProvider.fromDirectory(tempDir.toString());
+
+		SkillDescriptor descriptor = provider.getSkillDescriptors().get(0);
+		String xml = descriptor.toXml();
+		assertThat(xml).contains("<skill>");
+		assertThat(xml).contains("</skill>");
+		assertThat(xml).contains("<name>test-skill</name>");
+		assertThat(xml).contains("<description>A test skill</description>");
+	}
+
+}


### PR DESCRIPTION
Closes #37

## Summary
- Add `SkillProvider` and `SkillDescriptor` interfaces in the common module as a Service Provider Interface for pluggable skill backends
- Create `FileSystemSkillProvider` as the default implementation (refactored from existing logic)
- Refactor `SkillsFunction` to delegate to providers at invocation time
- Add `addSkillProvider()` to `SkillsTool.Builder`
- Full backward compatibility with existing `addSkillsDirectory`/`Resource` API

## Test plan
- [x] Unit tests for `FileSystemSkillProvider`
- [x] Unit tests for `SkillsTool` with provider integration
- [x] Verify backward compatibility with existing API