### PR TITLE
Add tool governance advisors and reasoning trace observability

### DIFF
--- a/spring-ai-agent-utils/README.md
+++ b/spring-ai-agent-utils/README.md
@@ -28,6 +28,12 @@ These are the agent tools needed to implement any agentic behavior
 
 - **[AutoMemoryToolsAdvisor](docs/AutoMemoryToolsAdvisor.md)** - Automatic long-term memory prompt and tool wiring
 - **[ToolCallPolicyAdvisor](docs/ToolCallPolicyAdvisor.md)** - Allow, deny, or rewrite tool calls before execution
+- **[ToolApprovalAdvisor](docs/ToolApprovalAdvisor.md)** - Human-in-the-loop approval gates with `CompletableFuture` blocking
+- **[ToolArgumentValidationAdvisor](docs/ToolArgumentValidationAdvisor.md)** - Enforce maximum tool argument sizes
+- **[ToolTimeoutAdvisor](docs/ToolTimeoutAdvisor.md)** - Per-tool timeout enforcement
+- **[ToolRateLimitAdvisor](docs/ToolRateLimitAdvisor.md)** - Per-loop (per-request) tool call rate limiting
+- **[ToolFilterAdvisor](docs/ToolFilterAdvisor.md)** - Include/exclude tool callbacks by glob pattern
+- **[ReasoningTraceAdvisor](docs/ReasoningTraceAdvisor.md)** - Per-iteration reasoning trace and timing observability
 
 #### Agent Skills
 

--- a/spring-ai-agent-utils/README.md
+++ b/spring-ai-agent-utils/README.md
@@ -24,6 +24,11 @@ These are the agent tools needed to implement any agentic behavior
 
 - **[AskUserQuestionTool](docs/AskUserQuestionTool.md)** - Ask users clarifying questions with multiple-choice options during agent execution
 
+#### Advisors
+
+- **[AutoMemoryToolsAdvisor](docs/AutoMemoryToolsAdvisor.md)** - Automatic long-term memory prompt and tool wiring
+- **[ToolCallPolicyAdvisor](docs/ToolCallPolicyAdvisor.md)** - Allow, deny, or rewrite tool calls before execution
+
 #### Agent Skills
 
 - **[SkillsTool](docs/SkillsTool.md)** - Extend AI agent capabilities with reusable, composable knowledge modules defined in Markdown with YAML front-matter

--- a/spring-ai-agent-utils/docs/ReasoningTraceAdvisor.md
+++ b/spring-ai-agent-utils/docs/ReasoningTraceAdvisor.md
@@ -1,0 +1,20 @@
+# ReasoningTraceAdvisor
+
+`ReasoningTraceAdvisor` emits per-iteration observability traces with timing data.
+
+## Features
+
+- Captures per-iteration duration.
+- Captures user input and assistant output excerpts.
+- Captures tool calls returned by the model.
+- Sends traces to a pluggable sink (`Consumer<ReasoningTraceEntry>`).
+
+## Quick Start
+
+```java
+ReasoningTraceAdvisor advisor = ReasoningTraceAdvisor.builder()
+    .traceSink(trace -> logger.info("{}", trace))
+    .includeToolArguments(false)
+    .maxTextLength(2000)
+    .build();
+```

--- a/spring-ai-agent-utils/docs/ToolApprovalAdvisor.md
+++ b/spring-ai-agent-utils/docs/ToolApprovalAdvisor.md
@@ -1,0 +1,27 @@
+# ToolApprovalAdvisor
+
+`ToolApprovalAdvisor` adds a human-in-the-loop approval gate before tool execution.
+
+## Features
+
+- Blocks tool execution until `CompletableFuture` approval resolves.
+- Supports approve, deny, and approve-with-rewritten-arguments flows.
+- Supports optional approval timeout.
+
+## Quick Start
+
+```java
+ToolApprovalAdvisor advisor = ToolApprovalAdvisor.builder()
+    .approvalManager(request -> {
+        // Integrate with your UI/workflow queue here
+        return CompletableFuture.completedFuture(
+            ToolApprovalAdvisor.ToolApprovalDecision.approve());
+    })
+    .build();
+```
+
+## Decision Types
+
+- `ToolApprovalDecision.approve()`
+- `ToolApprovalDecision.approveWithRewrite(String rewrittenArguments)`
+- `ToolApprovalDecision.deny(String reason)`

--- a/spring-ai-agent-utils/docs/ToolArgumentValidationAdvisor.md
+++ b/spring-ai-agent-utils/docs/ToolArgumentValidationAdvisor.md
@@ -1,0 +1,16 @@
+# ToolArgumentValidationAdvisor
+
+`ToolArgumentValidationAdvisor` enforces argument payload size limits for every tool call.
+
+## Features
+
+- Validates UTF-8 argument size before tool execution.
+- Blocks oversized payloads with configurable error messaging.
+
+## Quick Start
+
+```java
+ToolArgumentValidationAdvisor advisor = ToolArgumentValidationAdvisor.builder()
+    .maxArgumentBytes(65_536)
+    .build();
+```

--- a/spring-ai-agent-utils/docs/ToolCallPolicyAdvisor.md
+++ b/spring-ai-agent-utils/docs/ToolCallPolicyAdvisor.md
@@ -1,0 +1,74 @@
+# ToolCallPolicyAdvisor
+
+`ToolCallPolicyAdvisor` is a Spring AI `ChatClient` advisor that lets you enforce policy on tool calls immediately before they execute.
+
+It supports three policy actions:
+
+- `ALLOW` - execute the tool call as-is.
+- `DENY` - block the tool call and return a policy denial message to the model.
+- `REWRITE` - replace tool arguments before executing the tool.
+
+## Why use it
+
+Use this advisor when your agent should not execute every model-proposed tool call blindly. Typical use cases:
+
+- Allow-list and deny-list enforcement by tool name.
+- Argument sanitization (strip unsafe fields, inject defaults).
+- Guardrails for sensitive tools (shell, file write, network operations).
+- Deterministic policy handling independent of model behavior.
+
+## Quick Start
+
+```java
+ToolCallPolicyAdvisor advisor = ToolCallPolicyAdvisor.builder()
+    .policy((toolName, arguments) -> {
+        if ("Shell".equals(toolName)) {
+            return ToolCallDecision.deny("Shell access is disabled in this environment");
+        }
+        return ToolCallDecision.allow();
+    })
+    .build();
+```
+
+Register it before `ToolCallingAdvisor`:
+
+```java
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        ToolCallPolicyAdvisor.builder().build(),
+        ToolCallAdvisor.builder().build())
+    .build();
+```
+
+## Rewriting arguments
+
+```java
+ToolCallPolicyAdvisor advisor = ToolCallPolicyAdvisor.builder()
+    .policy((toolName, arguments) -> {
+        if ("EditFile".equals(toolName)) {
+            String rewritten = "{\"path\":\"README.md\",\"content\":\"safe\"}";
+            return ToolCallDecision.rewrite(rewritten, "Path restricted by policy");
+        }
+        return ToolCallDecision.allow();
+    })
+    .build();
+```
+
+## Builder Options
+
+| Builder method | Type | Default | Description |
+|---|---|---|---|
+| `order(int)` | `int` | `HIGHEST_PRECEDENCE + 250` | Advisor order. Runs before default `ToolCallingAdvisor` (`+300`). |
+| `policy(ToolCallPolicy)` | functional interface | allow all | Policy invoked per tool call with `(toolName, arguments)`. |
+| `deniedCallResponse(BiFunction<String, ToolCallDecision, String>)` | function | built-in message | Custom response payload returned when policy action is `DENY`. |
+
+## Decision API
+
+Use `ToolCallDecision` helpers inside your policy:
+
+- `ToolCallDecision.allow()`
+- `ToolCallDecision.deny("reason")`
+- `ToolCallDecision.rewrite(rewrittenArguments)`
+- `ToolCallDecision.rewrite(rewrittenArguments, "reason")`
+
+`ToolCallDecision.rewrite(...)` requires non-empty rewritten arguments.

