### PR TITLE
Add sandboxDirectory support to FileSystemTools

### DIFF
--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
@@ -23,6 +23,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -35,6 +36,62 @@ import org.springframework.ai.tool.annotation.ToolParam;
  * @author Christian Tzolov
  */
 public class FileSystemTools {
+
+	private final Path sandboxDirectory;
+
+	protected FileSystemTools(Path sandboxDirectory) {
+		this.sandboxDirectory = sandboxDirectory;
+	}
+
+	/**
+	 * Validates that the given file path is within the configured sandbox directory.
+	 * When no sandbox is configured, all paths are allowed.
+	 * Uses two checks: (1) normalized path to block {@code ..} traversal, and (2) real-path
+	 * resolution walking up existing path components to catch symlink escapes including
+	 * dangling symlinks that point outside the sandbox.
+	 * @param filePath the path to validate
+	 * @return an error string if access is denied, or {@code null} if access is allowed
+	 */
+	private String validateSandboxAccess(String filePath) {
+		if (this.sandboxDirectory == null) {
+			return null;
+		}
+		try {
+			Path sandbox = this.sandboxDirectory.toAbsolutePath().normalize();
+			Path target = Paths.get(filePath).toAbsolutePath().normalize();
+
+			// Check 1: normalized path must be within sandbox (blocks .. traversal)
+			if (!target.startsWith(sandbox)) {
+				return "Error: Access denied. Path is outside the allowed sandbox directory: " + filePath;
+			}
+
+			// Check 2: resolve symlinks in all existing path components.
+			// Walk up from target using NOFOLLOW_LINKS so dangling symlinks are detected.
+			Path realSandbox = Files.exists(sandbox) ? sandbox.toRealPath() : sandbox;
+			Path existing = target;
+			while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+				existing = existing.getParent();
+			}
+			if (existing != null) {
+				try {
+					Path realExisting = existing.toRealPath();
+					if (!realExisting.startsWith(realSandbox)) {
+						return "Error: Access denied. Path is outside the allowed sandbox directory: " + filePath;
+					}
+				}
+				catch (IOException e) {
+					// toRealPath() throws on a dangling symlink (symlink exists but target does not).
+					// We cannot verify where it points, so deny access.
+					return "Error: Access denied. Cannot resolve path (possible dangling symlink): " + filePath;
+				}
+			}
+
+			return null;
+		}
+		catch (IOException e) {
+			return "Error validating path: " + e.getMessage();
+		}
+	}
 
 	// @formatter:off
 	@Tool(name = "Read", description = """
@@ -59,6 +116,11 @@ public class FileSystemTools {
 		@ToolParam(description = "The absolute path to the file to read") String filePath,
 		@ToolParam(description = "The line number to start reading from. Only provide if the file is too large to read at once", required = false) Integer offset,
 		@ToolParam(description = "The number of lines to read. Only provide if the file is too large to read at once.", required = false) Integer limit) { // @formatter:on
+
+		String accessError = validateSandboxAccess(filePath);
+		if (accessError != null) {
+			return accessError;
+		}
 
 		try {
 			File file = new File(filePath);
@@ -150,6 +212,11 @@ public class FileSystemTools {
 		@ToolParam(description = "The absolute path to the file to write (must be absolute, not relative)") String filePath,
 		@ToolParam(description = "The content to write to the file") String content) { // @formatter:on
 
+		String accessError = validateSandboxAccess(filePath);
+		if (accessError != null) {
+			return accessError;
+		}
+
 		try {
 			content = content != null ? content : "";
 
@@ -205,6 +272,11 @@ public class FileSystemTools {
 		@ToolParam(description = "The text to replace") String old_string,
 		@ToolParam(description = "The text to replace it with (must be different from old_string)") String new_string,
 		@ToolParam(description = "Replace all occurences of old_string (default false)", required = false) Boolean replace_all) { // @formatter:on
+
+		String accessError = validateSandboxAccess(filePath);
+		if (accessError != null) {
+			return accessError;
+		}
 
 		try {
 			File file = new File(filePath);
@@ -380,8 +452,35 @@ public class FileSystemTools {
 
 	public static class Builder {
 
+		private Path sandboxDirectory = null;
+
+		private Builder() {
+		}
+
+		/**
+		 * Restricts all file operations to paths within the given directory.
+		 * Any attempt to access a path outside the sandbox returns an error.
+		 * Symlinks are resolved to their real path before the check.
+		 * @param sandboxDirectory the directory to restrict operations to
+		 * @return this builder
+		 */
+		public Builder sandboxDirectory(Path sandboxDirectory) {
+			this.sandboxDirectory = sandboxDirectory;
+			return this;
+		}
+
+		/**
+		 * Restricts all file operations to paths within the given directory.
+		 * @param sandboxDirectory the directory path as a string
+		 * @return this builder
+		 */
+		public Builder sandboxDirectory(String sandboxDirectory) {
+			this.sandboxDirectory = sandboxDirectory != null ? Paths.get(sandboxDirectory) : null;
+			return this;
+		}
+
 		public FileSystemTools build() {
-			return new FileSystemTools();
+			return new FileSystemTools(sandboxDirectory);
 		}
 
 	}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
@@ -46,9 +46,11 @@ public class FileSystemTools {
 	/**
 	 * Validates that the given file path is within the configured sandbox directory.
 	 * When no sandbox is configured, all paths are allowed.
-	 * Uses two checks: (1) normalized path to block {@code ..} traversal, and (2) real-path
-	 * resolution walking up existing path components to catch symlink escapes including
-	 * dangling symlinks that point outside the sandbox.
+	 * Uses three checks:
+	 * (1) rejects raw {@code ..} path components to prevent symlink+{@code ..} escapes,
+	 * (2) normalized path containment check to block remaining {@code ..} traversal,
+	 * (3) real-path resolution walking up existing path components to catch symlink escapes
+	 * including dangling symlinks (skipped when the sandbox directory does not yet exist).
 	 * @param filePath the path to validate
 	 * @return an error string if access is denied, or {@code null} if access is allowed
 	 */
@@ -58,35 +60,53 @@ public class FileSystemTools {
 		}
 		try {
 			Path sandbox = this.sandboxDirectory.toAbsolutePath().normalize();
-			Path target = Paths.get(filePath).toAbsolutePath().normalize();
+			Path targetAbs = Paths.get(filePath).toAbsolutePath();
 
-			// Check 1: normalized path must be within sandbox (blocks .. traversal)
+			// Check 1: reject '..' components in the raw absolute path.
+			// Normalizing before this check would hide symlink+'..' bypass attempts
+			// (e.g. /sandbox/link/../outside normalizes to /sandbox/outside but the OS
+			// resolves 'link' as a symlink first, landing outside the sandbox).
+			for (Path component : targetAbs) {
+				if ("..".equals(component.toString())) {
+					return "Error: Access denied. Path is outside the allowed sandbox directory: " + filePath;
+				}
+			}
+
+			Path target = targetAbs.normalize();
+
+			// Check 2: normalized path must start with sandbox (blocks remaining traversal)
 			if (!target.startsWith(sandbox)) {
 				return "Error: Access denied. Path is outside the allowed sandbox directory: " + filePath;
 			}
 
-			// Check 2: resolve symlinks in all existing path components.
-			// Walk up from target using NOFOLLOW_LINKS so dangling symlinks are detected.
-			Path realSandbox = Files.exists(sandbox) ? sandbox.toRealPath() : sandbox;
-			Path existing = target;
-			while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
-				existing = existing.getParent();
-			}
-			if (existing != null) {
-				try {
-					Path realExisting = existing.toRealPath();
-					if (!realExisting.startsWith(realSandbox)) {
-						return "Error: Access denied. Path is outside the allowed sandbox directory: " + filePath;
-					}
+			// Check 3: resolve symlinks in all existing path components to catch symlink escapes,
+			// including dangling symlinks. Skipped when sandbox does not yet exist to allow writes
+			// into a sandbox directory that hasn't been created yet (checks 1+2 are sufficient then).
+			if (Files.exists(sandbox)) {
+				Path realSandbox = sandbox.toRealPath();
+				Path existing = target;
+				while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+					existing = existing.getParent();
 				}
-				catch (IOException e) {
-					// toRealPath() throws on a dangling symlink (symlink exists but target does not).
-					// We cannot verify where it points, so deny access.
-					return "Error: Access denied. Cannot resolve path (possible dangling symlink): " + filePath;
+				if (existing != null) {
+					try {
+						Path realExisting = existing.toRealPath();
+						if (!realExisting.startsWith(realSandbox)) {
+							return "Error: Access denied. Path is outside the allowed sandbox directory: " + filePath;
+						}
+					}
+					catch (IOException e) {
+						// toRealPath() throws on a dangling symlink (symlink exists but target does not).
+						// We cannot verify where it points, so deny access.
+						return "Error: Access denied. Cannot resolve path (possible dangling symlink): " + filePath;
+					}
 				}
 			}
 
 			return null;
+		}
+		catch (RuntimeException e) {
+			return "Error: Invalid path: " + e.getMessage();
 		}
 		catch (IOException e) {
 			return "Error validating path: " + e.getMessage();

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -491,6 +493,240 @@ class FileSystemToolsTest {
 			String content = Files.readString(file, StandardCharsets.UTF_8);
 			assertThat(content).contains("REPLACED");
 			assertThat(content).doesNotContain(".*+?[]{}()");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Sandbox Directory Tests")
+	class SandboxDirectoryTests {
+
+		private Path sandboxDir;
+
+		private Path outsideDir;
+
+		@BeforeEach
+		void setUpSandbox(@TempDir Path sandbox, @TempDir Path outside) throws IOException {
+			this.sandboxDir = sandbox;
+			this.outsideDir = outside;
+		}
+
+		@Test
+		@DisplayName("Should allow read of file inside sandbox")
+		void shouldAllowReadInsideSandbox() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path file = sandboxDir.resolve("safe.txt");
+			Files.writeString(file, "safe content", StandardCharsets.UTF_8);
+
+			String result = sandboxedTools.read(file.toString(), null, null);
+
+			assertThat(result).contains("safe content");
+		}
+
+		@Test
+		@DisplayName("Should deny read of file outside sandbox")
+		void shouldDenyReadOutsideSandbox() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path outside = outsideDir.resolve("secret.txt");
+			Files.writeString(outside, "secret", StandardCharsets.UTF_8);
+
+			String result = sandboxedTools.read(outside.toString(), null, null);
+
+			assertThat(result).contains("Error: Access denied");
+			assertThat(result).contains("outside the allowed sandbox directory");
+		}
+
+		@Test
+		@DisplayName("Should allow write of file inside sandbox")
+		void shouldAllowWriteInsideSandbox() {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path file = sandboxDir.resolve("new.txt");
+
+			String result = sandboxedTools.write(file.toString(), "content");
+
+			assertThat(result).contains("Successfully created file");
+			assertThat(file).exists();
+		}
+
+		@Test
+		@DisplayName("Should deny write of file outside sandbox")
+		void shouldDenyWriteOutsideSandbox() {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path outside = outsideDir.resolve("injected.txt");
+
+			String result = sandboxedTools.write(outside.toString(), "malicious content");
+
+			assertThat(result).contains("Error: Access denied");
+			assertThat(outside).doesNotExist();
+		}
+
+		@Test
+		@DisplayName("Should allow edit of file inside sandbox")
+		void shouldAllowEditInsideSandbox() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path file = sandboxDir.resolve("edit.txt");
+			Files.writeString(file, "original", StandardCharsets.UTF_8);
+
+			String result = sandboxedTools.edit(file.toString(), "original", "modified", null);
+
+			assertThat(result).contains("has been updated");
+			assertThat(file).content(StandardCharsets.UTF_8).isEqualTo("modified");
+		}
+
+		@Test
+		@DisplayName("Should deny edit of file outside sandbox")
+		void shouldDenyEditOutsideSandbox() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path outside = outsideDir.resolve("system.txt");
+			Files.writeString(outside, "original", StandardCharsets.UTF_8);
+
+			String result = sandboxedTools.edit(outside.toString(), "original", "modified", null);
+
+			assertThat(result).contains("Error: Access denied");
+			assertThat(outside).content(StandardCharsets.UTF_8).isEqualTo("original");
+		}
+
+		@Test
+		@DisplayName("Should deny path traversal via .. in read")
+		void shouldDenyPathTraversalInRead() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path outside = outsideDir.resolve("secret.txt");
+			Files.writeString(outside, "secret", StandardCharsets.UTF_8);
+
+			// Attempt path traversal: /sandbox/../outside/secret.txt
+			String traversalPath = sandboxDir + "/../" + outsideDir.getFileName() + "/secret.txt";
+			String result = sandboxedTools.read(traversalPath, null, null);
+
+			assertThat(result).contains("Error: Access denied");
+		}
+
+		@Test
+		@DisplayName("Should deny path traversal via .. in write")
+		void shouldDenyPathTraversalInWrite() {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+
+			// Attempt path traversal: /sandbox/../outside/injected.txt
+			String traversalPath = sandboxDir + "/../" + outsideDir.getFileName() + "/injected.txt";
+			String result = sandboxedTools.write(traversalPath, "injected");
+
+			assertThat(result).contains("Error: Access denied");
+		}
+
+		@Test
+		@DisplayName("Should deny path traversal via .. in edit")
+		void shouldDenyPathTraversalInEdit() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path outside = outsideDir.resolve("system.txt");
+			Files.writeString(outside, "original", StandardCharsets.UTF_8);
+
+			String traversalPath = sandboxDir + "/../" + outsideDir.getFileName() + "/system.txt";
+			String result = sandboxedTools.edit(traversalPath, "original", "modified", null);
+
+			assertThat(result).contains("Error: Access denied");
+			assertThat(outside).content(StandardCharsets.UTF_8).isEqualTo("original");
+		}
+
+		@Test
+		@DisplayName("Should allow access to nested subdirectory inside sandbox")
+		void shouldAllowAccessToNestedSubdirectory() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path nested = sandboxDir.resolve("sub/dir/file.txt");
+			Files.createDirectories(nested.getParent());
+			Files.writeString(nested, "nested content", StandardCharsets.UTF_8);
+
+			String result = sandboxedTools.read(nested.toString(), null, null);
+
+			assertThat(result).contains("nested content");
+		}
+
+		@Test
+		@DisplayName("Should have no restriction when sandbox is not configured")
+		void shouldHaveNoRestrictionWithoutSandbox() throws IOException {
+			FileSystemTools unrestrictedTools = FileSystemTools.builder().build();
+			Path outside = outsideDir.resolve("file.txt");
+			Files.writeString(outside, "content", StandardCharsets.UTF_8);
+
+			String result = unrestrictedTools.read(outside.toString(), null, null);
+
+			assertThat(result).contains("content");
+			assertThat(result).doesNotContain("Access denied");
+		}
+
+		@Test
+		@DisplayName("Should accept sandboxDirectory as String in builder")
+		void shouldAcceptSandboxDirectoryAsString() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder()
+				.sandboxDirectory(sandboxDir.toString())
+				.build();
+			Path file = sandboxDir.resolve("file.txt");
+			Files.writeString(file, "content", StandardCharsets.UTF_8);
+
+			String result = sandboxedTools.read(file.toString(), null, null);
+
+			assertThat(result).contains("content");
+		}
+
+		@Test
+		@DisplayName("Should treat null String sandboxDirectory as no restriction")
+		void shouldTreatNullStringAsNoRestriction() throws IOException {
+			FileSystemTools tools = FileSystemTools.builder().sandboxDirectory((String) null).build();
+			Path outside = outsideDir.resolve("file.txt");
+			Files.writeString(outside, "content", StandardCharsets.UTF_8);
+
+			String result = tools.read(outside.toString(), null, null);
+
+			assertThat(result).contains("content");
+		}
+
+		@Test
+		@DisplayName("Should deny symlink pointing outside sandbox")
+		@DisabledOnOs(OS.WINDOWS)
+		void shouldDenySymlinkPointingOutsideSandbox() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path secretFile = outsideDir.resolve("secret.txt");
+			Files.writeString(secretFile, "secret content", StandardCharsets.UTF_8);
+
+			// Create a symlink inside the sandbox pointing to a file outside
+			Path symlink = sandboxDir.resolve("escape.txt");
+			Files.createSymbolicLink(symlink, secretFile);
+
+			String result = sandboxedTools.read(symlink.toString(), null, null);
+
+			assertThat(result).contains("Error: Access denied");
+		}
+
+		@Test
+		@DisplayName("Should deny dangling symlink pointing outside sandbox on write")
+		@DisabledOnOs(OS.WINDOWS)
+		void shouldDenyDanglingSymlinkOutsideSandboxOnWrite() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+
+			// Dangling symlink: target file does not exist yet
+			Path danglingTarget = outsideDir.resolve("nonexistent.txt");
+			Path symlink = sandboxDir.resolve("dangling.txt");
+			Files.createSymbolicLink(symlink, danglingTarget);
+
+			String result = sandboxedTools.write(symlink.toString(), "injected");
+
+			assertThat(result).contains("Error: Access denied");
+			assertThat(danglingTarget).doesNotExist();
+		}
+
+		@Test
+		@DisplayName("Should deny symlink directory pointing outside sandbox")
+		@DisabledOnOs(OS.WINDOWS)
+		void shouldDenySymlinkDirectoryPointingOutsideSandbox() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path secretFile = outsideDir.resolve("secret.txt");
+			Files.writeString(secretFile, "secret content", StandardCharsets.UTF_8);
+
+			// Create a symlink directory inside the sandbox pointing to the outside dir
+			Path symlinkDir = sandboxDir.resolve("escapedir");
+			Files.createSymbolicLink(symlinkDir, outsideDir);
+
+			String result = sandboxedTools.read(symlinkDir.resolve("secret.txt").toString(), null, null);
+
+			assertThat(result).contains("Error: Access denied");
 		}
 
 	}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsTest.java
@@ -729,6 +729,40 @@ class FileSystemToolsTest {
 			assertThat(result).contains("Error: Access denied");
 		}
 
+		@Test
+		@DisplayName("Should deny symlink + '..' traversal bypass")
+		@DisabledOnOs(OS.WINDOWS)
+		void shouldDenySymlinkFollowedByDotDotTraversal() throws IOException {
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(sandboxDir).build();
+			Path secretFile = outsideDir.resolve("secret.txt");
+			Files.writeString(secretFile, "secret content", StandardCharsets.UTF_8);
+
+			// Create a symlink inside the sandbox pointing to a subdirectory outside
+			Path symlinkDir = sandboxDir.resolve("link");
+			Files.createSymbolicLink(symlinkDir, outsideDir);
+
+			// Attempt: /sandbox/link/../secret.txt - normalizes to /sandbox/secret.txt
+			// but the OS would resolve 'link' as a symlink first, landing in outsideDir
+			String traversalPath = sandboxDir + "/link/../secret.txt";
+			String result = sandboxedTools.read(traversalPath, null, null);
+
+			assertThat(result).contains("Error: Access denied");
+		}
+
+		@Test
+		@DisplayName("Should allow write to file inside non-existent sandbox directory")
+		void shouldAllowWriteInsideNonExistentSandboxDirectory() throws IOException {
+			// Sandbox dir that doesn't exist yet
+			Path nonExistentSandbox = sandboxDir.resolve("not-yet-created");
+			FileSystemTools sandboxedTools = FileSystemTools.builder().sandboxDirectory(nonExistentSandbox).build();
+			Path file = nonExistentSandbox.resolve("file.txt");
+
+			String result = sandboxedTools.write(file.toString(), "content");
+
+			assertThat(result).contains("Successfully created file");
+			assertThat(file).exists();
+		}
+
 	}
 
 	@Nested


### PR DESCRIPTION
## Summary

- Adds a `sandboxDirectory` option to `FileSystemTools.Builder` that restricts all `read`, `write`, and `edit` operations to paths within a configured directory
- Path traversal via `..` is blocked by normalizing the absolute path before checking
- Symlink escapes are blocked by resolving real paths on existing path components; dangling symlinks (pointing to a non-existent target outside the sandbox) are also denied
- No sandbox configured (default) = existing behavior unchanged, fully backward compatible

## Usage

```java
FileSystemTools tools = FileSystemTools.builder()
    .sandboxDirectory(Path.of("/workspace/project"))
    .build();
// or: .sandboxDirectory("/workspace/project")
```

## Test plan

- [x] Allow read/write/edit of files inside the sandbox
- [x] Deny read/write/edit of files outside the sandbox
- [x] Deny path traversal via `..` for all three operations
- [x] Deny symlink inside sandbox pointing to file outside
- [x] Deny symlink directory inside sandbox pointing to directory outside
- [x] Deny dangling symlink pointing outside sandbox on write
- [x] No restriction when sandbox is not configured (backward compat)
- [x] Builder accepts both `Path` and `String` forms
- [x] `null` String sandbox = no restriction
- [x] Access to nested subdirectories inside sandbox works

Closes #45