### PR TITLE
Add diff tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ These are the agent tools needed to implement any agentic behavior
 - **[ShellTools](spring-ai-agent-utils/docs/ShellTools.md)** - Execute shell commands with timeout control, background process management, and regex output filtering
 - **[GrepTool](spring-ai-agent-utils/docs/GrepTool.md)** - Pure Java grep implementation for code search with regex, glob filtering, and multiple output modes
 - **[GlobTool](spring-ai-agent-utils/docs/GlobTool.md)** - Fast file pattern matching tool for finding files by name patterns with glob syntax
+- **[DiffTool](spring-ai-agent-utils/docs/DiffTool.md)** - Pure Java unified-diff tool for comparing strings or files using Myers' O(ND) algorithm; output is compatible with `patch` and `git apply`
 - **[SmartWebFetchTool](spring-ai-agent-utils/docs/SmartWebFetchTool.md)** - AI-powered web content summarization with caching
 - **[BraveWebSearchTool](spring-ai-agent-utils/docs/BraveWebSearchTool.md)** - Web search with domain filtering
 

--- a/spring-ai-agent-utils/README.md
+++ b/spring-ai-agent-utils/README.md
@@ -19,6 +19,7 @@ These are the agent tools needed to implement any agentic behavior
 - **[GlobTool](docs/GlobTool.md)** - Fast file pattern matching tool for finding files by name patterns with glob syntax
 - **[SmartWebFetchTool](docs/SmartWebFetchTool.md)** - AI-powered web content summarization with caching
 - **[BraveWebSearchTool](docs/BraveWebSearchTool.md)** - Web search with domain filtering
+- **[DiffTool](docs/DiffTool.md)** - Pure Java unified-diff tool for comparing strings or files using Myers' O(ND) algorithm; output is compatible with `patch` and `git apply`
 
 #### User feedback
 