--- a/spring-ai-agent-utils/docs/ToolFilterAdvisor.md
+++ b/spring-ai-agent-utils/docs/ToolFilterAdvisor.md
@@ -1,0 +1,18 @@
+# ToolFilterAdvisor
+
+`ToolFilterAdvisor` filters available tool callbacks by include/exclude glob patterns.
+
+## Features
+
+- Include patterns (allow-list) for tool names.
+- Exclude patterns (deny-list) for tool names.
+- Uses simple wildcard matching (`*`, `?`).
+
+## Quick Start
+
+```java
+ToolFilterAdvisor advisor = ToolFilterAdvisor.builder()
+    .includePatterns(List.of("*File", "Web*"))
+    .excludePatterns(List.of("Write*"))
+    .build();
+```

--- a/spring-ai-agent-utils/docs/ToolRateLimitAdvisor.md
+++ b/spring-ai-agent-utils/docs/ToolRateLimitAdvisor.md
@@ -1,0 +1,17 @@
+# ToolRateLimitAdvisor
+
+`ToolRateLimitAdvisor` limits how many tool calls can be executed in a single request loop.
+
+## Features
+
+- Shared per-request tool call counter across all tools.
+- Configurable max calls per request.
+- Configurable rate-limit response payload.
+
+## Quick Start
+
+```java
+ToolRateLimitAdvisor advisor = ToolRateLimitAdvisor.builder()
+    .maxToolCallsPerRequest(10)
+    .build();
+```

--- a/spring-ai-agent-utils/docs/ToolTimeoutAdvisor.md
+++ b/spring-ai-agent-utils/docs/ToolTimeoutAdvisor.md
@@ -1,0 +1,18 @@
+# ToolTimeoutAdvisor
+
+`ToolTimeoutAdvisor` enforces timeout limits on tool execution.
+
+## Features
+
+- Global default timeout.
+- Per-tool timeout overrides.
+- Configurable timeout response payload.
+
+## Quick Start
+
+```java
+ToolTimeoutAdvisor advisor = ToolTimeoutAdvisor.builder()
+    .defaultTimeout(Duration.ofSeconds(30))
+    .perToolTimeouts(Map.of("Shell", Duration.ofSeconds(10)))
+    .build();
+```

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ReasoningTraceAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ReasoningTraceAdvisor.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Emits per-iteration reasoning traces with timing and tool-call information.
+ *
+ * @author vaquarkhan
+ */
+public class ReasoningTraceAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	private final Consumer<ReasoningTraceEntry> traceSink;
+
+	private final int maxTextLength;
+
+	private final boolean includeToolArguments;
+
+	private final ThreadLocal<Long> iterationStartNanos = new ThreadLocal<>();
+
+	private final ThreadLocal<String> requestInput = new ThreadLocal<>();
+
+	private ReasoningTraceAdvisor(int order, Consumer<ReasoningTraceEntry> traceSink, int maxTextLength,
+			boolean includeToolArguments) {
+		this.order = order;
+		this.traceSink = traceSink;
+		this.maxTextLength = maxTextLength;
+		this.includeToolArguments = includeToolArguments;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		this.iterationStartNanos.set(System.nanoTime());
+		this.requestInput.set(extractUserInput(chatClientRequest));
+		return chatClientRequest;
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		long startNanos = this.iterationStartNanos.get() != null ? this.iterationStartNanos.get() : System.nanoTime();
+		long durationNanos = System.nanoTime() - startNanos;
+
+		List<ToolCallTrace> toolCalls = new ArrayList<>();
+		StringBuilder assistantText = new StringBuilder();
+
+		if (chatClientResponse != null && chatClientResponse.chatResponse() != null
+				&& chatClientResponse.chatResponse().getResults() != null) {
+			for (var generation : chatClientResponse.chatResponse().getResults()) {
+				var output = generation.getOutput();
+				if (output.getToolCalls() != null) {
+					for (var toolCall : output.getToolCalls()) {
+						toolCalls.add(new ToolCallTrace(toolCall.name(),
+								this.includeToolArguments ? truncate(toolCall.arguments()) : null));
+					}
+				}
+				if (StringUtils.hasText(output.getText())) {
+					if (!assistantText.isEmpty()) {
+						assistantText.append("\n");
+					}
+					assistantText.append(output.getText());
+				}
+			}
+		}
+
+		this.traceSink.accept(new ReasoningTraceEntry(Instant.now(), durationNanos / 1_000_000L, this.requestInput.get(),
+				toolCalls, truncate(assistantText.toString())));
+		this.iterationStartNanos.remove();
+		this.requestInput.remove();
+		return chatClientResponse;
+	}
+
+	private String extractUserInput(ChatClientRequest chatClientRequest) {
+		if (chatClientRequest == null || chatClientRequest.prompt() == null) {
+			return null;
+		}
+		Message message = chatClientRequest.prompt().getLastUserOrToolResponseMessage();
+		if (message != null && message.getMessageType() == MessageType.USER && StringUtils.hasText(message.getText())) {
+			return truncate(message.getText());
+		}
+		return null;
+	}
+
+	private String truncate(String text) {
+		if (!StringUtils.hasText(text) || text.length() <= this.maxTextLength) {
+			return text;
+		}
+		return text.substring(0, this.maxTextLength) + "...";
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Per-iteration trace entry.
+	 *
+	 * @param timestamp trace timestamp
+	 * @param durationMs advisor iteration duration in milliseconds
+	 * @param userInput last user input text
+	 * @param toolCalls tool calls emitted in this iteration
+	 * @param assistantText assistant text emitted in this iteration
+	 */
+	public record ReasoningTraceEntry(Instant timestamp, long durationMs, String userInput, List<ToolCallTrace> toolCalls,
+			String assistantText) {
+	}
+
+	/**
+	 * Tool call trace element.
+	 *
+	 * @param name tool name
+	 * @param arguments serialized tool arguments
+	 */
+	public record ToolCallTrace(String name, String arguments) {
+	}
+
+	public static final class Builder {
+
+		// Early advisor, before tool-calling advisor
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 210;
+
+		private Consumer<ReasoningTraceEntry> traceSink = trace -> {
+		};
+
+		private int maxTextLength = 2000;
+
+		private boolean includeToolArguments = true;
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder traceSink(Consumer<ReasoningTraceEntry> traceSink) {
+			Assert.notNull(traceSink, "traceSink must not be null");
+			this.traceSink = traceSink;
+			return this;
+		}
+
+		public Builder maxTextLength(int maxTextLength) {
+			Assert.isTrue(maxTextLength > 0, "maxTextLength must be > 0");
+			this.maxTextLength = maxTextLength;
+			return this;
+		}
+
+		public Builder includeToolArguments(boolean includeToolArguments) {
+			this.includeToolArguments = includeToolArguments;
+			return this;
+		}
+
+		public ReasoningTraceAdvisor build() {
+			return new ReasoningTraceAdvisor(this.order, this.traceSink, this.maxTextLength, this.includeToolArguments);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolApprovalAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolApprovalAdvisor.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiFunction;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Human-in-the-loop advisor that blocks tool execution until approval is resolved.
+ *
+ * @author vaquarkhan
+ */
+public class ToolApprovalAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	private final ManualApprovalManager approvalManager;
+
+	private final Duration approvalTimeout;
+
+	private final BiFunction<String, ToolApprovalDecision, String> deniedCallResponse;
+
+	private ToolApprovalAdvisor(int order, ManualApprovalManager approvalManager, Duration approvalTimeout,
+			BiFunction<String, ToolApprovalDecision, String> deniedCallResponse) {
+		this.order = order;
+		this.approvalManager = approvalManager;
+		this.approvalTimeout = approvalTimeout;
+		this.deniedCallResponse = deniedCallResponse;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		if (!(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions)) {
+			return chatClientRequest;
+		}
+
+		ToolCallingChatOptions toolOptionsCopy = toolOptions.copy();
+		List<ToolCallback> callbacks = toolOptionsCopy.getToolCallbacks();
+		if (callbacks == null || callbacks.isEmpty()) {
+			return chatClientRequest;
+		}
+
+		List<ToolCallback> wrappedCallbacks = new ArrayList<>(callbacks.size());
+		for (ToolCallback callback : callbacks) {
+			if (callback instanceof ApprovalAwareToolCallback) {
+				wrappedCallbacks.add(callback);
+			}
+			else {
+				wrappedCallbacks.add(new ApprovalAwareToolCallback(callback, this.approvalManager, this.approvalTimeout,
+						this.deniedCallResponse));
+			}
+		}
+
+		toolOptionsCopy.setToolCallbacks(wrappedCallbacks);
+		return chatClientRequest.mutate().prompt(chatClientRequest.prompt().mutate().chatOptions(toolOptionsCopy).build()).build();
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Manual approval manager contract.
+	 */
+	@FunctionalInterface
+	public interface ManualApprovalManager {
+
+		CompletableFuture<ToolApprovalDecision> requestApproval(ToolApprovalRequest request);
+
+	}
+
+	/**
+	 * Approval request payload.
+	 *
+	 * @param toolName tool name proposed by the model
+	 * @param arguments serialized tool arguments
+	 */
+	public record ToolApprovalRequest(String toolName, String arguments) {
+	}
+
+	/**
+	 * Approval decision payload.
+	 *
+	 * @param approved true to allow execution
+	 * @param rewrittenArguments optional rewritten arguments when approved
+	 * @param reason optional reason used for deny messaging
+	 */
+	public record ToolApprovalDecision(boolean approved, String rewrittenArguments, String reason) {
+
+		public static ToolApprovalDecision approve() {
+			return new ToolApprovalDecision(true, null, null);
+		}
+
+		public static ToolApprovalDecision approveWithRewrite(String rewrittenArguments) {
+			Assert.hasText(rewrittenArguments, "rewrittenArguments must not be empty");
+			return new ToolApprovalDecision(true, rewrittenArguments, null);
+		}
+
+		public static ToolApprovalDecision deny(String reason) {
+			return new ToolApprovalDecision(false, null, reason);
+		}
+
+	}
+
+	private static final class ApprovalAwareToolCallback implements ToolCallback {
+
+		private final ToolCallback delegate;
+
+		private final ManualApprovalManager approvalManager;
+
+		private final Duration approvalTimeout;
+
+		private final BiFunction<String, ToolApprovalDecision, String> deniedCallResponse;
+
+		private ApprovalAwareToolCallback(ToolCallback delegate, ManualApprovalManager approvalManager, Duration approvalTimeout,
+				BiFunction<String, ToolApprovalDecision, String> deniedCallResponse) {
+			this.delegate = delegate;
+			this.approvalManager = approvalManager;
+			this.approvalTimeout = approvalTimeout;
+			this.deniedCallResponse = deniedCallResponse;
+		}
+
+		@Override
+		public String call(String toolInput) {
+			String toolName = this.delegate.getToolDefinition().name();
+			try {
+				CompletableFuture<ToolApprovalDecision> approvalFuture = this.approvalManager
+					.requestApproval(new ToolApprovalRequest(toolName, toolInput));
+				ToolApprovalDecision decision = (this.approvalTimeout == null) ? approvalFuture.get()
+						: approvalFuture.get(this.approvalTimeout.toMillis(), TimeUnit.MILLISECONDS);
+				if (decision == null || !decision.approved()) {
+					return this.deniedCallResponse.apply(toolName,
+							decision != null ? decision : ToolApprovalDecision.deny("No approval decision returned"));
+				}
+				if (StringUtils.hasText(decision.rewrittenArguments())) {
+					return this.delegate.call(decision.rewrittenArguments());
+				}
+				return this.delegate.call(toolInput);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				return this.deniedCallResponse.apply(toolName, ToolApprovalDecision.deny("Approval interrupted"));
+			}
+			catch (TimeoutException ex) {
+				return this.deniedCallResponse.apply(toolName, ToolApprovalDecision.deny("Approval timed out"));
+			}
+			catch (ExecutionException ex) {
+				return this.deniedCallResponse.apply(toolName,
+						ToolApprovalDecision.deny("Approval failed: " + ex.getCause().getMessage()));
+			}
+		}
+
+		@Override
+		public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+			return this.delegate.getToolDefinition();
+		}
+
+		@Override
+		public org.springframework.ai.tool.metadata.ToolMetadata getToolMetadata() {
+			return this.delegate.getToolMetadata();
+		}
+
+	}
+
+	public static final class Builder {
+
+		// Before default ToolCallingAdvisor (HIGHEST_PRECEDENCE + 300)
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 240;
+
+		private ManualApprovalManager approvalManager = request -> CompletableFuture.completedFuture(ToolApprovalDecision.approve());
+
+		private Duration approvalTimeout = null;
+
+		private BiFunction<String, ToolApprovalDecision, String> deniedCallResponse = (toolName, decision) -> {
+			String reason = decision != null && StringUtils.hasText(decision.reason()) ? " Reason: " + decision.reason() : "";
+			return "Tool call denied by approval manager for tool '%s'.%s".formatted(toolName, reason);
+		};
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder approvalManager(ManualApprovalManager approvalManager) {
+			Assert.notNull(approvalManager, "approvalManager must not be null");
+			this.approvalManager = approvalManager;
+			return this;
+		}
+
+		public Builder approvalTimeout(Duration approvalTimeout) {
+			Assert.isTrue(approvalTimeout == null || !approvalTimeout.isNegative(), "approvalTimeout must not be negative");
+			this.approvalTimeout = approvalTimeout;
+			return this;
+		}
+
+		public Builder deniedCallResponse(BiFunction<String, ToolApprovalDecision, String> deniedCallResponse) {
+			Assert.notNull(deniedCallResponse, "deniedCallResponse must not be null");
+			this.deniedCallResponse = deniedCallResponse;
+			return this;
+		}
+
+		public ToolApprovalAdvisor build() {
+			return new ToolApprovalAdvisor(this.order, this.approvalManager, this.approvalTimeout, this.deniedCallResponse);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolArgumentValidationAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolArgumentValidationAdvisor.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.Assert;
+
+/**
+ * Enforces maximum tool argument payload size before execution.
+ *
+ * @author vaquarkhan
+ */
+public class ToolArgumentValidationAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	private final int maxArgumentBytes;
+
+	private final BiFunction<String, Integer, String> validationErrorResponse;
+
+	private ToolArgumentValidationAdvisor(int order, int maxArgumentBytes,
+			BiFunction<String, Integer, String> validationErrorResponse) {
+		this.order = order;
+		this.maxArgumentBytes = maxArgumentBytes;
+		this.validationErrorResponse = validationErrorResponse;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		if (!(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions)) {
+			return chatClientRequest;
+		}
+
+		ToolCallingChatOptions toolOptionsCopy = toolOptions.copy();
+		List<ToolCallback> callbacks = toolOptionsCopy.getToolCallbacks();
+		if (callbacks == null || callbacks.isEmpty()) {
+			return chatClientRequest;
+		}
+
+		List<ToolCallback> wrappedCallbacks = new ArrayList<>(callbacks.size());
+		for (ToolCallback callback : callbacks) {
+			if (callback instanceof ArgumentValidationToolCallback) {
+				wrappedCallbacks.add(callback);
+			}
+			else {
+				wrappedCallbacks
+					.add(new ArgumentValidationToolCallback(callback, this.maxArgumentBytes, this.validationErrorResponse));
+			}
+		}
+
+		toolOptionsCopy.setToolCallbacks(wrappedCallbacks);
+		return chatClientRequest.mutate().prompt(chatClientRequest.prompt().mutate().chatOptions(toolOptionsCopy).build()).build();
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private static final class ArgumentValidationToolCallback implements ToolCallback {
+
+		private final ToolCallback delegate;
+
+		private final int maxArgumentBytes;
+
+		private final BiFunction<String, Integer, String> validationErrorResponse;
+
+		private ArgumentValidationToolCallback(ToolCallback delegate, int maxArgumentBytes,
+				BiFunction<String, Integer, String> validationErrorResponse) {
+			this.delegate = delegate;
+			this.maxArgumentBytes = maxArgumentBytes;
+			this.validationErrorResponse = validationErrorResponse;
+		}
+
+		@Override
+		public String call(String toolInput) {
+			String input = toolInput != null ? toolInput : "";
+			int argumentBytes = input.getBytes(StandardCharsets.UTF_8).length;
+			String toolName = this.delegate.getToolDefinition().name();
+			if (argumentBytes > this.maxArgumentBytes) {
+				return this.validationErrorResponse.apply(toolName, argumentBytes);
+			}
+			return this.delegate.call(toolInput);
+		}
+
+		@Override
+		public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+			return this.delegate.getToolDefinition();
+		}
+
+		@Override
+		public org.springframework.ai.tool.metadata.ToolMetadata getToolMetadata() {
+			return this.delegate.getToolMetadata();
+		}
+
+	}
+
+	public static final class Builder {
+
+		// Before default ToolCallingAdvisor (HIGHEST_PRECEDENCE + 300)
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 245;
+
+		private int maxArgumentBytes = 65_536;
+
+		private BiFunction<String, Integer, String> validationErrorResponse = (toolName, actualBytes) -> "Tool '%s' arguments are too large: %d bytes"
+			.formatted(toolName, actualBytes);
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder maxArgumentBytes(int maxArgumentBytes) {
+			Assert.isTrue(maxArgumentBytes > 0, "maxArgumentBytes must be > 0");
+			this.maxArgumentBytes = maxArgumentBytes;
+			return this;
+		}
+
+		public Builder validationErrorResponse(BiFunction<String, Integer, String> validationErrorResponse) {
+			Assert.notNull(validationErrorResponse, "validationErrorResponse must not be null");
+			this.validationErrorResponse = validationErrorResponse;
+			return this;
+		}
+
+		public ToolArgumentValidationAdvisor build() {
+			return new ToolArgumentValidationAdvisor(this.order, this.maxArgumentBytes, this.validationErrorResponse);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolCallPolicyAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolCallPolicyAdvisor.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * A {@link BaseAdvisor} that enforces a configurable policy for each tool call before
+ * execution.
+ *
+ * @author vaquarkhan
+ */
+public class ToolCallPolicyAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	private final ToolCallPolicy policy;
+
+	private final BiFunction<String, ToolCallDecision, String> deniedCallResponse;
+
+	private ToolCallPolicyAdvisor(int order, ToolCallPolicy policy,
+			BiFunction<String, ToolCallDecision, String> deniedCallResponse) {
+		this.order = order;
+		this.policy = policy;
+		this.deniedCallResponse = deniedCallResponse;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		if (!(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions)) {
+			return chatClientRequest;
+		}
+
+		ToolCallingChatOptions toolOptionsCopy = toolOptions.copy();
+		List<ToolCallback> callbacks = toolOptionsCopy.getToolCallbacks();
+
+		if (callbacks == null || callbacks.isEmpty()) {
+			return chatClientRequest;
+		}
+
+		List<ToolCallback> wrappedCallbacks = new ArrayList<>(callbacks.size());
+		for (ToolCallback callback : callbacks) {
+			if (callback instanceof PolicyAwareToolCallback) {
+				wrappedCallbacks.add(callback);
+			}
+			else {
+				wrappedCallbacks.add(new PolicyAwareToolCallback(callback, this.policy, this.deniedCallResponse));
+			}
+		}
+
+		toolOptionsCopy.setToolCallbacks(wrappedCallbacks);
+		return chatClientRequest.mutate().prompt(chatClientRequest.prompt().mutate().chatOptions(toolOptionsCopy).build()).build();
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Policy invoked immediately before a tool executes.
+	 */
+	@FunctionalInterface
+	public interface ToolCallPolicy {
+
+		ToolCallDecision apply(String toolName, String arguments);
+
+	}
+
+	/**
+	 * Decision returned by {@link ToolCallPolicy}.
+	 *
+	 * @param action policy action for this call
+	 * @param rewrittenArguments rewritten arguments for {@link ToolCallAction#REWRITE}
+	 * @param reason optional human-readable reason
+	 */
+	public record ToolCallDecision(ToolCallAction action, String rewrittenArguments, String reason) {
+
+		public ToolCallDecision {
+			Assert.notNull(action, "action must not be null");
+			if (action == ToolCallAction.REWRITE) {
+				Assert.hasText(rewrittenArguments, "rewrittenArguments must not be empty when action is REWRITE");
+			}
+		}
+
+		public static ToolCallDecision allow() {
+			return new ToolCallDecision(ToolCallAction.ALLOW, null, null);
+		}
+
+		public static ToolCallDecision deny(String reason) {
+			return new ToolCallDecision(ToolCallAction.DENY, null, reason);
+		}
+
+		public static ToolCallDecision rewrite(String rewrittenArguments) {
+			return rewrite(rewrittenArguments, null);
+		}
+
+		public static ToolCallDecision rewrite(String rewrittenArguments, String reason) {
+			return new ToolCallDecision(ToolCallAction.REWRITE, rewrittenArguments, reason);
+		}
+
+	}
+
+	/**
+	 * Allowed policy actions for a tool call.
+	 */
+	public enum ToolCallAction {
+
+		ALLOW, DENY, REWRITE
+
+	}
+
+	private static final class PolicyAwareToolCallback implements ToolCallback {
+
+		private final ToolCallback delegate;
+
+		private final ToolCallPolicy policy;
+
+		private final BiFunction<String, ToolCallDecision, String> deniedCallResponse;
+
+		private PolicyAwareToolCallback(ToolCallback delegate, ToolCallPolicy policy,
+				BiFunction<String, ToolCallDecision, String> deniedCallResponse) {
+			this.delegate = delegate;
+			this.policy = policy;
+			this.deniedCallResponse = deniedCallResponse;
+		}
+
+		@Override
+		public String call(String toolInput) {
+			String toolName = this.delegate.getToolDefinition().name();
+			ToolCallDecision decision = Objects.requireNonNull(this.policy.apply(toolName, toolInput),
+					"policy must not return null decision");
+
+			return switch (decision.action()) {
+				case ALLOW -> this.delegate.call(toolInput);
+				case REWRITE -> this.delegate.call(decision.rewrittenArguments());
+				case DENY -> this.deniedCallResponse.apply(toolName, decision);
+			};
+		}
+
+		@Override
+		public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+			return this.delegate.getToolDefinition();
+		}
+
+		@Override
+		public org.springframework.ai.tool.metadata.ToolMetadata getToolMetadata() {
+			return this.delegate.getToolMetadata();
+		}
+
+	}
+
+	public static final class Builder {
+
+		// Before default ToolCallingAdvisor (HIGHEST_PRECEDENCE + 300)
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 250;
+
+		private ToolCallPolicy policy = (toolName, arguments) -> ToolCallDecision.allow();
+
+		private BiFunction<String, ToolCallDecision, String> deniedCallResponse = (toolName, decision) -> {
+			String reason = StringUtils.hasText(decision.reason()) ? " Reason: " + decision.reason() : "";
+			return "Tool call denied by policy for tool '%s'.%s".formatted(toolName, reason);
+		};
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder policy(ToolCallPolicy policy) {
+			Assert.notNull(policy, "policy must not be null");
+			this.policy = policy;
+			return this;
+		}
+
+		public Builder deniedCallResponse(BiFunction<String, ToolCallDecision, String> deniedCallResponse) {
+			Assert.notNull(deniedCallResponse, "deniedCallResponse must not be null");
+			this.deniedCallResponse = deniedCallResponse;
+			return this;
+		}
+
+		public ToolCallPolicyAdvisor build() {
+			return new ToolCallPolicyAdvisor(this.order, this.policy, this.deniedCallResponse);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolFilterAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolFilterAdvisor.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.List;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.Assert;
+import org.springframework.util.PatternMatchUtils;
+
+/**
+ * Filters available tool callbacks by include/exclude glob patterns.
+ *
+ * @author vaquarkhan
+ */
+public class ToolFilterAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	private final List<String> includePatterns;
+
+	private final List<String> excludePatterns;
+
+	private ToolFilterAdvisor(int order, List<String> includePatterns, List<String> excludePatterns) {
+		this.order = order;
+		this.includePatterns = includePatterns;
+		this.excludePatterns = excludePatterns;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		if (!(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions)) {
+			return chatClientRequest;
+		}
+
+		ToolCallingChatOptions toolOptionsCopy = toolOptions.copy();
+		List<ToolCallback> callbacks = toolOptionsCopy.getToolCallbacks();
+		if (callbacks == null || callbacks.isEmpty()) {
+			return chatClientRequest;
+		}
+
+		List<ToolCallback> filtered = callbacks.stream().filter(this::isAllowed).toList();
+		toolOptionsCopy.setToolCallbacks(filtered);
+		return chatClientRequest.mutate().prompt(chatClientRequest.prompt().mutate().chatOptions(toolOptionsCopy).build()).build();
+	}
+
+	private boolean isAllowed(ToolCallback callback) {
+		String toolName = callback.getToolDefinition().name();
+		boolean included = this.includePatterns.isEmpty()
+				|| PatternMatchUtils.simpleMatch(this.includePatterns.toArray(String[]::new), toolName);
+		if (!included) {
+			return false;
+		}
+		boolean excluded = !this.excludePatterns.isEmpty()
+				&& PatternMatchUtils.simpleMatch(this.excludePatterns.toArray(String[]::new), toolName);
+		return !excluded;
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		// Before default ToolCallingAdvisor (HIGHEST_PRECEDENCE + 300)
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 248;
+
+		private List<String> includePatterns = List.of();
+
+		private List<String> excludePatterns = List.of();
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder includePatterns(List<String> includePatterns) {
+			Assert.notNull(includePatterns, "includePatterns must not be null");
+			this.includePatterns = includePatterns;
+			return this;
+		}
+
+		public Builder excludePatterns(List<String> excludePatterns) {
+			Assert.notNull(excludePatterns, "excludePatterns must not be null");
+			this.excludePatterns = excludePatterns;
+			return this;
+		}
+
+		public ToolFilterAdvisor build() {
+			return new ToolFilterAdvisor(this.order, this.includePatterns, this.excludePatterns);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolRateLimitAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolRateLimitAdvisor.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.Assert;
+
+/**
+ * Enforces per-loop (per-request) tool call limits.
+ *
+ * @author vaquarkhan
+ */
+public class ToolRateLimitAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	private final int maxToolCallsPerRequest;
+
+	private final BiFunction<String, Integer, String> rateLimitResponse;
+
+	private ToolRateLimitAdvisor(int order, int maxToolCallsPerRequest,
+			BiFunction<String, Integer, String> rateLimitResponse) {
+		this.order = order;
+		this.maxToolCallsPerRequest = maxToolCallsPerRequest;
+		this.rateLimitResponse = rateLimitResponse;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		if (!(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions)) {
+			return chatClientRequest;
+		}
+
+		ToolCallingChatOptions toolOptionsCopy = toolOptions.copy();
+		List<ToolCallback> callbacks = toolOptionsCopy.getToolCallbacks();
+		if (callbacks == null || callbacks.isEmpty() || this.maxToolCallsPerRequest <= 0) {
+			return chatClientRequest;
+		}
+
+		AtomicInteger callCounter = new AtomicInteger(0);
+		List<ToolCallback> wrappedCallbacks = new ArrayList<>(callbacks.size());
+		for (ToolCallback callback : callbacks) {
+			if (callback instanceof RateLimitedToolCallback) {
+				wrappedCallbacks.add(callback);
+			}
+			else {
+				wrappedCallbacks.add(new RateLimitedToolCallback(callback, callCounter, this.maxToolCallsPerRequest,
+						this.rateLimitResponse));
+			}
+		}
+		toolOptionsCopy.setToolCallbacks(wrappedCallbacks);
+		return chatClientRequest.mutate().prompt(chatClientRequest.prompt().mutate().chatOptions(toolOptionsCopy).build()).build();
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private static final class RateLimitedToolCallback implements ToolCallback {
+
+		private final ToolCallback delegate;
+
+		private final AtomicInteger callCounter;
+
+		private final int maxToolCallsPerRequest;
+
+		private final BiFunction<String, Integer, String> rateLimitResponse;
+
+		private RateLimitedToolCallback(ToolCallback delegate, AtomicInteger callCounter, int maxToolCallsPerRequest,
+				BiFunction<String, Integer, String> rateLimitResponse) {
+			this.delegate = delegate;
+			this.callCounter = callCounter;
+			this.maxToolCallsPerRequest = maxToolCallsPerRequest;
+			this.rateLimitResponse = rateLimitResponse;
+		}
+
+		@Override
+		public String call(String toolInput) {
+			String toolName = this.delegate.getToolDefinition().name();
+			int calls = this.callCounter.incrementAndGet();
+			if (calls > this.maxToolCallsPerRequest) {
+				return this.rateLimitResponse.apply(toolName, this.maxToolCallsPerRequest);
+			}
+			return this.delegate.call(toolInput);
+		}
+
+		@Override
+		public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+			return this.delegate.getToolDefinition();
+		}
+
+		@Override
+		public org.springframework.ai.tool.metadata.ToolMetadata getToolMetadata() {
+			return this.delegate.getToolMetadata();
+		}
+
+	}
+
+	public static final class Builder {
+
+		// Before default ToolCallingAdvisor (HIGHEST_PRECEDENCE + 300)
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 247;
+
+		private int maxToolCallsPerRequest = 0;
+
+		private BiFunction<String, Integer, String> rateLimitResponse = (toolName, maxCalls) -> "Tool rate limit exceeded for request: max %d calls, blocked '%s'"
+			.formatted(maxCalls, toolName);
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder maxToolCallsPerRequest(int maxToolCallsPerRequest) {
+			Assert.isTrue(maxToolCallsPerRequest >= 0, "maxToolCallsPerRequest must be >= 0");
+			this.maxToolCallsPerRequest = maxToolCallsPerRequest;
+			return this;
+		}
+
+		public Builder rateLimitResponse(BiFunction<String, Integer, String> rateLimitResponse) {
+			Assert.notNull(rateLimitResponse, "rateLimitResponse must not be null");
+			this.rateLimitResponse = rateLimitResponse;
+			return this;
+		}
+
+		public ToolRateLimitAdvisor build() {
+			return new ToolRateLimitAdvisor(this.order, this.maxToolCallsPerRequest, this.rateLimitResponse);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolTimeoutAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/ToolTimeoutAdvisor.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.util.Assert;
+
+/**
+ * Enforces timeout limits for tool execution.
+ *
+ * @author vaquarkhan
+ */
+public class ToolTimeoutAdvisor implements BaseAdvisor {
+
+	private final int order;
+
+	private final Duration defaultTimeout;
+
+	private final Map<String, Duration> perToolTimeouts;
+
+	private final ExecutorService executorService;
+
+	private final BiFunction<String, Duration, String> timeoutResponse;
+
+	private ToolTimeoutAdvisor(int order, Duration defaultTimeout, Map<String, Duration> perToolTimeouts,
+			ExecutorService executorService, BiFunction<String, Duration, String> timeoutResponse) {
+		this.order = order;
+		this.defaultTimeout = defaultTimeout;
+		this.perToolTimeouts = perToolTimeouts;
+		this.executorService = executorService;
+		this.timeoutResponse = timeoutResponse;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		if (!(chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions)) {
+			return chatClientRequest;
+		}
+
+		ToolCallingChatOptions toolOptionsCopy = toolOptions.copy();
+		List<ToolCallback> callbacks = toolOptionsCopy.getToolCallbacks();
+		if (callbacks == null || callbacks.isEmpty()) {
+			return chatClientRequest;
+		}
+
+		List<ToolCallback> wrappedCallbacks = new ArrayList<>(callbacks.size());
+		for (ToolCallback callback : callbacks) {
+			if (callback instanceof TimeoutToolCallback) {
+				wrappedCallbacks.add(callback);
+			}
+			else {
+				wrappedCallbacks.add(new TimeoutToolCallback(callback, this.defaultTimeout, this.perToolTimeouts,
+						this.executorService, this.timeoutResponse));
+			}
+		}
+
+		toolOptionsCopy.setToolCallbacks(wrappedCallbacks);
+		return chatClientRequest.mutate().prompt(chatClientRequest.prompt().mutate().chatOptions(toolOptionsCopy).build()).build();
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private static final class TimeoutToolCallback implements ToolCallback {
+
+		private final ToolCallback delegate;
+
+		private final Duration defaultTimeout;
+
+		private final Map<String, Duration> perToolTimeouts;
+
+		private final ExecutorService executorService;
+
+		private final BiFunction<String, Duration, String> timeoutResponse;
+
+		private TimeoutToolCallback(ToolCallback delegate, Duration defaultTimeout, Map<String, Duration> perToolTimeouts,
+				ExecutorService executorService, BiFunction<String, Duration, String> timeoutResponse) {
+			this.delegate = delegate;
+			this.defaultTimeout = defaultTimeout;
+			this.perToolTimeouts = perToolTimeouts;
+			this.executorService = executorService;
+			this.timeoutResponse = timeoutResponse;
+		}
+
+		@Override
+		public String call(String toolInput) {
+			String toolName = this.delegate.getToolDefinition().name();
+			Duration timeout = this.perToolTimeouts.getOrDefault(toolName, this.defaultTimeout);
+			try {
+				return CompletableFuture.supplyAsync(() -> this.delegate.call(toolInput), this.executorService)
+					.orTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS)
+					.join();
+			}
+			catch (CompletionException ex) {
+				if (ex.getCause() instanceof java.util.concurrent.TimeoutException) {
+					return this.timeoutResponse.apply(toolName, timeout);
+				}
+				throw ex;
+			}
+		}
+
+		@Override
+		public org.springframework.ai.tool.definition.ToolDefinition getToolDefinition() {
+			return this.delegate.getToolDefinition();
+		}
+
+		@Override
+		public org.springframework.ai.tool.metadata.ToolMetadata getToolMetadata() {
+			return this.delegate.getToolMetadata();
+		}
+
+	}
+
+	public static final class Builder {
+
+		// Before default ToolCallingAdvisor (HIGHEST_PRECEDENCE + 300)
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 246;
+
+		private Duration defaultTimeout = Duration.ofSeconds(30);
+
+		private Map<String, Duration> perToolTimeouts = Map.of();
+
+		private ExecutorService executorService = Executors.newCachedThreadPool();
+
+		private BiFunction<String, Duration, String> timeoutResponse = (toolName, timeout) -> "Tool '%s' timed out after %d ms"
+			.formatted(toolName, timeout.toMillis());
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder defaultTimeout(Duration defaultTimeout) {
+			Assert.notNull(defaultTimeout, "defaultTimeout must not be null");
+			Assert.isTrue(!defaultTimeout.isNegative() && !defaultTimeout.isZero(),
+					"defaultTimeout must be positive");
+			this.defaultTimeout = defaultTimeout;
+			return this;
+		}
+
+		public Builder perToolTimeouts(Map<String, Duration> perToolTimeouts) {
+			Assert.notNull(perToolTimeouts, "perToolTimeouts must not be null");
+			this.perToolTimeouts = perToolTimeouts;
+			return this;
+		}
+
+		public Builder executorService(ExecutorService executorService) {
+			Assert.notNull(executorService, "executorService must not be null");
+			this.executorService = executorService;
+			return this;
+		}
+
+		public Builder timeoutResponse(BiFunction<String, Duration, String> timeoutResponse) {
+			Assert.notNull(timeoutResponse, "timeoutResponse must not be null");
+			this.timeoutResponse = timeoutResponse;
+			return this;
+		}
+
+		public ToolTimeoutAdvisor build() {
+			return new ToolTimeoutAdvisor(this.order, this.defaultTimeout, this.perToolTimeouts, this.executorService,
+					this.timeoutResponse);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ReasoningTraceAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ReasoningTraceAdvisorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReasoningTraceAdvisor Tests")
+class ReasoningTraceAdvisorTest {
+
+	@Test
+	@DisplayName("Emits iteration trace with timing and user input")
+	void emitsTrace() {
+		List<ReasoningTraceAdvisor.ReasoningTraceEntry> traces = new ArrayList<>();
+		ReasoningTraceAdvisor advisor = ReasoningTraceAdvisor.builder().traceSink(traces::add).build();
+
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hello trace"))).build();
+		ChatClientResponse response = ChatClientResponse.builder().context(Map.of()).build();
+
+		advisor.before(request, null);
+		advisor.after(response, null);
+
+		assertThat(traces).hasSize(1);
+		assertThat(traces.get(0).durationMs()).isGreaterThanOrEqualTo(0);
+		assertThat(traces.get(0).userInput()).contains("hello trace");
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolApprovalAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolApprovalAdvisorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ToolApprovalAdvisor Tests")
+class ToolApprovalAdvisorTest {
+
+	@Test
+	@DisplayName("Denied approval blocks tool execution")
+	void deniedApprovalBlocksExecution() {
+		ToolCallback callback = toolCallback("WriteFile");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolApprovalAdvisor advisor = ToolApprovalAdvisor.builder()
+			.approvalManager(req -> CompletableFuture.completedFuture(ToolApprovalAdvisor.ToolApprovalDecision.deny("manual")))
+			.build();
+
+		ToolCallback guarded = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions())
+			.getToolCallbacks()
+			.get(0);
+		String result = guarded.call("{\"x\":1}");
+
+		assertThat(result).contains("denied").contains("manual");
+		verify(callback, never()).call(anyString());
+	}
+
+	@Test
+	@DisplayName("Approval rewrite uses rewritten arguments")
+	void approvalRewriteUsesRewrittenArguments() {
+		ToolCallback callback = toolCallback("EditFile");
+		when(callback.call(anyString())).thenReturn("ok");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolApprovalAdvisor advisor = ToolApprovalAdvisor.builder()
+			.approvalManager(req -> CompletableFuture
+				.completedFuture(ToolApprovalAdvisor.ToolApprovalDecision.approveWithRewrite("{\"safe\":true}")))
+			.build();
+
+		ToolCallback guarded = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions())
+			.getToolCallbacks()
+			.get(0);
+		String result = guarded.call("{\"unsafe\":true}");
+
+		assertThat(result).isEqualTo("ok");
+		verify(callback).call("{\"safe\":true}");
+	}
+
+	private static ToolCallback toolCallback(String toolName) {
+		ToolCallback callback = mock(ToolCallback.class);
+		ToolDefinition toolDefinition = mock(ToolDefinition.class);
+		when(toolDefinition.name()).thenReturn(toolName);
+		when(callback.getToolDefinition()).thenReturn(toolDefinition);
+		return callback;
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolArgumentValidationAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolArgumentValidationAdvisorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ToolArgumentValidationAdvisor Tests")
+class ToolArgumentValidationAdvisorTest {
+
+	@Test
+	@DisplayName("Oversized arguments are blocked")
+	void oversizedArgumentsAreBlocked() {
+		ToolCallback callback = toolCallback("WriteFile");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolArgumentValidationAdvisor advisor = ToolArgumentValidationAdvisor.builder().maxArgumentBytes(5).build();
+		ToolCallback guarded = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions())
+			.getToolCallbacks()
+			.get(0);
+
+		String result = guarded.call("{\"long\":true}");
+		assertThat(result).contains("too large");
+		verify(callback, never()).call(anyString());
+	}
+
+	@Test
+	@DisplayName("Valid arguments are executed")
+	void validArgumentsAreExecuted() {
+		ToolCallback callback = toolCallback("ReadFile");
+		when(callback.call(anyString())).thenReturn("ok");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolArgumentValidationAdvisor advisor = ToolArgumentValidationAdvisor.builder().maxArgumentBytes(100).build();
+		ToolCallback guarded = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions())
+			.getToolCallbacks()
+			.get(0);
+
+		String result = guarded.call("{}");
+		assertThat(result).isEqualTo("ok");
+		verify(callback).call("{}");
+	}
+
+	private static ToolCallback toolCallback(String toolName) {
+		ToolCallback callback = mock(ToolCallback.class);
+		ToolDefinition toolDefinition = mock(ToolDefinition.class);
+		when(toolDefinition.name()).thenReturn(toolName);
+		when(callback.getToolDefinition()).thenReturn(toolDefinition);
+		return callback;
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolCallPolicyAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolCallPolicyAdvisorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ToolCallPolicyAdvisor}.
+ *
+ * @author vaquarkhan
+ */
+@DisplayName("ToolCallPolicyAdvisor Tests")
+@ExtendWith(MockitoExtension.class)
+class ToolCallPolicyAdvisorTest {
+
+	private final AdvisorChain advisorChain = mock(AdvisorChain.class);
+
+	@Test
+	@DisplayName("Default order is HIGHEST_PRECEDENCE + 250")
+	void defaultOrder() {
+		ToolCallPolicyAdvisor advisor = ToolCallPolicyAdvisor.builder().build();
+		assertThat(advisor.getOrder()).isEqualTo(BaseAdvisor.HIGHEST_PRECEDENCE + 250);
+	}
+
+	@Test
+	@DisplayName("Returns request unchanged when no ToolCallingChatOptions")
+	void beforePassesThroughWhenNoToolOptions() {
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hello"))).build();
+
+		ToolCallPolicyAdvisor advisor = ToolCallPolicyAdvisor.builder().build();
+		ChatClientRequest result = advisor.before(request, advisorChain);
+
+		assertThat(result).isSameAs(request);
+	}
+
+	@Test
+	@DisplayName("Policy can deny a tool call")
+	void denyToolCall() {
+		ToolCallback callback = toolCallback("WriteFile");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(new Prompt(new UserMessage("hello"), options))
+			.build();
+
+		ToolCallPolicyAdvisor advisor = ToolCallPolicyAdvisor.builder()
+			.policy((name, args) -> ToolCallPolicyAdvisor.ToolCallDecision.deny("blocked"))
+			.build();
+
+		ToolCallback guardedCallback = ((DefaultToolCallingChatOptions) advisor.before(request, advisorChain)
+			.prompt()
+			.getOptions()).getToolCallbacks().get(0);
+
+		String result = guardedCallback.call("{\"path\":\"/tmp/x\"}");
+
+		assertThat(result).contains("denied").contains("WriteFile").contains("blocked");
+		verify(callback, never()).call(anyString());
+	}
+
+	@Test
+	@DisplayName("Policy can rewrite tool arguments before execution")
+	void rewriteToolArguments() {
+		ToolCallback callback = toolCallback("EditFile");
+		when(callback.call(anyString())).thenReturn("delegate-result");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(new Prompt(new UserMessage("hello"), options))
+			.build();
+
+		ToolCallPolicyAdvisor advisor = ToolCallPolicyAdvisor.builder()
+			.policy((name, args) -> ToolCallPolicyAdvisor.ToolCallDecision.rewrite("{\"safe\":true}"))
+			.build();
+
+		ToolCallback guardedCallback = ((DefaultToolCallingChatOptions) advisor.before(request, advisorChain)
+			.prompt()
+			.getOptions()).getToolCallbacks().get(0);
+
+		String result = guardedCallback.call("{\"unsafe\":true}");
+
+		assertThat(result).isEqualTo("delegate-result");
+		verify(callback).call("{\"safe\":true}");
+	}
+
+	@Test
+	@DisplayName("Policy allow executes original callback with original arguments")
+	void allowCallsOriginalCallback() {
+		ToolCallback callback = toolCallback("ReadFile");
+		when(callback.call(anyString())).thenReturn("ok");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder()
+			.prompt(new Prompt(new UserMessage("hello"), options))
+			.build();
+
+		ToolCallPolicyAdvisor advisor = ToolCallPolicyAdvisor.builder()
+			.policy((name, args) -> ToolCallPolicyAdvisor.ToolCallDecision.allow())
+			.build();
+
+		ToolCallback guardedCallback = ((DefaultToolCallingChatOptions) advisor.before(request, advisorChain)
+			.prompt()
+			.getOptions()).getToolCallbacks().get(0);
+
+		String result = guardedCallback.call("{\"path\":\"README.md\"}");
+
+		assertThat(result).isEqualTo("ok");
+		verify(callback).call("{\"path\":\"README.md\"}");
+	}
+
+	@Test
+	@DisplayName("Rewrite decision requires non-empty rewritten arguments")
+	void rewriteRequiresArguments() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> new ToolCallPolicyAdvisor.ToolCallDecision(
+					ToolCallPolicyAdvisor.ToolCallAction.REWRITE, "", null));
+	}
+
+	private static ToolCallback toolCallback(String toolName) {
+		ToolCallback callback = mock(ToolCallback.class);
+		ToolDefinition toolDefinition = mock(ToolDefinition.class);
+		when(toolDefinition.name()).thenReturn(toolName);
+		when(callback.getToolDefinition()).thenReturn(toolDefinition);
+		return callback;
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolFilterAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolFilterAdvisorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ToolFilterAdvisor Tests")
+class ToolFilterAdvisorTest {
+
+	@Test
+	@DisplayName("Include and exclude patterns are applied to tool names")
+	void filtersByGlobPatterns() {
+		ToolCallback read = toolCallback("ReadFile");
+		ToolCallback write = toolCallback("WriteFile");
+		ToolCallback web = toolCallback("WebSearch");
+
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(read, write, web));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolFilterAdvisor advisor = ToolFilterAdvisor.builder()
+			.includePatterns(List.of("*File"))
+			.excludePatterns(List.of("Write*"))
+			.build();
+
+		List<String> names = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions()).getToolCallbacks()
+			.stream()
+			.map(tc -> tc.getToolDefinition().name())
+			.toList();
+
+		assertThat(names).containsExactly("ReadFile");
+	}
+
+	private static ToolCallback toolCallback(String toolName) {
+		ToolCallback callback = mock(ToolCallback.class);
+		ToolDefinition toolDefinition = mock(ToolDefinition.class);
+		when(toolDefinition.name()).thenReturn(toolName);
+		when(callback.getToolDefinition()).thenReturn(toolDefinition);
+		return callback;
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolRateLimitAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolRateLimitAdvisorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ToolRateLimitAdvisor Tests")
+class ToolRateLimitAdvisorTest {
+
+	@Test
+	@DisplayName("Second call is blocked when max is one")
+	void secondCallBlocked() {
+		ToolCallback callback = toolCallback("AnyTool", input -> "ok");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolRateLimitAdvisor advisor = ToolRateLimitAdvisor.builder().maxToolCallsPerRequest(1).build();
+		ToolCallback guarded = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions())
+			.getToolCallbacks()
+			.get(0);
+
+		assertThat(guarded.call("{}")).isEqualTo("ok");
+		assertThat(guarded.call("{}")).contains("rate limit exceeded");
+	}
+
+	private static ToolCallback toolCallback(String toolName, java.util.function.Function<String, String> fn) {
+		ToolCallback callback = mock(ToolCallback.class);
+		ToolDefinition toolDefinition = mock(ToolDefinition.class);
+		when(toolDefinition.name()).thenReturn(toolName);
+		when(callback.getToolDefinition()).thenReturn(toolDefinition);
+		when(callback.call(org.mockito.ArgumentMatchers.anyString())).thenAnswer(invocation -> fn.apply(invocation.getArgument(0)));
+		return callback;
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolTimeoutAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/ToolTimeoutAdvisorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.advisors;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ToolTimeoutAdvisor Tests")
+class ToolTimeoutAdvisorTest {
+
+	@Test
+	@DisplayName("Timeout returns timeout response")
+	void timeoutReturnsTimeoutResponse() {
+		ToolCallback callback = toolCallback("SlowTool", input -> {
+			try {
+				Thread.sleep(120);
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+			}
+			return "slow";
+		});
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolTimeoutAdvisor advisor = ToolTimeoutAdvisor.builder().defaultTimeout(Duration.ofMillis(20)).build();
+		ToolCallback guarded = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions())
+			.getToolCallbacks()
+			.get(0);
+
+		String result = guarded.call("{}");
+		assertThat(result).contains("timed out");
+	}
+
+	@Test
+	@DisplayName("Fast tool completes normally")
+	void fastToolCompletesNormally() {
+		ToolCallback callback = toolCallback("FastTool", input -> "ok");
+		DefaultToolCallingChatOptions options = new DefaultToolCallingChatOptions();
+		options.setToolCallbacks(List.of(callback));
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"), options)).build();
+
+		ToolTimeoutAdvisor advisor = ToolTimeoutAdvisor.builder().defaultTimeout(Duration.ofSeconds(1)).build();
+		ToolCallback guarded = ((DefaultToolCallingChatOptions) advisor.before(request, null).prompt().getOptions())
+			.getToolCallbacks()
+			.get(0);
+
+		assertThat(guarded.call("{}")).isEqualTo("ok");
+	}
+
+	private static ToolCallback toolCallback(String toolName, java.util.function.Function<String, String> fn) {
+		ToolCallback callback = mock(ToolCallback.class);
+		ToolDefinition toolDefinition = mock(ToolDefinition.class);
+		when(toolDefinition.name()).thenReturn(toolName);
+		when(callback.getToolDefinition()).thenReturn(toolDefinition);
+		when(callback.call(org.mockito.ArgumentMatchers.anyString())).thenAnswer(invocation -> fn.apply(invocation.getArgument(0)));
+		return callback;
+	}
+
+}


### PR DESCRIPTION
## Summary

This PR adds a set of standalone ChatClient advisors for tool governance and loop observability in spring-ai-agent-utils:

- `ToolCallPolicyAdvisor` for allow/deny/rewrite decisions before tool execution.
- `ToolApprovalAdvisor` for human-in-the-loop approvals using `CompletableFuture` blocking.
- `ToolArgumentValidationAdvisor` for tool argument byte-size limits.
- `ToolTimeoutAdvisor` for per-tool timeout enforcement (with default + overrides).
- `ToolRateLimitAdvisor` for per-request (loop) tool call rate limiting.
- `ToolFilterAdvisor` for include/exclude filtering by glob-style tool name patterns.
- `ReasoningTraceAdvisor` for per-iteration trace emission with timing and tool-call metadata.

**Additional changes:**
- Added focused unit tests for all new advisors.
- Added docs pages for each advisor under `spring-ai-agent-utils/docs`.
- Updated `spring-ai-agent-utils/README.md` advisor section to include all new advisors.

## Why

These advisors provide missing governance and observability controls commonly needed in production agent systems:
- enforce policy and approval on tool usage,
- bound unsafe/expensive tool calls (size, timeout, rate),
- scope tool exposure by pattern,
- improve loop-level traceability for operations and debugging.

## Test Plan

- Ran advisor-focused unit tests:
  - ToolCallPolicyAdvisorTest
  - ToolApprovalAdvisorTest
  - ToolArgumentValidationAdvisorTest
  - ToolTimeoutAdvisorTest
  - ToolRateLimitAdvisorTest
  - ToolFilterAdvisorTest
  - ReasoningTraceAdvisorTest
  -- Result: all tests passed (`15` tests, `0` failures).

**Command used:**

```bash
mvn -f spring-ai-agent-utils/pom.xml "-Dtest=ToolCallPolicyAdvisorTest,ToolApprovalAdvisorTest,ToolArgumentValidationAdvisorTest,ToolTimeoutAdvisorTest,ToolRateLimitAdvisorTest,ToolFilterAdvisorTest,ReasoningTraceAdvisorTest" test