@@ -332,6 +333,40 @@ String results = searchTool.webSearch(
 
 // Or use search operators for efficiency
 String results2 = searchTool.webSearch("Spring AI site:spring.io", null, null);
+```
+
+### DiffTool
+
+Pure Java unified-diff tool for comparing two text blocks or two files on disk. Uses Eugene W. Myers' O(ND) difference algorithm and emits output compatible with the `patch` utility and `git apply`. Includes a lightweight summary mode for insertion/deletion/hunk counts and whitespace-insensitive comparison modes.
+
+[**View Full Documentation →**](../docs/tools/DiffTool.md)
+
+**Quick Example:**
+```java
+DiffTool diffTool = DiffTool.builder().build();
+
+// Compare two strings
+String unified = diffTool.diff(
+    "hello\nworld\n",   // before
+    "hello\njava\n",    // after
+    "a/file.txt",       // beforeLabel
+    "b/file.txt",       // afterLabel
+    null,               // contextLines (default 3, max 10)
+    null                // whitespaceMode (default STRICT)
+);
+
+// Compare two files on disk
+String fileDiff = diffTool.diffFiles(
+    "src/main/resources/application.yml",
+    "src/main/resources/application-new.yml",
+    null,
+    DiffTool.WhitespaceMode.IGNORE_TRAILING
+);
+
+// Get aggregate counts without rendering the full diff
+DiffTool.DiffSummary summary = diffTool.summarize(before, after, null, null);
+System.out.println(summary.insertions() + " +, " + summary.deletions() + " -, "
+    + summary.hunks() + " hunks");
 ```
 ---
 

--- a/spring-ai-agent-utils/docs/DiffTool.md
+++ b/spring-ai-agent-utils/docs/DiffTool.md
@@ -1,0 +1,229 @@
+# DiffTool
+
+Pure Java unified-diff tool for comparing two text blocks or two files on disk. Uses Eugene W. Myers' O(ND) difference algorithm and emits output compatible with the `patch` utility and `git apply`.
+
+**Features:**
+- Unified-diff output with configurable surrounding context
+- String-to-string and file-to-file comparison
+- Whitespace-insensitive modes (`STRICT`, `IGNORE_TRAILING`, `IGNORE_ALL`)
+- Lightweight summary mode returning insertion, deletion, and hunk counts
+- Correct handling of missing trailing newlines (`\ No newline at end of file`)
+- Zero runtime dependencies beyond Spring AI core and the JDK; stateless and thread-safe
+
+## Available Tools
+
+### 1. diff - Compare two strings
+
+The primary tool for comparing two text blocks and producing a unified diff.
+
+**Parameters:**
+- `before` (required) - Original text (the 'before' side)
+- `after` (required) - Modified text (the 'after' side)
+- `beforeLabel` (optional) - Label emitted on the `---` header line (default: `before`)
+- `afterLabel` (optional) - Label emitted on the `+++` header line (default: `after`)
+- `contextLines` (optional) - Unchanged context lines around each change (default: 3, max: 10)
+- `whitespaceMode` (optional) - Whitespace handling: `STRICT`, `IGNORE_TRAILING`, or `IGNORE_ALL` (default: `STRICT`)
+
+**Basic Usage:**
+
+```java
+DiffTool diffTool = DiffTool.builder().build();
+
+// Basic comparison
+String result = diffTool.diff(
+    "hello\nworld\n",   // before
+    "hello\njava\n",    // after
+    null,               // beforeLabel (uses "before")
+    null,               // afterLabel (uses "after")
+    null,               // contextLines (default 3)
+    null                // whitespaceMode (default STRICT)
+);
+
+// With custom labels
+String result = diffTool.diff(
+    originalConfig,
+    updatedConfig,
+    "a/config.yml",
+    "b/config.yml",
+    null,
+    null
+);
+
+// Whitespace-insensitive comparison
+String result = diffTool.diff(
+    before,
+    after,
+    null,
+    null,
+    5,                              // 5 context lines
+    DiffTool.WhitespaceMode.IGNORE_ALL
+);
+```
+
+**Output Format:**
+```
+--- a/config.yml
++++ b/config.yml
+@@ -1,3 +1,3 @@
+ hello
+-world
++java
+```
+
+**Important Notes:**
+- Output follows the standard unified-diff format and is compatible with `patch` and `git apply`
+- Returns an empty string when inputs are equivalent under the selected whitespace mode
+- Output uses the line terminator dominant in `before` (or in `after` when `before` has no lines)
+- Appends `\ No newline at end of file` marker when either side is missing a trailing newline
+- `contextLines` is clamped to the range `[0, 10]`
+
+### 2. DiffFiles - Compare two files
+
+Produces a unified diff between the current contents of two files on disk.
+
+**Parameters:**
+- `beforePath` (required) - Path to the original file
+- `afterPath` (required) - Path to the modified file
+- `contextLines` (optional) - Unchanged context lines around each change (default: 3, max: 10)
+- `whitespaceMode` (optional) - Whitespace handling: `STRICT`, `IGNORE_TRAILING`, or `IGNORE_ALL` (default: `STRICT`)
+
+**Usage:**
+
+```java
+DiffTool diffTool = DiffTool.builder().build();
+
+// Compare two files
+String result = diffTool.diffFiles(
+    "src/main/resources/application.yml",    // beforePath
+    "src/main/resources/application-new.yml", // afterPath
+    null,                                     // contextLines (default 3)
+    null                                      // whitespaceMode (default STRICT)
+);
+
+// With extra context and whitespace-insensitive
+String result = diffTool.diffFiles(
+    "old.txt",
+    "new.txt",
+    7,
+    DiffTool.WhitespaceMode.IGNORE_TRAILING
+);
+```
+
+**Output Format:**
+```
+--- a/src/main/resources/application.yml
++++ b/src/main/resources/application-new.yml
+@@ -10,7 +10,7 @@
+ spring:
+   datasource:
+-    url: jdbc:h2:mem:test
++    url: jdbc:postgresql://localhost/app
+```
+
+**Key Features:**
+- **Automatic labels**: Header lines use `a/<beforePath>` and `b/<afterPath>`
+- **Path resolution**: Relative paths are resolved against the JVM working directory
+- **Error handling**: Returns `Error reading files: <message>` if either file cannot be read
+
+**Important Notes:**
+- Both paths must be non-blank
+- Files are read with the platform default charset via `Files.readString`
+- Uses the same diff engine as the `diff` tool
+
+### 3. DiffSummarize - Aggregate change counts
+
+Returns aggregate counts without emitting the full unified-diff body.
+
+**Parameters:**
+- `before` (required) - Original text (the 'before' side)
+- `after` (required) - Modified text (the 'after' side)
+- `contextLines` (optional) - Unchanged context lines used when grouping hunks (default: 3, max: 10)
+- `whitespaceMode` (optional) - Whitespace handling: `STRICT`, `IGNORE_TRAILING`, or `IGNORE_ALL` (default: `STRICT`)
+
+**Usage:**
+
+```java
+DiffTool diffTool = DiffTool.builder().build();
+
+// Get change counts for two strings
+DiffTool.DiffSummary summary = diffTool.summarize(
+    before,
+    after,
+    null,
+    null
+);
+
+System.out.println("Insertions: " + summary.insertions());
+System.out.println("Deletions:  " + summary.deletions());
+System.out.println("Hunks:      " + summary.hunks());
+```
+
+**Output Format:**
+```
+DiffSummary[insertions=4, deletions=2, hunks=1]
+```
+
+**Key Features:**
+- **Lightweight**: Skips unified-diff rendering — only the edit script and hunk grouping are computed
+- **Same engine**: Counts match exactly what the `diff` tool would emit
+- **Useful for gating**: Cheaply check whether changes exist or exceed a threshold
+
+**Example Workflow:**
+
+```java
+DiffTool diffTool = DiffTool.builder().build();
+
+// 1. Summarize first to decide whether to render
+DiffTool.DiffSummary summary = diffTool.summarize(before, after, null, null);
+
+if (summary.insertions() == 0 && summary.deletions() == 0) {
+    System.out.println("No changes.");
+    return;
+}
+
+// 2. Render the full diff only when needed
+String unified = diffTool.diff(before, after, "a/file", "b/file", null, null);
+System.out.println(unified);
+```
+
+**Whitespace Modes:**
+
+| Mode | Behavior |
+|------|----------|
+| `STRICT` | Compare lines byte-for-byte |
+| `IGNORE_TRAILING` | Ignore trailing whitespace (see `String#stripTrailing()`) |
+| `IGNORE_ALL` | Collapse all whitespace runs to a single space, then trim |
+
+**Configuration & Limits:**
+
+| Setting | Default | Maximum | Description |
+|---------|---------|---------|-------------|
+| `contextLines` | 3 | 10 | Unchanged lines shown around each change region |
+| `whitespaceMode` | `STRICT` | — | Line-equality policy |
+
+**Best Practices:**
+
+1. **Use git-style labels**: Emit `a/<path>` and `b/<path>` for easy consumption by `git apply`
+   ```java
+   diffTool.diff(before, after, "a/pom.xml", "b/pom.xml", null, null);
+   ```
+
+2. **Summarize before rendering**: Skip the full diff when there are no changes
+   ```java
+   if (diffTool.summarize(before, after, null, null).hunks() == 0) return;
+   ```
+
+3. **Tune context for readability**: Increase `contextLines` for reviews, keep the default for patches
+   ```java
+   diffTool.diff(before, after, null, null, 7, null);
+   ```
+
+4. **Choose the right whitespace mode**: Use `IGNORE_TRAILING` for cross-platform text files; reserve `IGNORE_ALL` for formatting-only diffs
+   ```java
+   diffTool.diff(before, after, null, null, null, DiffTool.WhitespaceMode.IGNORE_TRAILING);
+   ```
+
+5. **Prefer `diffFiles` for disk content**: Avoids manual `Files.readString` and produces git-style labels automatically
+   ```java
+   diffTool.diffFiles("old.yml", "new.yml", null, null);
+   ```

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/DiffTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/DiffTool.java
@@ -29,23 +29,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
-import org.springframework.util.Assert;
 
 /**
  * Spring AI tool that produces unified-diff output between two text blocks using
  * Eugene W. Myers' O(ND) difference algorithm. Output is compatible with the
  * {@code patch} utility and {@code git apply}.
  *
- * <p>
- * This tool has zero runtime dependencies beyond Spring AI core and the JDK. It
- * complements {@code FileSystemTools} by letting agents show what they changed.
- *
- * <p>
- * <strong>Thread Safety:</strong> This class and all its collaborators are stateless
- * and safe for concurrent use.
- *
  * @author Martin Vlčák
- *
  */
 public class DiffTool {
 
@@ -55,19 +45,9 @@ public class DiffTool {
 
 	private static final int MAX_CONTEXT = 10;
 
-	/**
-	 * An ordered list of {@link EditOp} operations that transforms one sequence into
-	 * another.
-	 *
-	 * @param <T> element type of the operations
-	 * @param ops the ordered edit operations; defensively copied on construction
-	 */
-	private static record EditScript<T>(List<EditOp<T>> ops) {
+	private record EditScript<T>(List<EditOp<T>> ops) {
 
 		public EditScript {
-			if (ops == null) {
-				throw new IllegalArgumentException("ops must not be null");
-			}
 			ops = List.copyOf(ops);
 		}
 
@@ -81,73 +61,29 @@ public class DiffTool {
 
 	}
 
-	/**
-	 * A single operation in an edit script produced by the Myers diff algorithm. An edit
-	 * script is a sequence of {@link Equal}, {@link Delete}, and {@link Insert} ops that,
-	 * applied in order, transform the {@code before} sequence into the {@code after}
-	 * sequence.
-	 *
-	 * @param <T> element type carried by the operation (typically {@link String} for
-	 * line-level diffing)
-	 */
 	private sealed interface EditOp<T> permits EditOp.Equal, EditOp.Delete, EditOp.Insert {
 
-		/**
-		 * Returns the element this operation carries.
-		 */
 		T value();
 
-		/**
-		 * Element that appears unchanged in both {@code before} and {@code after}.
-		 */
 		record Equal<T>(T value) implements EditOp<T> {
 		}
 
-		/**
-		 * Element that appears in {@code before} but not in {@code after}.
-		 */
 		record Delete<T>(T value) implements EditOp<T> {
 		}
 
-		/**
-		 * Element that appears in {@code after} but not in {@code before}.
-		 */
 		record Insert<T>(T value) implements EditOp<T> {
 		}
 
 	}
 
-	/**
-	 * A contiguous region of an edit script containing one or more changes surrounded by
-	 * matching context lines, ready to be rendered as a unified-diff hunk.
-	 *
-	 * <p>
-	 * {@code beforeStart} and {@code afterStart} are 1-based line numbers referring to the
-	 * first line of the hunk in the corresponding side.
-	 *
-	 * @param beforeStart 1-based line number of the hunk's first line on the before side
-	 * @param beforeCount number of lines the hunk covers on the before side
-	 * @param afterStart 1-based line number of the hunk's first line on the after side
-	 * @param afterCount number of lines the hunk covers on the after side
-	 * @param ops the edit operations making up the hunk, in order
-	 */
-	private static record Hunk(int beforeStart, int beforeCount, int afterStart, int afterCount, List<EditOp<String>> ops) {
+	private record Hunk(int beforeStart, int beforeCount, int afterStart, int afterCount, List<EditOp<String>> ops) {
 
 		public Hunk {
-			if (ops == null) {
-				throw new IllegalArgumentException("ops must not be null");
-			}
 			ops = List.copyOf(ops);
 		}
 
 	}
 
-	/**
-	 * Groups an {@link EditScript} into {@link Hunk hunks} with {@code contextLines}
-	 * unchanged lines on each side of a change region. Two change regions separated by
-	 * {@code 2 * contextLines + 1} or more unchanged lines produce two hunks; a shorter
-	 * gap is merged into a single hunk.
-	 */
 	private List<Hunk> buildHunk(EditScript<String> script, int contextLines) {
 		List<EditOp<String>> ops = script.ops();
 		int n = ops.size();
@@ -229,9 +165,6 @@ public class DiffTool {
 
 	private String formatUnifiedDiff(List<Hunk> hunks, String beforeLabel, String afterLabel, boolean beforeEndsWithNewline,
 									boolean afterEndsWithNewline, String terminator) {
-		if (hunks == null) {
-			throw new IllegalArgumentException("hunks must not be null");
-		}
 		if (hunks.isEmpty()) {
 			return "";
 		}
@@ -311,22 +244,6 @@ public class DiffTool {
 		return -1;
 	}
 
-	/**
-	 * Tokenizes both sides, computes the Myers edit script, groups it into hunks,
-	 * and renders the unified-diff body. Returns an empty string when the two
-	 * sides are equivalent under {@code ws}.
-	 *
-	 * <p>Output uses the terminator dominant in {@code before}, or in {@code after}
-	 * when {@code before} has no lines.
-	 *
-	 * @param before raw text of the original side
-	 * @param after raw text of the modified side
-	 * @param beforeLabel label emitted on the {@code ---} header line
-	 * @param afterLabel label emitted on the {@code +++} header line
-	 * @param contextLines number of unchanged lines to include around each change region
-	 * @param ws whitespace-sensitivity mode for line comparison
-	 * @return unified-diff text, or empty string if the inputs are equivalent under {@code ws}
-	 */
 	private String renderDiff(String before, String after, String beforeLabel, String afterLabel, int contextLines,
 	                          WhitespaceMode ws) {
 		Tokenized bt = tokenize(before);
@@ -339,12 +256,6 @@ public class DiffTool {
 				bt.endsWithNewline(), at.endsWithNewline(), term);
 	}
 
-	/**
-	 * When the two sides differ only by their trailing newline, the pure content-based
-	 * edit script is empty even though the files differ. Rewrite the final {@code Equal}
-	 * op as a {@code Delete} + {@code Insert} so the formatter can render the mandatory
-	 * {@code \ No newline at end of file} marker.
-	 */
 	private EditScript<String> forceTrailingChangeIfNewlineMismatch(EditScript<String> script,
 	                                                                Tokenized bt, Tokenized at) {
 		if (bt.endsWithNewline() == at.endsWithNewline()) {
@@ -368,25 +279,7 @@ public class DiffTool {
 		return new EditScript<>(rewritten);
 	}
 
-
-
-	/**
-	 * Computes the edit script using a custom element equator.
-	 * @param before the original sequence
-	 * @param after the modified sequence
-	 * @param equator equality predicate
-	 * @return a minimal edit script
-	 */
 	private EditScript<String> diff(List<String> before, List<String> after, BiPredicate<String, String> equator) {
-		if (before == null) {
-			throw new IllegalArgumentException("before must not be null");
-		}
-		if (after == null) {
-			throw new IllegalArgumentException("after must not be null");
-		}
-		if (equator == null) {
-			throw new IllegalArgumentException("equator must not be null");
-		}
 
 		int n = before.size();
 		int m = after.size();
@@ -421,7 +314,7 @@ public class DiffTool {
 				}
 			}
 		}
-		throw new IllegalStateException("unreachable");
+		return new EditScript<>(List.of());  // unreachable: Myers always terminates
 	}
 
 	private EditScript<String> backtrack(List<String> before, List<String> after, List<int[]> trace, int n, int m, int max) {
@@ -471,31 +364,14 @@ public class DiffTool {
 		return new EditScript<>(ops);
 	}
 
-	/**
-	 * The tokenized result.
-	 *
-	 * @param lines the lines, without any terminator
-	 * @param endsWithNewline whether the original input ended with a line terminator
-	 * @param dominantTerminator the terminator observed most often in the input
-	 *        ({@code "\n"} or {@code "\r\n"}); {@code "\n"} wins on ties, and
-	 *        {@code "\n"} is also the default when the input contained no terminators
-	 */
-	record Tokenized(List<String> lines, boolean endsWithNewline, String dominantTerminator) {
+	private record Tokenized(List<String> lines, boolean endsWithNewline, String dominantTerminator) {
 
 		public Tokenized {
-			Objects.requireNonNull(lines, "lines must not be null");
-			Objects.requireNonNull(dominantTerminator, "dominantTerminator must not be null");
 			lines = List.copyOf(lines);
 		}
 	}
 
-	/**
-	 * Tokenizes the input into lines.
-	 * @param input the raw text, must not be null
-	 * @return the tokenized result
-	 */
-	Tokenized tokenize(String input) {
-		Objects.requireNonNull(input, "input must not be null");
+	private Tokenized tokenize(String input) {
 		if (input.isEmpty()) {
 			return new Tokenized(List.of(), false, "\n");
 		}
@@ -533,18 +409,12 @@ public class DiffTool {
 
 	public enum WhitespaceMode {
 
-		/** Compare lines byte-for-byte. */
 		STRICT,
 
-		/** Ignore trailing whitespace (see {@link String#stripTrailing()}). */
 		IGNORE_TRAILING,
 
-		/** Collapse all whitespace runs to a single space, then trim. */
 		IGNORE_ALL;
 
-		/**
-		 * Normalizes a line for comparison according to this mode.
-		 */
 		private static String normalize(String line, WhitespaceMode mode) {
 			if (line == null) {
 				return null;
@@ -556,14 +426,11 @@ public class DiffTool {
 			};
 		}
 
-		/**
-		 * Returns an equator that compares two lines under this whitespace mode.
-		 */
 		private BiPredicate<String, String> equator() {
 			return (a, b) -> {
 				String na = normalize(a, this);
 				String nb = normalize(b, this);
-				return na == null ? nb == null : na.equals(nb);
+				return Objects.equals(na, nb);
 			};
 		}
 
@@ -582,22 +449,29 @@ public class DiffTool {
 			@JsonPropertyDescription("Number of contiguous change regions (hunks)") int hunks) {
 	}
 
-	@Tool(name = "DiffTool",
-			description = """
-					Produces a unified diff between two text blocks. Output follows the
-					standard unified-diff format (--- / +++ / @@ headers) and is compatible
-					with the `patch` utility and `git apply`.
+	// @formatter:off
+	@Tool(name = "DiffTool", description = """
+		Produces a unified diff between two text blocks using Eugene W. Myers' O(ND) difference algorithm. The output follows the standard unified-diff format (--- / +++ / @@ headers) and is compatible with the `patch` utility and `git apply`.
 
-					Use this to show what changed after editing a file, summarize edits in
-					PR-style output, or audit agent modifications.
-					""")
+		Use this to show what changed after editing a file, summarize edits in PR-style output, or audit agent modifications.
+
+		Usage:
+		- The `before` and `after` parameters are required and should be the raw text of the original and modified content.
+		- Optionally provide `beforeLabel` and `afterLabel` to control the header lines (e.g. `a/config.yml` and `b/config.yml` for git-style labels). Defaults: "before" / "after".
+		- `contextLines` controls the number of unchanged lines shown around each change region. Default: 3, maximum: 10. Values above the maximum are clamped; negatives are clamped to 0.
+		- `whitespaceMode` controls line-equality: STRICT (default, byte-for-byte), IGNORE_TRAILING (ignores trailing whitespace), or IGNORE_ALL (collapses all whitespace runs to a single space, then trims).
+		- Returns an empty string when the two sides are equivalent under the selected whitespace mode.
+		- The output uses the line terminator dominant in `before` (or in `after` when `before` has no lines).
+		- When either side is missing a trailing newline, a `\\ No newline at end of file` marker is emitted so patch tools can round-trip correctly.
+		- For a lightweight count-only variant that skips rendering, use the `DiffSummarize` tool instead.
+		""")
 	public String diff(
 			@ToolParam(description = "Original text (the 'before' side)") String before,
 			@ToolParam(description = "Modified text (the 'after' side)") String after,
 			@ToolParam(description = "Label for the before side. Example: 'a/config.yml'", required = false) String beforeLabel,
 			@ToolParam(description = "Label for the after side. Example: 'b/config.yml'", required = false) String afterLabel,
 			@ToolParam(description = "Unchanged context lines around each change. Default 3, max 10.", required = false) Integer contextLines,
-			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) {
+			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) { // @formatter:on
 
 		int ctx = (contextLines == null) ? DEFAULT_CONTEXT
 				: Math.min(MAX_CONTEXT, Math.max(0, contextLines));
@@ -609,21 +483,33 @@ public class DiffTool {
 		return renderDiff(before, after, bLabel, aLabel, ctx, ws);
 	}
 
-	@Tool(name = "DiffFiles",
-			description = """
-					Produces a unified diff between the current contents of two files on
-					disk. Paths are resolved against the JVM working directory when not
-					absolute. Returns the same unified-diff format as the `diff` tool.
-					""")
+	// @formatter:off
+	@Tool(name = "DiffFiles", description = """
+		Produces a unified diff between the current contents of two files on disk. Returns the same unified-diff format as the `DiffTool` tool and is compatible with the `patch` utility and `git apply`.
+
+		Use this when the before/after content already lives in files and you want to avoid reading them into memory yourself.
+
+		Usage:
+		- The `beforePath` and `afterPath` parameters are required. Relative paths are resolved against the JVM working directory.
+		- Header lines are automatically emitted as `a/<beforePath>` and `b/<afterPath>` so `git apply -p1` strips the prefix correctly.
+		- `contextLines` controls the number of unchanged lines shown around each change region. Default: 3, maximum: 10.
+		- `whitespaceMode` controls line-equality: STRICT (default), IGNORE_TRAILING, or IGNORE_ALL.
+		- Returns an empty string when the two files are equivalent under the selected whitespace mode.
+		- Returns `Error: ...` if either path is blank, or `Error reading files: ...` if either file cannot be read.
+		- Files are read with the platform default charset.
+		""")
 	public String diffFiles(
 			@ToolParam(description = "Path to the original file") String beforePath,
 			@ToolParam(description = "Path to the modified file") String afterPath,
 			@ToolParam(description = "Unchanged context lines around each change. Default 3, max 10.", required = false) Integer contextLines,
-			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) {
-
-		Assert.hasText(beforePath, "beforePath must not be blank");
-		Assert.hasText(afterPath, "afterPath must not be blank");
+			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) { // @formatter:on
 		try {
+			if (beforePath == null || beforePath.isBlank()) {
+				return "Error: beforePath must not be blank";
+			}
+			if (afterPath == null || afterPath.isBlank()) {
+				return "Error: afterPath must not be blank";
+			}
 			Path bp = Paths.get(beforePath);
 			Path ap = Paths.get(afterPath);
 			String before = Files.readString(bp);
@@ -641,19 +527,24 @@ public class DiffTool {
 		}
 	}
 
-	@Tool(name = "DiffSummarize",
-			description = """
-					Returns aggregate counts (insertions, deletions, hunks) for the diff
-					between two text blocks, without emitting the full unified-diff body.
-					""")
+	// @formatter:off
+	@Tool(name = "DiffSummarize", description = """
+		Returns aggregate counts (insertions, deletions, hunks) for the diff between two text blocks, without emitting the full unified-diff body.
+
+		Use this to cheaply gate further work — for example, checking whether any changes exist, reporting the size of an edit, or deciding whether to render a full diff afterwards.
+
+		Usage:
+		- The `before` and `after` parameters are required and should be the raw text of the original and modified content.
+		- `contextLines` only affects how changes are grouped into hunks (it does not affect insertion/deletion counts). Default: 3, maximum: 10.
+		- `whitespaceMode` controls line-equality: STRICT (default), IGNORE_TRAILING, or IGNORE_ALL.
+		- Returns a `DiffSummary` with `insertions`, `deletions`, and `hunks` fields. All three are zero when the two sides are equivalent under the selected whitespace mode.
+		- Counts match exactly what the `DiffTool` tool would emit for the same inputs.
+		""")
 	public DiffSummary summarize(
 			@ToolParam(description = "Original text (the 'before' side)") String before,
 			@ToolParam(description = "Modified text (the 'after' side)") String after,
 			@ToolParam(description = "Unchanged context lines around each change. Default 3, max 10.", required = false) Integer contextLines,
-			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) {
-
-		Assert.notNull(before, "before must not be null");
-		Assert.notNull(after, "after must not be null");
+			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) { // @formatter:on
 
 		int ctx = (contextLines == null) ? DEFAULT_CONTEXT
 				: Math.min(MAX_CONTEXT, Math.max(0, contextLines));
@@ -667,7 +558,7 @@ public class DiffTool {
 		return new DiffSummary(script.insertions(), script.deletions(), hunks.size());
 	}
 
-	public static DiffTool.Builder builder() {
+	public static Builder builder() {
 		return new Builder();
 	}
 

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/DiffTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/DiffTool.java
@@ -1,0 +1,680 @@
+/*
+* Copyright 2025 - 2025 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiPredicate;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.util.Assert;
+
+/**
+ * Spring AI tool that produces unified-diff output between two text blocks using
+ * Eugene W. Myers' O(ND) difference algorithm. Output is compatible with the
+ * {@code patch} utility and {@code git apply}.
+ *
+ * <p>
+ * This tool has zero runtime dependencies beyond Spring AI core and the JDK. It
+ * complements {@code FileSystemTools} by letting agents show what they changed.
+ *
+ * <p>
+ * <strong>Thread Safety:</strong> This class and all its collaborators are stateless
+ * and safe for concurrent use.
+ *
+ * @author Martin Vlčák
+ *
+ */
+public class DiffTool {
+
+	private static final String NO_NEWLINE_MARKER = "\\ No newline at end of file";
+
+	private static final int DEFAULT_CONTEXT = 3;
+
+	private static final int MAX_CONTEXT = 10;
+
+	/**
+	 * An ordered list of {@link EditOp} operations that transforms one sequence into
+	 * another.
+	 *
+	 * @param <T> element type of the operations
+	 * @param ops the ordered edit operations; defensively copied on construction
+	 */
+	private static record EditScript<T>(List<EditOp<T>> ops) {
+
+		public EditScript {
+			if (ops == null) {
+				throw new IllegalArgumentException("ops must not be null");
+			}
+			ops = List.copyOf(ops);
+		}
+
+		public long insertions() {
+			return this.ops.stream().filter(o -> o instanceof EditOp.Insert<T>).count();
+		}
+
+		public long deletions() {
+			return this.ops.stream().filter(o -> o instanceof EditOp.Delete<T>).count();
+		}
+
+	}
+
+	/**
+	 * A single operation in an edit script produced by the Myers diff algorithm. An edit
+	 * script is a sequence of {@link Equal}, {@link Delete}, and {@link Insert} ops that,
+	 * applied in order, transform the {@code before} sequence into the {@code after}
+	 * sequence.
+	 *
+	 * @param <T> element type carried by the operation (typically {@link String} for
+	 * line-level diffing)
+	 */
+	private sealed interface EditOp<T> permits EditOp.Equal, EditOp.Delete, EditOp.Insert {
+
+		/**
+		 * Returns the element this operation carries.
+		 */
+		T value();
+
+		/**
+		 * Element that appears unchanged in both {@code before} and {@code after}.
+		 */
+		record Equal<T>(T value) implements EditOp<T> {
+		}
+
+		/**
+		 * Element that appears in {@code before} but not in {@code after}.
+		 */
+		record Delete<T>(T value) implements EditOp<T> {
+		}
+
+		/**
+		 * Element that appears in {@code after} but not in {@code before}.
+		 */
+		record Insert<T>(T value) implements EditOp<T> {
+		}
+
+	}
+
+	/**
+	 * A contiguous region of an edit script containing one or more changes surrounded by
+	 * matching context lines, ready to be rendered as a unified-diff hunk.
+	 *
+	 * <p>
+	 * {@code beforeStart} and {@code afterStart} are 1-based line numbers referring to the
+	 * first line of the hunk in the corresponding side.
+	 *
+	 * @param beforeStart 1-based line number of the hunk's first line on the before side
+	 * @param beforeCount number of lines the hunk covers on the before side
+	 * @param afterStart 1-based line number of the hunk's first line on the after side
+	 * @param afterCount number of lines the hunk covers on the after side
+	 * @param ops the edit operations making up the hunk, in order
+	 */
+	private static record Hunk(int beforeStart, int beforeCount, int afterStart, int afterCount, List<EditOp<String>> ops) {
+
+		public Hunk {
+			if (ops == null) {
+				throw new IllegalArgumentException("ops must not be null");
+			}
+			ops = List.copyOf(ops);
+		}
+
+	}
+
+	/**
+	 * Groups an {@link EditScript} into {@link Hunk hunks} with {@code contextLines}
+	 * unchanged lines on each side of a change region. Two change regions separated by
+	 * {@code 2 * contextLines + 1} or more unchanged lines produce two hunks; a shorter
+	 * gap is merged into a single hunk.
+	 */
+	private List<Hunk> buildHunk(EditScript<String> script, int contextLines) {
+		List<EditOp<String>> ops = script.ops();
+		int n = ops.size();
+		if (n == 0) {
+			return List.of();
+		}
+
+		// Precompute 1-based line numbers for each op position (and one past the end).
+		int[] beforeLines = new int[n + 1];
+		int[] afterLines = new int[n + 1];
+		int bl = 1;
+		int al = 1;
+		for (int i = 0; i < n; i++) {
+			beforeLines[i] = bl;
+			afterLines[i] = al;
+			EditOp<String> op = ops.get(i);
+			if (op instanceof EditOp.Equal<String>) {
+				bl++;
+				al++;
+			}
+			else if (op instanceof EditOp.Delete<String>) {
+				bl++;
+			}
+			else if (op instanceof EditOp.Insert<String>) {
+				al++;
+			}
+		}
+		beforeLines[n] = bl;
+		afterLines[n] = al;
+
+		List<Hunk> hunks = new ArrayList<>();
+		int i = 0;
+
+		while (i < n) {
+			// Skip forward to the next non-Equal op.
+			while (i < n && ops.get(i) instanceof EditOp.Equal<String>) {
+				i++;
+			}
+			if (i >= n) {
+				break;
+			}
+
+			int hunkStart = Math.max(0, i - contextLines);
+			int lastChangeIdx = i;
+			int j = i + 1;
+
+			while (j < n) {
+				EditOp<String> op = ops.get(j);
+				if (!(op instanceof EditOp.Equal<String>)) {
+					lastChangeIdx = j;
+					j++;
+					continue;
+				}
+				int runStart = j;
+				while (j < n && ops.get(j) instanceof EditOp.Equal<String>) {
+					j++;
+				}
+				int runLen = j - runStart;
+				if (j >= n || runLen >= 2 * contextLines + 1) {
+					break;
+				}
+				// Short run — absorbed into the current hunk; keep extending.
+			}
+
+			int hunkEndExclusive = Math.min(n, lastChangeIdx + 1 + contextLines);
+
+			List<EditOp<String>> hunkOps = new ArrayList<>(ops.subList(hunkStart, hunkEndExclusive));
+			int bStart = beforeLines[hunkStart];
+			int aStart = afterLines[hunkStart];
+			int bCount = beforeLines[hunkEndExclusive] - bStart;
+			int aCount = afterLines[hunkEndExclusive] - aStart;
+
+			hunks.add(new Hunk(bStart, bCount, aStart, aCount, hunkOps));
+			i = hunkEndExclusive;
+		}
+
+		return hunks;
+	}
+
+	private String formatUnifiedDiff(List<Hunk> hunks, String beforeLabel, String afterLabel, boolean beforeEndsWithNewline,
+									boolean afterEndsWithNewline, String terminator) {
+		if (hunks == null) {
+			throw new IllegalArgumentException("hunks must not be null");
+		}
+		if (hunks.isEmpty()) {
+			return "";
+		}
+
+		StringBuilder sb = new StringBuilder();
+		sb.append("--- ").append(beforeLabel).append(terminator);
+		sb.append("+++ ").append(afterLabel).append(terminator);
+
+		int lastHunkIdx = hunks.size() - 1;
+		for (int hi = 0; hi < hunks.size(); hi++) {
+			Hunk h = hunks.get(hi);
+			appendHunkHeader(sb, h, terminator);
+
+			int opsSize = h.ops().size();
+			int lastBeforeLineIdx = lastOpIndexOnSide(h.ops(), true);
+			int lastAfterLineIdx = lastOpIndexOnSide(h.ops(), false);
+			boolean isLastHunk = (hi == lastHunkIdx);
+
+			for (int i = 0; i < opsSize; i++) {
+				EditOp<String> op = h.ops().get(i);
+				if (op instanceof EditOp.Equal<String> eq) {
+					sb.append(' ').append(eq.value()).append(terminator);
+				}
+				else if (op instanceof EditOp.Delete<String> del) {
+					sb.append('-').append(del.value()).append(terminator);
+				}
+				else if (op instanceof EditOp.Insert<String> ins) {
+					sb.append('+').append(ins.value()).append(terminator);
+				}
+
+				if (isLastHunk) {
+					boolean needBefore = (i == lastBeforeLineIdx) && !beforeEndsWithNewline;
+					boolean needAfter = (i == lastAfterLineIdx) && !afterEndsWithNewline;
+					if (needBefore || needAfter) {
+						sb.append(NO_NEWLINE_MARKER).append(terminator);
+					}
+				}
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private void appendHunkHeader(StringBuilder sb, Hunk h, String terminator) {
+		sb.append("@@ -");
+		appendRange(sb, h.beforeStart(), h.beforeCount());
+		sb.append(" +");
+		appendRange(sb, h.afterStart(), h.afterCount());
+		sb.append(" @@").append(terminator);
+	}
+
+	private void appendRange(StringBuilder sb, int start, int count) {
+		if (count == 0) {
+			sb.append(start - 1).append(",0");
+		}
+		else if (count == 1) {
+			sb.append(start);
+		}
+		else {
+			sb.append(start).append(',').append(count);
+		}
+	}
+
+	private int lastOpIndexOnSide(List<EditOp<String>> ops, boolean beforeSide) {
+		for (int i = ops.size() - 1; i >= 0; i--) {
+			EditOp<String> op = ops.get(i);
+			if (op instanceof EditOp.Equal<String>) {
+				return i;
+			}
+			if (beforeSide && op instanceof EditOp.Delete<String>) {
+				return i;
+			}
+			if (!beforeSide && op instanceof EditOp.Insert<String>) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * Tokenizes both sides, computes the Myers edit script, groups it into hunks,
+	 * and renders the unified-diff body. Returns an empty string when the two
+	 * sides are equivalent under {@code ws}.
+	 *
+	 * <p>Output uses the terminator dominant in {@code before}, or in {@code after}
+	 * when {@code before} has no lines.
+	 *
+	 * @param before raw text of the original side
+	 * @param after raw text of the modified side
+	 * @param beforeLabel label emitted on the {@code ---} header line
+	 * @param afterLabel label emitted on the {@code +++} header line
+	 * @param contextLines number of unchanged lines to include around each change region
+	 * @param ws whitespace-sensitivity mode for line comparison
+	 * @return unified-diff text, or empty string if the inputs are equivalent under {@code ws}
+	 */
+	private String renderDiff(String before, String after, String beforeLabel, String afterLabel, int contextLines,
+	                          WhitespaceMode ws) {
+		Tokenized bt = tokenize(before);
+		Tokenized at = tokenize(after);
+		EditScript<String> script = diff(bt.lines(), at.lines(), ws.equator());
+		script = forceTrailingChangeIfNewlineMismatch(script, bt, at);
+		List<Hunk> hunks = buildHunk(script, contextLines);
+		String term = bt.lines().isEmpty() ? at.dominantTerminator() : bt.dominantTerminator();
+		return formatUnifiedDiff(hunks, beforeLabel, afterLabel,
+				bt.endsWithNewline(), at.endsWithNewline(), term);
+	}
+
+	/**
+	 * When the two sides differ only by their trailing newline, the pure content-based
+	 * edit script is empty even though the files differ. Rewrite the final {@code Equal}
+	 * op as a {@code Delete} + {@code Insert} so the formatter can render the mandatory
+	 * {@code \ No newline at end of file} marker.
+	 */
+	private EditScript<String> forceTrailingChangeIfNewlineMismatch(EditScript<String> script,
+	                                                                Tokenized bt, Tokenized at) {
+		if (bt.endsWithNewline() == at.endsWithNewline()) {
+			return script;
+		}
+		if (bt.lines().isEmpty() || at.lines().isEmpty()) {
+			return script;
+		}
+		List<EditOp<String>> ops = script.ops();
+		if (ops.isEmpty()) {
+			return script;
+		}
+		EditOp<String> last = ops.get(ops.size() - 1);
+		if (!(last instanceof EditOp.Equal<String> eq)) {
+			return script;
+		}
+		List<EditOp<String>> rewritten = new ArrayList<>(ops);
+		rewritten.remove(rewritten.size() - 1);
+		rewritten.add(new EditOp.Delete<>(eq.value()));
+		rewritten.add(new EditOp.Insert<>(eq.value()));
+		return new EditScript<>(rewritten);
+	}
+
+
+
+	/**
+	 * Computes the edit script using a custom element equator.
+	 * @param before the original sequence
+	 * @param after the modified sequence
+	 * @param equator equality predicate
+	 * @return a minimal edit script
+	 */
+	private EditScript<String> diff(List<String> before, List<String> after, BiPredicate<String, String> equator) {
+		if (before == null) {
+			throw new IllegalArgumentException("before must not be null");
+		}
+		if (after == null) {
+			throw new IllegalArgumentException("after must not be null");
+		}
+		if (equator == null) {
+			throw new IllegalArgumentException("equator must not be null");
+		}
+
+		int n = before.size();
+		int m = after.size();
+
+		// Edge case: both empty — nothing to do.
+		if (n == 0 && m == 0) {
+			return new EditScript<>(List.of());
+		}
+
+		int max = n + m;
+		int[] v = new int[2 * max + 1];
+		List<int[]> trace = new ArrayList<>();
+
+		for (int d = 0; d <= max; d++) {
+			trace.add(v.clone());
+			for (int k = -d; k <= d; k += 2) {
+				int x;
+				if (k == -d || (k != d && v[k - 1 + max] < v[k + 1 + max])) {
+					x = v[k + 1 + max]; // insertion (move down)
+				}
+				else {
+					x = v[k - 1 + max] + 1; // deletion (move right)
+				}
+				int y = x - k;
+				while (x < n && y < m && equator.test(before.get(x), after.get(y))) {
+					x++;
+					y++;
+				}
+				v[k + max] = x;
+				if (x >= n && y >= m) {
+					return backtrack(before, after, trace, n, m, max);
+				}
+			}
+		}
+		throw new IllegalStateException("unreachable");
+	}
+
+	private EditScript<String> backtrack(List<String> before, List<String> after, List<int[]> trace, int n, int m, int max) {
+		List<EditOp<String>> ops = new ArrayList<>();
+		int x = n;
+		int y = m;
+
+		for (int d = trace.size() - 1; d >= 0; d--) {
+			int[] v = trace.get(d);
+			int k = x - y;
+
+			int prevK;
+			if (k == -d || (k != d && v[k - 1 + max] < v[k + 1 + max])) {
+				prevK = k + 1; // came from insertion
+			}
+			else {
+				prevK = k - 1; // came from deletion
+			}
+
+			int prevX = v[prevK + max];
+			int prevY = prevX - prevK;
+
+			// Emit diagonal matches (in reverse order)
+			while (x > prevX && y > prevY) {
+				ops.add(new EditOp.Equal<>(before.get(x - 1)));
+				x--;
+				y--;
+			}
+
+			// Emit the edit at this depth (d == 0 is the origin, no edit)
+			if (d > 0) {
+				if (x == prevX) {
+					// Insertion: the inserted element is after[prevY]
+					ops.add(new EditOp.Insert<>(after.get(prevY)));
+				}
+				else {
+					// Deletion: the deleted element is before[prevX]
+					ops.add(new EditOp.Delete<>(before.get(prevX)));
+				}
+			}
+
+			x = prevX;
+			y = prevY;
+		}
+
+		Collections.reverse(ops);
+		return new EditScript<>(ops);
+	}
+
+	/**
+	 * The tokenized result.
+	 *
+	 * @param lines the lines, without any terminator
+	 * @param endsWithNewline whether the original input ended with a line terminator
+	 * @param dominantTerminator the terminator observed most often in the input
+	 *        ({@code "\n"} or {@code "\r\n"}); {@code "\n"} wins on ties, and
+	 *        {@code "\n"} is also the default when the input contained no terminators
+	 */
+	record Tokenized(List<String> lines, boolean endsWithNewline, String dominantTerminator) {
+
+		public Tokenized {
+			Objects.requireNonNull(lines, "lines must not be null");
+			Objects.requireNonNull(dominantTerminator, "dominantTerminator must not be null");
+			lines = List.copyOf(lines);
+		}
+	}
+
+	/**
+	 * Tokenizes the input into lines.
+	 * @param input the raw text, must not be null
+	 * @return the tokenized result
+	 */
+	Tokenized tokenize(String input) {
+		Objects.requireNonNull(input, "input must not be null");
+		if (input.isEmpty()) {
+			return new Tokenized(List.of(), false, "\n");
+		}
+
+		List<String> lines = new ArrayList<>();
+		int start = 0;
+		boolean endsWithNewline = false;
+		int unixCount = 0;
+		int windowsCount = 0;
+
+		for (int i = 0; i < input.length(); i++) {
+			if (input.charAt(i) == '\n') {
+				int end = i;
+				if (i > 0 && input.charAt(i - 1) == '\r') {
+					end = i - 1;
+					windowsCount++;
+				}
+				else {
+					unixCount++;
+				}
+				lines.add(input.substring(start, end));
+				start = i + 1;
+				endsWithNewline = (start == input.length());
+			}
+		}
+
+		if (start < input.length()) {
+			lines.add(input.substring(start));
+			endsWithNewline = false;
+		}
+
+		String dominant = windowsCount > unixCount ? "\r\n" : "\n";
+		return new Tokenized(lines, endsWithNewline, dominant);
+	}
+
+	public enum WhitespaceMode {
+
+		/** Compare lines byte-for-byte. */
+		STRICT,
+
+		/** Ignore trailing whitespace (see {@link String#stripTrailing()}). */
+		IGNORE_TRAILING,
+
+		/** Collapse all whitespace runs to a single space, then trim. */
+		IGNORE_ALL;
+
+		/**
+		 * Normalizes a line for comparison according to this mode.
+		 */
+		private static String normalize(String line, WhitespaceMode mode) {
+			if (line == null) {
+				return null;
+			}
+			return switch (mode) {
+				case STRICT -> line;
+				case IGNORE_TRAILING -> line.stripTrailing();
+				case IGNORE_ALL -> line.replaceAll("\\s+", " ").strip();
+			};
+		}
+
+		/**
+		 * Returns an equator that compares two lines under this whitespace mode.
+		 */
+		private BiPredicate<String, String> equator() {
+			return (a, b) -> {
+				String na = normalize(a, this);
+				String nb = normalize(b, this);
+				return na == null ? nb == null : na.equals(nb);
+			};
+		}
+
+	}
+
+	/**
+	 * Aggregate counts for a diff between two text blocks.
+	 *
+	 * @param insertions number of inserted lines
+	 * @param deletions number of deleted lines
+	 * @param hunks number of contiguous change regions
+	 */
+	public record DiffSummary(
+			@JsonPropertyDescription("Number of inserted lines") long insertions,
+			@JsonPropertyDescription("Number of deleted lines") long deletions,
+			@JsonPropertyDescription("Number of contiguous change regions (hunks)") int hunks) {
+	}
+
+	@Tool(name = "DiffTool",
+			description = """
+					Produces a unified diff between two text blocks. Output follows the
+					standard unified-diff format (--- / +++ / @@ headers) and is compatible
+					with the `patch` utility and `git apply`.
+
+					Use this to show what changed after editing a file, summarize edits in
+					PR-style output, or audit agent modifications.
+					""")
+	public String diff(
+			@ToolParam(description = "Original text (the 'before' side)") String before,
+			@ToolParam(description = "Modified text (the 'after' side)") String after,
+			@ToolParam(description = "Label for the before side. Example: 'a/config.yml'", required = false) String beforeLabel,
+			@ToolParam(description = "Label for the after side. Example: 'b/config.yml'", required = false) String afterLabel,
+			@ToolParam(description = "Unchanged context lines around each change. Default 3, max 10.", required = false) Integer contextLines,
+			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) {
+
+		int ctx = (contextLines == null) ? DEFAULT_CONTEXT
+				: Math.min(MAX_CONTEXT, Math.max(0, contextLines));
+		WhitespaceMode ws = (whitespaceMode == null) ? WhitespaceMode.STRICT
+				: whitespaceMode;
+		String bLabel = (beforeLabel == null) ? "before" : beforeLabel;
+		String aLabel = (afterLabel == null) ? "after" : afterLabel;
+
+		return renderDiff(before, after, bLabel, aLabel, ctx, ws);
+	}
+
+	@Tool(name = "DiffFiles",
+			description = """
+					Produces a unified diff between the current contents of two files on
+					disk. Paths are resolved against the JVM working directory when not
+					absolute. Returns the same unified-diff format as the `diff` tool.
+					""")
+	public String diffFiles(
+			@ToolParam(description = "Path to the original file") String beforePath,
+			@ToolParam(description = "Path to the modified file") String afterPath,
+			@ToolParam(description = "Unchanged context lines around each change. Default 3, max 10.", required = false) Integer contextLines,
+			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) {
+
+		Assert.hasText(beforePath, "beforePath must not be blank");
+		Assert.hasText(afterPath, "afterPath must not be blank");
+		try {
+			Path bp = Paths.get(beforePath);
+			Path ap = Paths.get(afterPath);
+			String before = Files.readString(bp);
+			String after = Files.readString(ap);
+
+			int ctx = (contextLines == null) ? DEFAULT_CONTEXT
+					: Math.min(MAX_CONTEXT, Math.max(0, contextLines));
+			WhitespaceMode ws = (whitespaceMode == null) ? WhitespaceMode.STRICT
+					: whitespaceMode;
+
+			return renderDiff(before, after, "a/" + beforePath, "b/" + afterPath, ctx, ws);
+		}
+		catch (IOException e) {
+			return "Error reading files: " + e.getMessage();
+		}
+	}
+
+	@Tool(name = "DiffSummarize",
+			description = """
+					Returns aggregate counts (insertions, deletions, hunks) for the diff
+					between two text blocks, without emitting the full unified-diff body.
+					""")
+	public DiffSummary summarize(
+			@ToolParam(description = "Original text (the 'before' side)") String before,
+			@ToolParam(description = "Modified text (the 'after' side)") String after,
+			@ToolParam(description = "Unchanged context lines around each change. Default 3, max 10.", required = false) Integer contextLines,
+			@ToolParam(description = "Whitespace handling. Default STRICT.", required = false) WhitespaceMode whitespaceMode) {
+
+		Assert.notNull(before, "before must not be null");
+		Assert.notNull(after, "after must not be null");
+
+		int ctx = (contextLines == null) ? DEFAULT_CONTEXT
+				: Math.min(MAX_CONTEXT, Math.max(0, contextLines));
+		WhitespaceMode ws = (whitespaceMode == null) ? WhitespaceMode.STRICT
+				: whitespaceMode;
+
+		Tokenized bt = tokenize(before);
+		Tokenized at = tokenize(after);
+		EditScript<String> script = diff(bt.lines(), at.lines(), ws.equator());
+		List<Hunk> hunks = buildHunk(script, ctx);
+		return new DiffSummary(script.insertions(), script.deletions(), hunks.size());
+	}
+
+	public static DiffTool.Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+		public DiffTool build() {
+			return new DiffTool();
+		}
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/DiffToolTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/DiffToolTest.java
@@ -1,18 +1,18 @@
 /*
- * Copyright 2025 - 2025 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright 2025 - 2025 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package org.springaicommunity.agent.tools;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -338,8 +338,20 @@ class DiffToolTest {
 		if (diff.isEmpty()) {
 			return before;
 		}
-		DiffTool.Tokenized bt = tool.tokenize(before);
-		List<String> src = new ArrayList<>(bt.lines());
+		List<String> src = new ArrayList<>();
+		if (!before.isEmpty()) {
+			int s = 0;
+			for (int i = 0; i < before.length(); i++) {
+				if (before.charAt(i) == '\n') {
+					int end = (i > 0 && before.charAt(i - 1) == '\r') ? i - 1 : i;
+					src.add(before.substring(s, end));
+					s = i + 1;
+				}
+			}
+			if (s < before.length()) {
+				src.add(before.substring(s));
+			}
+		}
 		List<String> out = new ArrayList<>();
 
 		String term = diff.contains("\r\n") ? "\r\n" : "\n";
@@ -352,7 +364,6 @@ class DiffToolTest {
 
 		int srcIdx = 0;
 		boolean afterEndsWithNewline = true;
-		boolean beforeEndsWithNewline = bt.endsWithNewline();
 
 		while (di < diffLines.length) {
 			String line = diffLines[di];
@@ -381,20 +392,17 @@ class DiffToolTest {
 				out.add(content);
 			}
 			else if (prefix == '\\' && diffLines[di].contains("No newline")) {
-				// \ No newline at end of file applies to the previously emitted line
-					// Determine which side: look at previous non-backslash line prefix
-					int prev = di - 1;
-					while (prev >= 0 && diffLines[prev].isEmpty()) {
-						prev--;
-					}
-					if (prev >= 0) {
-						char prevPrefix = diffLines[prev].charAt(0);
-					if (prevPrefix == '+' || prevPrefix == ' ') {
+				int prev = di - 1;
+				while (prev >= 0 && diffLines[prev].isEmpty()) {
+					prev--;
+				}
+				if (prev >= 0) {
+					char prevPrefix = diffLines[prev].charAt(0);
+					if (prevPrefix == '+') {
 						afterEndsWithNewline = false;
 					}
-					if (prevPrefix == ' ' && !beforeEndsWithNewline) {
-						// Marker covers before too (already set via input).
-
+					else if (prevPrefix == ' ') {
+						afterEndsWithNewline = false;
 					}
 				}
 			}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/DiffToolTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/DiffToolTest.java
@@ -1,0 +1,427 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link DiffTool}.
+ *
+ * @author Martin Vlčák
+ */
+@DisplayName("DiffTool Tests")
+class DiffToolTest {
+
+	private DiffTool tool;
+
+	@TempDir
+	Path tempDir;
+
+	@BeforeEach
+	void setUp() {
+		this.tool = DiffTool.builder().build();
+	}
+
+	@Nested
+	@DisplayName("String diff tests")
+	class TextDiffTests{
+
+		@Test
+		@DisplayName("Should return empty diff for identical inputs")
+		void shouldReturnEmptyDiffForIdenticalInputs() {
+			String text = "line1\nline2\nline3\n";
+			assertThat(tool.diff(text, text, "a", "b", null, null)).isEmpty();
+		}
+
+		@Test
+		@DisplayName("Should produce unified diff for simple change")
+		void shouldProduceUnifiedDiffForSimpleChange() {
+			String before = "a\nb\nc\n";
+			String after = "a\nB\nc\n";
+			String diff = tool.diff(before, after, "a/f", "b/f", 3, null);
+
+			assertThat(diff).isEqualTo("""
+				--- a/f
+				+++ b/f
+				@@ -1,3 +1,3 @@
+				 a
+				-b
+				+B
+				 c
+				""");
+		}
+
+		@Test
+		@DisplayName("Should emit zero before-start for pure insert at start")
+		void shouldEmitZeroBeforeStartForPureInsertAtStart() {
+			String diff = tool.diff("", "x\n", "a", "b", null, null);
+			assertThat(diff).isEqualTo("""
+				--- a
+				+++ b
+				@@ -0,0 +1 @@
+				+x
+				""");
+		}
+
+		@Test
+		@DisplayName("Should report missing trailing newline")
+		void shouldReportMissingTrailingNewline() {
+			String diff = tool.diff("a\n", "a", "a", "b", null, null);
+			assertThat(diff).contains("\\ No newline at end of file");
+		}
+
+		@Test
+		@DisplayName("Should match Myers paper edit distance")
+		void shouldMatchMyersPaperEditDistance() {
+			// Myers 1986, section 4a — canonical example: ABCABBA vs CBABAC, D = 5.
+			// Each letter becomes its own line so the line-level diff mirrors the paper.
+			String before = "A\nB\nC\nA\nB\nB\nA\n";
+			String after = "C\nB\nA\nB\nA\nC\n";
+			DiffTool.DiffSummary s = tool.summarize(before, after, null, null);
+			assertThat(s.insertions() + s.deletions()).isEqualTo(5L);
+		}
+
+		@Test
+		@DisplayName("Should treat trailing space as equal in IGNORE_TRAILING mode")
+		void shouldTreatTrailingSpaceAsEqualInIgnoreTrailingMode() {
+			String before = "hello  \nworld\n";
+			String after = "hello\nworld\n";
+			String diff = tool.diff(before, after, "a", "b", 3, DiffTool.WhitespaceMode.IGNORE_TRAILING);
+			assertThat(diff).isEmpty();
+		}
+
+		@Test
+		@DisplayName("Should treat whitespace-only change as no-op when summarizing in IGNORE_ALL mode")
+		void shouldTreatWhitespaceOnlyChangeAsNoOpWhenSummarizingInIgnoreAllMode() {
+			DiffTool.DiffSummary s = tool.summarize(
+					"hello   world\n", "hello world\n", null,
+					DiffTool.WhitespaceMode.IGNORE_ALL);
+			assertThat(s.insertions()).isZero();
+			assertThat(s.deletions()).isZero();
+			assertThat(s.hunks()).isZero();
+		}
+
+		@Test
+		@DisplayName("Should collapse internal whitespace in IGNORE_ALL mode")
+		void shouldCollapseInternalWhitespaceInIgnoreAllMode() {
+			String before = "hello   world\n";
+			String after  = "hello world\n";
+			assertThat(tool.diff(before, after, "a", "b", 3,
+					DiffTool.WhitespaceMode.IGNORE_ALL)).isEmpty();
+		}
+
+		@Test
+		@DisplayName("Should clamp context lines above max")
+		void shouldClampContextLinesAboveMax() {
+			// With 20 lines and ctx=999 (clamped to 10), two distant changes still produce two hunks
+			// because 18 unchanged lines between them > 2*10+1.
+			StringBuilder sb = new StringBuilder();
+			for (int i = 1; i <= 30; i++) sb.append("line").append(i).append('\n');
+			String before = sb.toString();
+			String after = before.replace("line1\n", "LINE1\n").replace("line30\n", "LINE30\n");
+			String diff = tool.diff(before, after, "a", "b", 999, null);
+			assertThat(diff.split("@@").length - 1).isEqualTo(4);
+		}
+
+		@Test
+		@DisplayName("Should clamp negative context lines to zero")
+		void shouldClampNegativeContextLinesToZero() {
+			// ctx=-5 → clamped to 0 → no context lines around the change
+			String diff = tool.diff("a\nb\nc\n", "a\nB\nc\n", "before.txt", "after.txt", -5, null);
+			assertThat(diff).contains("@@ -2 +2 @@\n-b\n+B\n");
+			assertThat(diff).doesNotContain(" a\n");
+			assertThat(diff).doesNotContain(" c\n");
+		}
+
+		@Test
+		@DisplayName("Should report correct summarize counts")
+		void shouldReportCorrectSummarizeCounts() {
+			DiffTool.DiffSummary s = tool.summarize("a\nb\nc\n", "a\nx\ny\nc\n", null, null);
+			assertThat(s.insertions()).isEqualTo(2L);
+			assertThat(s.deletions()).isEqualTo(1L);
+			assertThat(s.hunks()).isEqualTo(1);
+		}
+
+		@Test
+		@DisplayName("Should produce two hunks for two distant changes")
+		void shouldProduceTwoHunksForTwoDistantChanges() {
+			StringBuilder sb = new StringBuilder();
+			for (int i = 1; i <= 20; i++) {
+				sb.append("line").append(i).append('\n');
+			}
+			String before = sb.toString();
+			String after = before.replace("line1\n", "LINE1\n").replace("line20\n", "LINE20\n");
+			String diff = tool.diff(before, after, "a", "b", 3, null);
+			assertThat(diff.split("@@").length - 1).isEqualTo(4); // two @@ per hunk
+		}
+
+		@ParameterizedTest
+		@MethodSource("sampleStringsStream")
+		@DisplayName("Should round-trip diff back to after")
+		void shouldRoundTripDiffBackToAfter(SampleStrings sample) {
+			String before = sample.left();
+			String after = sample.right();
+			String diff = tool.diff(before, after, "a", "b", 3, null);
+			String applied = applyUnifiedDiff(before, diff);
+			assertThat(applied).as("round trip for pair: %s -> %s", before, after).isEqualTo(after);
+		}
+
+		private record SampleStrings(String left, String right){}
+
+		private static Stream<SampleStrings> sampleStringsStream() {
+			return Stream.of(
+					new SampleStrings("", ""),
+					new SampleStrings("", "a\n"),
+					new SampleStrings("a\n", "" ),
+					new SampleStrings("a\n", "a\n"),
+					new SampleStrings("a\nb\nc\n", "a\nB\nc\n"),
+					new SampleStrings("a\nb\nc\n", "a\nc\n"),
+					new SampleStrings("a\nc\n", "a\nb\nc\n"),
+					new SampleStrings("one\ntwo\nthree\nfour\nfive\n", "one\nTWO\nthree\nFOUR\nfive\n"),
+					new SampleStrings("x\ny\nz\n", "z\ny\nx\n"),
+					new SampleStrings("same line\n", "same line"),
+					new SampleStrings("no trailing", "no trailing"),
+					new SampleStrings("no trailing", "has trailing\n"),
+					//CRLF inputs
+					new SampleStrings("a\r\nb\r\nc\r\n", "a\r\nB\r\nc\r\n"),
+					new SampleStrings("a\r\n", "a"),
+					new SampleStrings("", "x\r\n")
+			);
+		}
+
+		@Nested
+		@DisplayName("CRLF input handling")
+		class CrlfInputTests{
+
+			@Test
+			@DisplayName("Should produce CRLF output for CRLF input")
+			void shouldProduceCrlfOutputForCrlfInput() {
+				String before = "a\r\nb\r\nc\r\n";
+				String after  = "a\r\nB\r\nc\r\n";
+				String diff = tool.diff(before, after, "a/f", "b/f", 3, null);
+
+				assertThat(diff).isEqualTo(
+						"""
+                                --- a/f\r
+                                +++ b/f\r
+                                @@ -1,3 +1,3 @@\r
+                                 a\r
+                                -b\r
+                                +B\r
+                                 c\r
+                                """);
+			}
+
+			@Test
+			@DisplayName("Should use CRLF on No-newline marker for CRLF input")
+			void shouldUseCrlfOnNoNewlineMarkerForCrlfInput() {
+				String diff = tool.diff("a\r\n", "a", "a", "b", null, null);
+				assertThat(diff).contains("\\ No newline at end of file\r\n");
+			}
+
+			@Test
+			@DisplayName("Should use CRLF when before side is CRLF-dominant")
+			void shouldUseCrlfWhenBeforeIsCrlfDominant() {
+				String diff = tool.diff("a\r\nb\r\n", "a\r\nB\n", "a", "b", 3, null);
+				assertThat(diff).contains("@@ -1,2 +1,2 @@\r\n");
+				assertThat(diff).contains("-b\r\n");
+				assertThat(diff).contains("+B\r\n");
+			}
+
+			@Test
+			@DisplayName("Should use LF when before side is LF-dominant")
+			void shouldUseLfWhenBeforeIsLfDominant() {
+				String diff = tool.diff("a\nb\n", "a\r\nB\r\n", "a", "b", 3, null);
+				assertThat(diff.lines().count()).isGreaterThan(0);
+				assertThat(diff).doesNotContain("\r");
+			}
+
+			@Test
+			@DisplayName("Should favor LF when terminator counts are tied")
+			void shouldFavorLfWhenTerminatorCountsAreTied() {
+				// one \r\n, one \n — tie, LF wins because condition is strictly >
+				String before = "a\r\nb\n";
+				String after  = "a\r\nB\n";
+				String diff = tool.diff(before, after, "a", "b", 3, null);
+				assertThat(diff).doesNotContain("\r");
+			}
+
+			@Test
+			@DisplayName("Should use after-side terminator when before side is empty")
+			void shouldUseAfterTerminatorWhenBeforeIsEmpty() {
+				String diff = tool.diff("", "x\r\n", "a", "b", null, null);
+				assertThat(diff).contains("+x\r\n");
+			}
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Diff files tests")
+	class DiffFilesTests{
+		@Test
+		@DisplayName("Should produce empty diff for identical files")
+		void shouldProduceEmptyDiffForIdenticalFiles() throws IOException {
+
+			Path before = tempDir.resolve("before.txt");
+			Path after = tempDir.resolve("after.txt");
+			String content = "Line 1\nLine 2\nLine 3";
+			Files.writeString(before, content, StandardCharsets.UTF_8);
+			Files.writeString(after, content, StandardCharsets.UTF_8);
+
+			assertEquals("", tool.diffFiles(before.toString(), after.toString(), 3, null));
+
+		}
+
+		@Test
+		@DisplayName("Should produce simple diff for different files")
+		void shouldProduceSimpleDiffForDifferentFiles() throws IOException {
+
+			Path before = tempDir.resolve("before.txt");
+			Path after = tempDir.resolve("after.txt");
+			String beforeInput = "A\nB\nC\nA\nB\nB\nA\n";
+			String afterInput = "C\nB\nA\nB\nA\nC\n";
+			String expected = tool.diff(beforeInput, afterInput, "a/"+before, "b/"+after,3, null);
+
+			Files.writeString(before, beforeInput, StandardCharsets.UTF_8);
+			Files.writeString(after, afterInput, StandardCharsets.UTF_8);
+
+			assertEquals(expected, tool.diffFiles(before.toString(), after.toString(), 3, null));
+
+		}
+
+		@Test
+		@DisplayName("Should return error string when a file is missing")
+		void shouldReturnErrorStringWhenFileIsMissing() {
+			String result = tool.diffFiles(
+					tempDir.resolve("does-not-exist-1.txt").toString(),
+					tempDir.resolve("does-not-exist-2.txt").toString(),
+					null, null);
+			assertThat(result).startsWith("Error reading files:");
+		}
+	}
+
+	/**
+	 * Minimal applyUnifiedDiff: parses hunk headers and applies ops in order.
+	 */
+	private String applyUnifiedDiff(String before, String diff) {
+		if (diff.isEmpty()) {
+			return before;
+		}
+		DiffTool.Tokenized bt = tool.tokenize(before);
+		List<String> src = new ArrayList<>(bt.lines());
+		List<String> out = new ArrayList<>();
+
+		String term = diff.contains("\r\n") ? "\r\n" : "\n";
+		String[] diffLines = diff.split(java.util.regex.Pattern.quote(term), -1);
+		int di = 0;
+		// Skip header
+		while (di < diffLines.length && !diffLines[di].startsWith("@@")) {
+			di++;
+		}
+
+		int srcIdx = 0;
+		boolean afterEndsWithNewline = true;
+		boolean beforeEndsWithNewline = bt.endsWithNewline();
+
+		while (di < diffLines.length) {
+			String line = diffLines[di];
+			if (line.startsWith("@@")) {
+				int beforeStart = parseStart(line, '-');
+				while (srcIdx < beforeStart - 1) {
+					out.add(src.get(srcIdx++));
+				}
+				di++;
+				continue;
+			}
+			if (line.isEmpty()) {
+				di++;
+				continue;
+			}
+			char prefix = line.charAt(0);
+			String content = line.substring(1);
+			if (prefix == ' ') {
+				out.add(content);
+				srcIdx++;
+			}
+			else if (prefix == '-') {
+				srcIdx++;
+			}
+			else if (prefix == '+') {
+				out.add(content);
+			}
+			else if (prefix == '\\' && diffLines[di].contains("No newline")) {
+				// \ No newline at end of file applies to the previously emitted line
+					// Determine which side: look at previous non-backslash line prefix
+					int prev = di - 1;
+					while (prev >= 0 && diffLines[prev].isEmpty()) {
+						prev--;
+					}
+					if (prev >= 0) {
+						char prevPrefix = diffLines[prev].charAt(0);
+					if (prevPrefix == '+' || prevPrefix == ' ') {
+						afterEndsWithNewline = false;
+					}
+					if (prevPrefix == ' ' && !beforeEndsWithNewline) {
+						// Marker covers before too (already set via input).
+
+					}
+				}
+			}
+			di++;
+		}
+		while (srcIdx < src.size()) {
+			out.add(src.get(srcIdx++));
+		}
+
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < out.size(); i++) {
+			sb.append(out.get(i));
+			if (i < out.size() - 1 || afterEndsWithNewline) {
+				sb.append(term);
+			}
+		}
+		return sb.toString();
+	}
+
+	private static int parseStart(String hunkHeader, char sign) {
+		int idx = hunkHeader.indexOf(sign);
+		int end = idx + 1;
+		while (end < hunkHeader.length() && (Character.isDigit(hunkHeader.charAt(end)))) {
+			end++;
+		}
+		int start = Integer.parseInt(hunkHeader.substring(idx + 1, end));
+		return start == 0 ? 1 : start;
+	}
+
+}


### PR DESCRIPTION
Add DiffTool Spring AI tool for unified-diff generation    
- Adds `DiffTool` exposing three Spring AI tools: `DiffTool` (string-to-string unified diff), `DiffFiles` (file-to-file unified diff), and `DiffSummarize` (counts-only variant).
- Pure-Java implementation of Eugene W. Myers' O(ND) difference algorithm — no external diff dependency. Output follows the standard unified-diff format (`---` / `+++` / `@@` headers) and is compatible with `patch` and `git apply`.
- Handles CRLF/LF terminators (picks the dominant one from the `before` side), emits `\ No newline at end of file` markers so patches round-trip, and supports `STRICT` / `IGNORE_TRAILING` / `IGNORE_ALL` whitespace modes. `contextLines` is clamped to `[0, 10]`.
- Documentation added at `docs/tools/DiffTool.md`; entries added to the top-level and module READMEs.
