### PR TITLE
Upgrade to Spring AI 2.0.0-RC1 and fix null guards in logging advisors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Use the BOM to manage versions consistently across all modules:
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agent-utils-bom</artifactId>
-            <version>0.7.0</version>
+            <version>0.9.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -115,7 +115,7 @@ Or add the core library directly:
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-agent-utils</artifactId>
-    <version>0.7.0</version>
+    <version>0.9.0</version>
 </dependency>
 ```
 
@@ -208,7 +208,7 @@ This project reimplements key Claude Code features based on:
 
 - Java 17+
 - Spring Boot 3.x / 4.x
-- Spring AI 2.0.0-M4 or later
+- Spring AI 2.0.0-RC1 or later
 - Maven 3.6+
 
 ## Building

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Use the BOM to manage versions consistently across all modules:
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agent-utils-bom</artifactId>
-            <version>0.7.0</version>
+            <version>0.9.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -63,14 +63,14 @@ Or add the core library directly:
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-agent-utils</artifactId>
-    <version>0.7.0</version>
+    <version>0.9.0</version>
 </dependency>
 ```
 
 _Check the latest version:_ [![](https://img.shields.io/maven-central/v/org.springaicommunity/spring-ai-agent-utils.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.springaicommunity/spring-ai-agent-utils)
 
 !!! note
-    You need Spring AI version `2.0.0-M4` or later.
+    You need Spring AI version `2.0.0-RC1` or later.
 
 **2. Configure your agent:**
 
@@ -147,7 +147,7 @@ public class Application {
 
 - Java 17+
 - Spring Boot 3.x / 4.x
-- Spring AI 2.0.0-M4 or later
+- Spring AI 2.0.0-RC1 or later
 - Maven 3.6+
 
 ## Building

--- a/docs/tools/migration-0.9.md
+++ b/docs/tools/migration-0.9.md
@@ -1,0 +1,154 @@
+# Migration Guide: 0.7.x to 0.9.0
+
+This release upgrades the Spring AI dependency from `2.0.0-M7` to `2.0.0-RC1` and Spring Framework from `7.0.1` to `7.0.7`. Several Spring AI APIs changed in ways that require updates to application code.
+
+## Dependency Version
+
+```xml
+<dependency>
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-agent-utils</artifactId>
+    <version>0.9.0</version>
+</dependency>
+```
+
+## Spring AI API Changes
+
+### `ToolCallAdvisor` removed
+
+`ToolCallAdvisor` is deprecated and no longer needs to be registered. Tool calling is now handled automatically by the framework when tools are present on the `ChatClient`.
+
+**Before:**
+
+```java
+chatClientBuilder.defaultAdvisors(
+    ToolCallAdvisor.builder().build(),
+    MessageChatMemoryAdvisor.builder(...).build());
+```
+
+**After:**
+
+```java
+chatClientBuilder.defaultAdvisors(
+    MessageChatMemoryAdvisor.builder(...).build());
+```
+
+If you were using `disableInternalConversationHistory()` or `conversationHistoryEnabled(false)`, that behaviour is now controlled by advisor ordering — see the [Memory advisor ordering](#memory-advisor-ordering) section below.
+
+### `defaultToolCallbacks()` → `defaultTools()`
+
+`ChatClient.Builder.defaultToolCallbacks()` is deprecated. Use `defaultTools()` instead. It accepts the same types: individual `ToolCallback` objects, `ToolCallbackProvider` instances, and annotated POJO classes.
+
+**Before:**
+
+```java
+chatClientBuilder
+    .defaultToolCallbacks(SkillsTool.builder().build())
+    .defaultToolCallbacks(mcpToolCallbackProvider);
+```
+
+**After:**
+
+```java
+chatClientBuilder
+    .defaultTools(SkillsTool.builder().build())
+    .defaultTools(mcpToolCallbackProvider);
+```
+
+### OpenAI starter artifact renamed
+
+The OpenAI SDK starter artifact has been renamed:
+
+| Before | After |
+|--------|-------|
+| `spring-ai-starter-model-openai-sdk` | `spring-ai-starter-model-openai` |
+
+```xml
+<!-- After -->
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-openai</artifactId>
+</dependency>
+```
+
+### OpenAI property prefix renamed
+
+All `spring.ai.openai-sdk.*` properties are renamed to `spring.ai.openai.*`:
+
+| Before | After |
+|--------|-------|
+| `spring.ai.openai-sdk.api-key` | `spring.ai.openai.api-key` |
+| `spring.ai.openai-sdk.chat.options.model` | `spring.ai.openai.chat.options.model` |
+| `spring.ai.openai-sdk.chat.options.temperature` | `spring.ai.openai.chat.options.temperature` |
+
+### `ModelOptionsUtils.toJsonString()` removed
+
+If you reference `ModelOptionsUtils.toJsonString()` in custom advisor or tool code, replace it with `JsonHelper`:
+
+**Before:**
+
+```java
+import org.springframework.ai.model.ModelOptionsUtils;
+
+String json = ModelOptionsUtils.toJsonString(object);
+```
+
+**After:**
+
+```java
+import org.springframework.ai.util.JsonHelper;
+
+String json = new JsonHelper().toJson(object);
+```
+
+### `ToolCallingChatOptions.copy()` removed
+
+`copy()` has been removed from the `ToolCallingChatOptions` interface. Use `mutate().build()` instead:
+
+**Before:**
+
+```java
+ToolCallingChatOptions copy = toolOptions.copy();
+```
+
+**After:**
+
+```java
+ToolCallingChatOptions copy = toolOptions.mutate().build();
+```
+
+### `DefaultToolCallingChatOptions` public constructor removed
+
+The no-arg public constructor is no longer available. Use the builder:
+
+**Before:**
+
+```java
+new DefaultToolCallingChatOptions()
+```
+
+**After:**
+
+```java
+DefaultToolCallingChatOptions.builder().build()
+```
+
+## Memory Advisor Ordering
+
+`MessageChatMemoryAdvisor` must be placed **outside** (before) the tool-calling loop so that memory is only read/written once per user turn rather than on every tool-call iteration. The advisor's default order (`Advisor.DEFAULT_CHAT_MEMORY_PRECEDENCE_ORDER = HIGHEST_PRECEDENCE + 200`) already satisfies this — do not override it with a higher value.
+
+**Incorrect** (places memory inside the tool-call loop):
+
+```java
+MessageChatMemoryAdvisor.builder(memory)
+    .order(Ordered.HIGHEST_PRECEDENCE + 1000)  // wrong — higher value = inner = inside tool loop
+    .build()
+```
+
+**Correct** (use the default order):
+
+```java
+MessageChatMemoryAdvisor.builder(memory).build()
+```
+
+The auto-configured `ToolCallingAdvisor` sits at `HIGHEST_PRECEDENCE + 300`. Memory at the default `HIGHEST_PRECEDENCE + 200` is numerically lower and therefore outermost, wrapping all tool calls in a single memory read/write cycle.

--- a/examples/ask-user-question-demo/pom.xml
+++ b/examples/ask-user-question-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>		
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>		
 	</properties>
 
 	<dependencies>
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -49,7 +49,7 @@
 
 		<!-- <dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-openai-sdk</artifactId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency> -->
 
 		<dependency>

--- a/examples/ask-user-question-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/ask-user-question-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -7,16 +7,16 @@ import org.springaicommunity.agent.utils.CommandLineQuestionHandler;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
 
 @SpringBootApplication
 public class Application {
-	
+
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
 	}
@@ -35,8 +35,8 @@ public class Application {
 					.build())
 
 				.defaultAdvisors(
-					ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
-					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build()).build())
+					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
+					.order(Ordered.HIGHEST_PRECEDENCE + 1000).build())
 
 				.build();
 				// @formatter:on
@@ -52,4 +52,5 @@ public class Application {
 			}
 		};
 	}
+
 }

--- a/examples/ask-user-question-demo/src/main/resources/application.properties
+++ b/examples/ask-user-question-demo/src/main/resources/application.properties
@@ -8,9 +8,9 @@ spring.ai.anthropic.chat.options.max-tokens=1000
 
 
 ## OpenAI SDK
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-spring.ai.openai-sdk.chat.options.temperature=1.0
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai.chat.options.temperature=1.0
 
 
 ## Google GenAI SDK

--- a/examples/code-agent-demo/pom.xml
+++ b/examples/code-agent-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- <dependency>
@@ -38,7 +38,7 @@
 
 		<!-- <dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-openai-sdk</artifactId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency> -->
 
 		<dependency>

--- a/examples/code-agent-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/code-agent-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -16,7 +16,6 @@ import org.springaicommunity.agent.utils.CommandLineQuestionHandler;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,10 +51,10 @@ public class Application {
 					.param(AgentEnvironment.AGENT_MODEL_KNOWLEDGE_CUTOFF_KEY, agentModelKnowledgeCutoff))
 
 				// AirBnb MCP Tools
-				.defaultToolCallbacks(mcpToolCallbackProvider)
+				.defaultTools(mcpToolCallbackProvider)
 
 				// Skills tool
-				.defaultToolCallbacks(SkillsTool.builder().addSkillsResources(skillPaths).build())
+				.defaultTools(SkillsTool.builder().addSkillsResources(skillPaths).build())
 
 				// Todo management tool
 				.defaultTools(TodoWriteTool.builder().build())
@@ -76,9 +75,6 @@ public class Application {
 
 				// Advisors
 				.defaultAdvisors(
-					ToolCallAdvisor.builder()
-						.conversationHistoryEnabled(false)
-						.build(), // tool calling advisor
 					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 						.order(Ordered.HIGHEST_PRECEDENCE + 1000)
 						.build())
@@ -86,7 +82,7 @@ public class Application {
 					// MyLoggingAdvisor.builder()
 					// 	.showAvailableTools(false)
 					// 	.showSystemMessage(false)
-					// 	.build()) 
+					// 	.build())
 				.build();
 				// @formatter:on
 
@@ -101,4 +97,5 @@ public class Application {
 			}
 		};
 	}
+
 }

--- a/examples/code-agent-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
+++ b/examples/code-agent-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
@@ -7,8 +7,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.StringUtils;
 
 public class MyLoggingAdvisor implements BaseAdvisor {
@@ -18,13 +18,13 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 	public final boolean showSystemMessage;
 
 	public final boolean showAvailableTools;
-	
+
 	public final boolean showUserText;
-	
+
 	public final boolean showAssistantText;
 
-
-	private MyLoggingAdvisor(int order, boolean showSystemMessage, boolean showAvailableTools, boolean showUserText, boolean showAssistantText) {
+	private MyLoggingAdvisor(int order, boolean showSystemMessage, boolean showAvailableTools, boolean showUserText,
+			boolean showAssistantText) {
 		this.order = order;
 		this.showSystemMessage = showSystemMessage;
 		this.showAvailableTools = showAvailableTools;
@@ -49,11 +49,12 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 		if (this.showAvailableTools) {
 			Object tools = "No Tools";
 
-			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+					&& toolOptions.getToolCallbacks() != null) {
 				tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
 			}
 
-			sb.append("\n - TOOLS: " + ModelOptionsUtils.toJsonString(tools));
+			sb.append("\n - TOOLS: " + new JsonHelper().toJson(tools));
 		}
 
 		Message lastMessage = chatClientRequest.prompt().getLastUserOrToolResponseMessage();
@@ -128,7 +129,7 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 		private boolean showSystemMessage = true;
 
 		private boolean showAvailableTools = true;
-		
+
 		private boolean showAssistantText = true;
 
 		private boolean showUserText = true;
@@ -147,6 +148,7 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 			this.showAvailableTools = showAvailableTools;
 			return this;
 		}
+
 		public Builder showAssistantText(boolean showAssistantText) {
 			this.showAssistantText = showAssistantText;
 			return this;
@@ -155,11 +157,11 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 		public Builder showUserText(boolean showUserText) {
 			this.showUserText = showUserText;
 			return this;
-		}	
+		}
 
 		public MyLoggingAdvisor build() {
-			MyLoggingAdvisor advisor = new MyLoggingAdvisor(this.order, this.showSystemMessage,
-					this.showAvailableTools, this.showUserText, this.showAssistantText);
+			MyLoggingAdvisor advisor = new MyLoggingAdvisor(this.order, this.showSystemMessage, this.showAvailableTools,
+					this.showUserText, this.showAssistantText);
 			return advisor;
 		}
 

--- a/examples/code-agent-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisorOld.java
+++ b/examples/code-agent-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisorOld.java
@@ -13,8 +13,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 
 public class MyLoggingAdvisorOld implements BaseAdvisor {
 
@@ -54,14 +54,14 @@ public class MyLoggingAdvisorOld implements BaseAdvisor {
 	private void printUser(String label, List<Message> messages, Object tools) {
 		String mt = messages.stream()
 			.map(message -> message.getMessageType() == MessageType.SYSTEM ? " - SYSTEM "
-					: " - " + ModelOptionsUtils.toJsonString(message))
+					: " - " + new JsonHelper().toJson(message))
 			.collect(Collectors.joining("\n"));
-		logger.info("\n" + label + ":\n" + mt + "\n   TOOLS: " + ModelOptionsUtils.toJsonString(tools) + "\n");
+		logger.info("\n" + label + ":\n" + mt + "\n   TOOLS: " + new JsonHelper().toJson(tools) + "\n");
 	}
 
 	private void printAssistant(String label, List<Generation> generations) {
 		String gt = generations.stream()
-			.map(g -> " - " + ModelOptionsUtils.toJsonString(g.getOutput()))
+			.map(g -> " - " + new JsonHelper().toJson(g.getOutput()))
 			.collect(Collectors.joining("\n"));
 		logger.info("\n" + label + ":\n" + gt + "\n");
 	}

--- a/examples/code-agent-demo/src/main/resources/application.properties
+++ b/examples/code-agent-demo/src/main/resources/application.properties
@@ -9,15 +9,6 @@ spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
 # spring.ai.openai.chat.options.model=gpt-4.1-mini-2025-04-14
 spring.ai.openai.chat.options.temperature=1.0
 
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-
-# spring.ai.openai-sdk.chat.options.model=gpt-5-nano-2025-08-07
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-#5.2 is expensive
-# spring.ai.openai-sdk.chat.options.model=gpt-5.2-2025-12-11
-# spring.ai.openai-sdk.chat.options.model=gpt-4.1-mini-2025-04-14
-spring.ai.openai-sdk.chat.options.temperature=1.0
-
 spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}
 # spring.ai.google.genai.location=${GOOGLE_CLOUD_LOCATION}
 spring.ai.google.genai.location=global

--- a/examples/memory/memory-filesystem-tools-demo/pom.xml
+++ b/examples/memory/memory-filesystem-tools-demo/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.2</version>
+		<version>4.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -43,7 +43,7 @@
 
 		<!-- <dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-openai-sdk</artifactId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency> -->
 
 		<dependency>

--- a/examples/memory/memory-filesystem-tools-demo/src/main/java/org/springaicommunity/skills/Application.java
+++ b/examples/memory/memory-filesystem-tools-demo/src/main/java/org/springaicommunity/skills/Application.java
@@ -2,7 +2,6 @@ package org.springaicommunity.skills;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.List;
 import java.util.Scanner;
 
 import org.springaicommunity.agent.tools.FileSystemTools;
@@ -10,7 +9,6 @@ import org.springaicommunity.agent.tools.ShellTools;
 import org.springaicommunity.agent.utils.AgentEnvironment;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -63,8 +61,6 @@ public class Application {
 					FileSystemTools.builder().build())
 				
 				.defaultAdvisors(
-					// Tool Calling advisor
-					ToolCallAdvisor.builder().build(),
 					// Custom logging advisor
 					MyLoggingAdvisor.builder()
 						.showAvailableTools(false)

--- a/examples/memory/memory-filesystem-tools-demo/src/main/java/org/springaicommunity/skills/MyLoggingAdvisor.java
+++ b/examples/memory/memory-filesystem-tools-demo/src/main/java/org/springaicommunity/skills/MyLoggingAdvisor.java
@@ -1,8 +1,5 @@
 package org.springaicommunity.skills;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
@@ -10,9 +7,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.StringUtils;
 
 public class MyLoggingAdvisor implements BaseAdvisor {
@@ -46,11 +42,12 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 		if (this.showAvailableTools) {
 			Object tools = "No Tools";
 
-			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+					&& toolOptions.getToolCallbacks() != null) {
 				tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
 			}
 
-			sb.append("\n - TOOLS: " + ModelOptionsUtils.toJsonString(tools));
+			sb.append("\n - TOOLS: " + new JsonHelper().toJson(tools));
 		}
 
 		Message lastMessage = chatClientRequest.prompt().getLastUserOrToolResponseMessage();

--- a/examples/memory/memory-filesystem-tools-demo/src/main/resources/application.properties
+++ b/examples/memory/memory-filesystem-tools-demo/src/main/resources/application.properties
@@ -8,9 +8,9 @@ spring.ai.anthropic.chat.options.max-tokens=1000
 
 
 ## OpenAI SDK
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-spring.ai.openai-sdk.chat.options.temperature=1.0
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai.chat.options.temperature=1.0
 
 ## Google GenAI SDK
 spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}

--- a/examples/memory/memory-tools-advisor-demo/pom.xml
+++ b/examples/memory/memory-tools-advisor-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -43,7 +43,7 @@
 
 		<!-- <dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-openai-sdk</artifactId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency> -->
 
 		<dependency>

--- a/examples/memory/memory-tools-advisor-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/memory/memory-tools-advisor-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -9,13 +9,13 @@ import org.springaicommunity.agent.utils.AgentEnvironment;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
 import org.springframework.core.io.Resource;
 
 @SpringBootApplication
@@ -34,7 +34,7 @@ public class Application {
 			@Value("classpath:/prompt/MAIN_AGENT_SYSTEM_PROMPT_V2.md") Resource systemPrompt,
 			@Value("${agent.memory.dir}") String memoryDir) throws IOException {
 
-		return args -> {		
+		return args -> {
 
 			ChatClient chatClient = chatClientBuilder // @formatter:off
 				// system prompt
@@ -62,10 +62,8 @@ public class Application {
 						})
 						.build(),
 
-					// Tool Calling advisor
-					ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
-
-					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(100).build()).build(),
+					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(100).build())
+						.order(Ordered.HIGHEST_PRECEDENCE + 1000).build(),
 
 					// Custom logging advisor
 					MyLoggingAdvisor.builder()

--- a/examples/memory/memory-tools-advisor-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
+++ b/examples/memory/memory-tools-advisor-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
@@ -1,8 +1,5 @@
 package org.springaicommunity.agent;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
@@ -10,9 +7,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.StringUtils;
 
 public class MyLoggingAdvisor implements BaseAdvisor {
@@ -50,11 +46,12 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 		if (this.showAvailableTools) {
 			Object tools = "No Tools";
 
-			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+					&& toolOptions.getToolCallbacks() != null) {
 				tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
 			}
 
-			sb.append("\n - TOOLS: " + ModelOptionsUtils.toJsonString(tools));
+			sb.append("\n - TOOLS: " + new JsonHelper().toJson(tools));
 		}
 
 		Message lastMessage = chatClientRequest.prompt().getLastUserOrToolResponseMessage();

--- a/examples/memory/memory-tools-demo/pom.xml
+++ b/examples/memory/memory-tools-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -43,7 +43,7 @@
 
 		<!-- <dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-openai-sdk</artifactId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency> -->
 
 		<dependency>

--- a/examples/memory/memory-tools-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/memory/memory-tools-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -9,7 +9,6 @@ import org.springaicommunity.agent.tools.TodoWriteTool;
 import org.springaicommunity.agent.utils.AgentEnvironment;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -61,8 +60,6 @@ public class Application {
 				)
 				
 				.defaultAdvisors(
-					// Tool Calling advisor
-					ToolCallAdvisor.builder().build(),
 					// Custom logging advisor
 					MyLoggingAdvisor.builder()
 						.showAvailableTools(false)

--- a/examples/memory/memory-tools-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
+++ b/examples/memory/memory-tools-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
@@ -1,8 +1,5 @@
 package org.springaicommunity.agent;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
@@ -10,9 +7,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.StringUtils;
 
 public class MyLoggingAdvisor implements BaseAdvisor {
@@ -50,11 +46,12 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 		if (this.showAvailableTools) {
 			Object tools = "No Tools";
 
-			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+					&& toolOptions.getToolCallbacks() != null) {
 				tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
 			}
 
-			sb.append("\n - TOOLS: " + ModelOptionsUtils.toJsonString(tools));
+			sb.append("\n - TOOLS: " + new JsonHelper().toJson(tools));
 		}
 
 		Message lastMessage = chatClientRequest.prompt().getLastUserOrToolResponseMessage();

--- a/examples/memory/memory-tools-demo/src/main/resources/application.properties
+++ b/examples/memory/memory-tools-demo/src/main/resources/application.properties
@@ -8,9 +8,9 @@ spring.ai.anthropic.chat.options.max-tokens=1000
 
 
 ## OpenAI SDK
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-spring.ai.openai-sdk.chat.options.temperature=1.0
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai.chat.options.temperature=1.0
 
 ## Google GenAI SDK
 spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}

--- a/examples/skills-demo/pom.xml
+++ b/examples/skills-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -43,7 +43,7 @@
 
 		<!-- <dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-openai-sdk</artifactId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency> -->
 
 		<!-- <dependency>

--- a/examples/skills-demo/src/main/java/org/springaicommunity/skills/Application.java
+++ b/examples/skills-demo/src/main/java/org/springaicommunity/skills/Application.java
@@ -10,7 +10,6 @@ import org.springaicommunity.agent.tools.SkillsTool;
 import org.springaicommunity.agent.tools.SmartWebFetchTool;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -35,7 +34,7 @@ public class Application {
 				.defaultSystem("Always use the available skills to assist the user in their requests.")
 
 				// Skills tool
-				.defaultToolCallbacks(SkillsTool.builder().addSkillsResources(agentSkillsDirs).build())
+				.defaultTools(SkillsTool.builder().addSkillsResources(agentSkillsDirs).build())
 
 				// Built-in tools
 				.defaultTools(
@@ -51,8 +50,6 @@ public class Application {
 				
 				
 				.defaultAdvisors(
-					// Tool Calling advisor
-					ToolCallAdvisor.builder().build(),
 					// Custom logging advisor
 					MyLoggingAdvisor.builder()
 						.showAvailableTools(false)
@@ -63,11 +60,11 @@ public class Application {
 
 			var answer = chatClient
 				.prompt("""
-					Explain reinforcement learning in simple terms and use.
-					Use required skills.
-					Then use the Youtube video https://youtu.be/vXtfdGphr3c?si=xy8U2Al_Um5vE4Jd transcript to support your answer.
-					Use absolute paths for the skills and scripts. Do not ask me for more details.
-					""")
+						Explain reinforcement learning in simple terms and use.
+						Use required skills.
+						Then use the Youtube video https://youtu.be/vXtfdGphr3c?si=xy8U2Al_Um5vE4Jd transcript to support your answer.
+						Use absolute paths for the skills and scripts. Do not ask me for more details.
+						""")
 				.call()
 				.content();
 

--- a/examples/skills-demo/src/main/java/org/springaicommunity/skills/MyLoggingAdvisor.java
+++ b/examples/skills-demo/src/main/java/org/springaicommunity/skills/MyLoggingAdvisor.java
@@ -1,8 +1,5 @@
 package org.springaicommunity.skills;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
@@ -10,9 +7,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
-import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 import org.springframework.util.StringUtils;
 
 public class MyLoggingAdvisor implements BaseAdvisor {
@@ -46,11 +42,12 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 		if (this.showAvailableTools) {
 			Object tools = "No Tools";
 
-			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+					&& toolOptions.getToolCallbacks() != null) {
 				tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
 			}
 
-			sb.append("\n - TOOLS: " + ModelOptionsUtils.toJsonString(tools));
+			sb.append("\n - TOOLS: " + new JsonHelper().toJson(tools));
 		}
 
 		Message lastMessage = chatClientRequest.prompt().getLastUserOrToolResponseMessage();

--- a/examples/skills-demo/src/main/resources/application.properties
+++ b/examples/skills-demo/src/main/resources/application.properties
@@ -8,9 +8,9 @@ spring.ai.anthropic.chat.options.max-tokens=1000
 
 
 ## OpenAI SDK
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-spring.ai.openai-sdk.chat.options.temperature=1.0
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai.chat.options.temperature=1.0
 
 ## Google GenAI SDK
 spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}

--- a/examples/subagent-a2a-demo/pom.xml
+++ b/examples/subagent-a2a-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 		<a2a.sdk.version>0.3.3.Final</a2a.sdk.version>
 	</properties>
 
@@ -42,13 +42,13 @@
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils-a2a</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- <dependency>

--- a/examples/subagent-a2a-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/subagent-a2a-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -23,7 +23,6 @@ import org.springaicommunity.agent.utils.AgentEnvironment;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
@@ -78,10 +77,10 @@ public class Application {
 					.param(AgentEnvironment.AGENT_MODEL_KNOWLEDGE_CUTOFF_KEY, agentModelKnowledgeCutoff))
 
 				// Sub-agent task tool callbacks
-				.defaultToolCallbacks(taskTools)
+				.defaultTools(taskTools)
 
 				// Agent Skills tool
-				.defaultToolCallbacks(SkillsTool.builder().addSkillsResources(skillPaths).build())
+				.defaultTools(SkillsTool.builder().addSkillsResources(skillPaths).build())
 				
 				.defaultTools(
 					// Task orchestration tools
@@ -97,7 +96,6 @@ public class Application {
 
 				// Advisors
 				.defaultAdvisors(
-					ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
 
 					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 						.order(Ordered.HIGHEST_PRECEDENCE + 1000)

--- a/examples/subagent-a2a-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
+++ b/examples/subagent-a2a-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
@@ -13,8 +13,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 
 public class MyLoggingAdvisor implements BaseAdvisor {
 
@@ -41,7 +41,8 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 	@Override
 	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
 		Object tools = "No Tools";
-		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+				&& toolOptions.getToolCallbacks() != null) {
 			tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
 		}
 		printUser("USER", chatClientRequest.prompt().getInstructions(), tools);
@@ -50,6 +51,9 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 
 	@Override
 	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResults() == null) {
+			return chatClientResponse;
+		}
 		printAssistant("ASSISTANT", chatClientResponse.chatResponse().getResults());
 		return chatClientResponse;
 	}
@@ -57,14 +61,15 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 	private void printUser(String label, List<Message> messages, Object tools) {
 		String mt = messages.stream()
 			.map(message -> message.getMessageType() == MessageType.SYSTEM ? " - SYSTEM "
-					: " - " + ModelOptionsUtils.toJsonString(message))
+					: " - " + new JsonHelper().toJson(message))
 			.collect(Collectors.joining("\n"));
-		logger.info("\n" + labelPrefix + " " + label + ":\n" + mt + "\n   TOOLS: " + ModelOptionsUtils.toJsonString(tools) + "\n");
+		logger.info(
+				"\n" + labelPrefix + " " + label + ":\n" + mt + "\n   TOOLS: " + new JsonHelper().toJson(tools) + "\n");
 	}
 
 	private void printAssistant(String label, List<Generation> generations) {
 		String gt = generations.stream()
-			.map(g -> " - " + ModelOptionsUtils.toJsonString(g.getOutput()))
+			.map(g -> " - " + new JsonHelper().toJson(g.getOutput()))
 			.collect(Collectors.joining("\n"));
 		logger.info("\n" + labelPrefix + " " + label + ":\n" + gt + "\n");
 	}

--- a/examples/subagent-a2a-demo/src/main/resources/application.properties
+++ b/examples/subagent-a2a-demo/src/main/resources/application.properties
@@ -6,10 +6,10 @@ spring.ai.anthropic.api-key=${ANTHROPIC_API_KEY}
 spring.ai.anthropic.chat.options.model=claude-sonnet-4-5-20250929
 
 ## OpenAI GPT
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-# spring.ai.openai-sdk.chat.options.model=gpt-5-nano-2025-08-07
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-spring.ai.openai-sdk.chat.options.temperature=1.0
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+# spring.ai.openai.chat.options.model=gpt-5-nano-2025-08-07
+spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai.chat.options.temperature=1.0
 
 ## Google Gemini
 spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}

--- a/examples/subagent-demo/pom.xml
+++ b/examples/subagent-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>
@@ -49,7 +49,7 @@
 
 		<!-- <dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-openai-sdk</artifactId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency> -->
 
 		<!-- <dependency>

--- a/examples/subagent-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/subagent-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -17,7 +17,6 @@ import org.springaicommunity.agent.utils.AgentEnvironment;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
@@ -65,18 +64,18 @@ public class Application {
 					.param(AgentEnvironment.AGENT_MODEL_KNOWLEDGE_CUTOFF_KEY, agentModelKnowledgeCutoff))
 
 				// sub-agent task tool callbacks
-				.defaultToolCallbacks(taskTools)
+				.defaultTools(taskTools)
 
 				// skills tool
-				// .defaultToolCallbacks(SkillsTool.builder().addSkillsResources(skillPaths).build())
+				.defaultTools(SkillsTool.builder().addSkillsResources(skillPaths).build())
 				
 				.defaultTools(
 					// task orchestration tools
-					// TodoWriteTool.builder().build(),
+					TodoWriteTool.builder().build(),
 
 					// common agentic tools
-					// GlobTool.builder().build(),
-					// GrepTool.builder().build(),
+					GlobTool.builder().build(),
+					GrepTool.builder().build(),
 					ShellTools.builder().build(),
 					FileSystemTools.builder().build(),
 
@@ -85,10 +84,6 @@ public class Application {
 
 				// Advisors
 				.defaultAdvisors(
-					ToolCallAdvisor.builder()
-						.conversationHistoryEnabled(false)
-						.build(), // tool calling advisor
-
 					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
 						.order(Ordered.HIGHEST_PRECEDENCE + 1000)
 						.build(),

--- a/examples/subagent-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
+++ b/examples/subagent-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
@@ -13,8 +13,8 @@ import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.MessageType;
 import org.springframework.ai.chat.model.Generation;
-import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
 
 public class MyLoggingAdvisor implements BaseAdvisor {
 
@@ -41,7 +41,8 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 	@Override
 	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
 		Object tools = "No Tools";
-		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions) {
+		if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+				&& toolOptions.getToolCallbacks() != null) {
 			tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
 		}
 		printUser("USER", chatClientRequest.prompt().getInstructions(), tools);
@@ -50,6 +51,9 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 
 	@Override
 	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResults() == null) {
+			return chatClientResponse;
+		}
 		printAssistant("ASSISTANT", chatClientResponse.chatResponse().getResults());
 		return chatClientResponse;
 	}
@@ -57,14 +61,15 @@ public class MyLoggingAdvisor implements BaseAdvisor {
 	private void printUser(String label, List<Message> messages, Object tools) {
 		String mt = messages.stream()
 			.map(message -> message.getMessageType() == MessageType.SYSTEM ? " - SYSTEM "
-					: " - " + ModelOptionsUtils.toJsonString(message))
+					: " - " + new JsonHelper().toJson(message))
 			.collect(Collectors.joining("\n"));
-		logger.info("\n" + labelPrefix + " " + label + ":\n" + mt + "\n   TOOLS: " + ModelOptionsUtils.toJsonString(tools) + "\n");
+		logger.info(
+				"\n" + labelPrefix + " " + label + ":\n" + mt + "\n   TOOLS: " + new JsonHelper().toJson(tools) + "\n");
 	}
 
 	private void printAssistant(String label, List<Generation> generations) {
 		String gt = generations.stream()
-			.map(g -> " - " + ModelOptionsUtils.toJsonString(g.getOutput()))
+			.map(g -> " - " + new JsonHelper().toJson(g.getOutput()))
 			.collect(Collectors.joining("\n"));
 		logger.info("\n" + labelPrefix + " " + label + ":\n" + gt + "\n");
 	}

--- a/examples/subagent-demo/src/main/resources/application.properties
+++ b/examples/subagent-demo/src/main/resources/application.properties
@@ -6,10 +6,10 @@ spring.ai.anthropic.api-key=${ANTHROPIC_API_KEY}
 spring.ai.anthropic.chat.options.model=claude-sonnet-4-5-20250929
 
 ## OpenAI GPT
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-# spring.ai.openai-sdk.chat.options.model=gpt-5-nano-2025-08-07
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-spring.ai.openai-sdk.chat.options.temperature=1.0
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+# spring.ai.openai.chat.options.model=gpt-5-nano-2025-08-07
+spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai.chat.options.temperature=1.0
 
 ## Google Gemini
 spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}

--- a/examples/todo-demo/pom.xml
+++ b/examples/todo-demo/pom.xml
@@ -20,7 +20,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<maven.deploy.skip>true</maven.deploy.skip>
-		<spring-ai.version>2.0.0-SNAPSHOT</spring-ai.version>
+		<spring-ai.version>2.0.0-RC1</spring-ai.version>
 	</properties>
 
 	<dependencies>
@@ -28,7 +28,7 @@
 		<dependency>
 			<groupId>org.springaicommunity</groupId>
 			<artifactId>spring-ai-agent-utils</artifactId>
-			<version>0.6.0</version>
+			<version>0.9.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- <dependency>

--- a/examples/todo-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/todo-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -11,7 +11,6 @@ import org.springaicommunity.agent.utils.AgentEnvironment;
 
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
@@ -21,6 +20,7 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 
@@ -62,8 +62,8 @@ public class Application {
 
 				// Advisors
 				.defaultAdvisors(
-					ToolCallAdvisor.builder().disableInternalConversationHistory().build(),
-					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build()) .build())
+					MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().maxMessages(500).build())
+					.order(Ordered.HIGHEST_PRECEDENCE + 1000).build())
 				.build();
 				// @formatter:on
 

--- a/examples/todo-demo/src/main/resources/application.properties
+++ b/examples/todo-demo/src/main/resources/application.properties
@@ -4,9 +4,9 @@ spring.main.web-application-type=none
 spring.ai.anthropic.api-key=${ANTHROPIC_API_KEY}
 spring.ai.anthropic.chat.options.model=claude-sonnet-4-5-20250929
 
-spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
-spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
-spring.ai.openai-sdk.chat.options.temperature=1.0
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+spring.ai.openai.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai.chat.options.temperature=1.0
 
 spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}
 # spring.ai.google.genai.location=${GOOGLE_CLOUD_LOCATION}

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 
-        <spring-ai.version>2.0.0-M7</spring-ai.version>
-        <spring-framework.version>7.0.1</spring-framework.version>
+        <spring-ai.version>2.0.0-RC1</spring-ai.version>
+        <spring-framework.version>7.0.7</spring-framework.version>
         <flexmark.version>0.64.8</flexmark.version>
     
 

--- a/spring-ai-agent-utils-a2a/README.md
+++ b/spring-ai-agent-utils-a2a/README.md
@@ -84,7 +84,7 @@ The resolver expects each A2A-compatible agent to expose an [Agent Card](https:/
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-agent-utils-a2a</artifactId>
-    <version>0.7.0</version>
+    <version>0.9.0</version>
 </dependency>
 ```
 

--- a/spring-ai-agent-utils-common/README.md
+++ b/spring-ai-agent-utils-common/README.md
@@ -79,7 +79,7 @@ TaskTool.builder()
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-agent-utils-common</artifactId>
-    <version>0.7.0</version>
+    <version>0.9.0</version>
 </dependency>
 ```
 

--- a/spring-ai-agent-utils/README.md
+++ b/spring-ai-agent-utils/README.md
@@ -45,7 +45,7 @@ While these tools can be used standalone, truly agentic behavior emerges when th
         <dependency>
             <groupId>org.springaicommunity</groupId>
             <artifactId>spring-ai-agent-utils-bom</artifactId>
-            <version>0.7.0</version>
+            <version>0.9.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -65,13 +65,13 @@ While these tools can be used standalone, truly agentic behavior emerges when th
 <dependency>
     <groupId>org.springaicommunity</groupId>
     <artifactId>spring-ai-agent-utils</artifactId>
-    <version>0.7.0</version>
+    <version>0.9.0</version>
 </dependency>
 ```
 
 _Check the latest version:_ [![](https://img.shields.io/maven-central/v/org.springaicommunity/spring-ai-agent-utils.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/org.springaicommunity/spring-ai-agent-utils)
 
-> **Note:** You need Spring AI version `2.0.0-M4` or later.
+> **Note:** You need Spring AI version `2.0.0-RC1` or later.
 
 
 ## Quick Start

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/AutoMemoryToolsAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/AutoMemoryToolsAdvisor.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiPredicate;
 
@@ -77,9 +78,9 @@ public class AutoMemoryToolsAdvisor implements BaseChatMemoryAdvisor {
 								? "<system-reminder>Consolidate the long-term memory by summarizing and removing redundant information.</system-reminder>"
 								: ""));
 
-			ToolCallingChatOptions toolOptionsCopy = toolOptions.copy();
+			ToolCallingChatOptions toolOptionsCopy = toolOptions.mutate().build();
 
-			List<ToolCallback> toolCallbacks = new ArrayList<>(toolOptionsCopy.getToolCallbacks());
+			List<ToolCallback> toolCallbacks = new ArrayList<>(Objects.requireNonNullElse(toolOptionsCopy.getToolCallbacks(), List.of()));
 
 			Set<String> existingNames = toolCallbacks.stream()
 				.map(tc -> tc.getToolDefinition().name())

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/AutoMemoryToolsAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/AutoMemoryToolsAdvisorTest.java
@@ -145,7 +145,7 @@ class AutoMemoryToolsAdvisorTest {
 		@Test
 		@DisplayName("Injects memory prompt when ToolCallingChatOptions present")
 		void injectsWithToolCallingOptions() {
-			Prompt prompt = new Prompt(List.of(new UserMessage("hi")), new DefaultToolCallingChatOptions());
+			Prompt prompt = new Prompt(List.of(new UserMessage("hi")), DefaultToolCallingChatOptions.builder().build());
 			ChatClientRequest request = request(prompt);
 
 			ChatClientRequest result = advisor("MEMORY_INSTRUCTIONS").before(request, advisorChain);
@@ -157,7 +157,7 @@ class AutoMemoryToolsAdvisorTest {
 		@DisplayName("Preserves existing system message text")
 		void preservesExistingSystemText() {
 			Prompt prompt = new Prompt(List.of(new SystemMessage("ORIGINAL"), new UserMessage("hi")),
-					new DefaultToolCallingChatOptions());
+					DefaultToolCallingChatOptions.builder().build());
 			ChatClientRequest request = request(prompt);
 
 			ChatClientRequest result = advisor("APPENDED").before(request, advisorChain);
@@ -179,7 +179,7 @@ class AutoMemoryToolsAdvisorTest {
 		@Test
 		@DisplayName("No consolidation reminder when trigger returns false (default)")
 		void noReminderByDefault() {
-			Prompt prompt = new Prompt(new UserMessage("hi"), new DefaultToolCallingChatOptions());
+			Prompt prompt = new Prompt(new UserMessage("hi"), DefaultToolCallingChatOptions.builder().build());
 			ChatClientRequest request = request(prompt);
 
 			ChatClientRequest result = advisor("MEMORY_PROMPT").before(request, advisorChain);
@@ -197,7 +197,7 @@ class AutoMemoryToolsAdvisorTest {
 				.memoryConsolidationTrigger((req, instant) -> true)
 				.build();
 
-			Prompt prompt = new Prompt(new UserMessage("hi"), new DefaultToolCallingChatOptions());
+			Prompt prompt = new Prompt(new UserMessage("hi"), DefaultToolCallingChatOptions.builder().build());
 			ChatClientRequest result = a.before(request(prompt), advisorChain);
 
 			assertThat(result.prompt().getSystemMessage().getText()).contains("Consolidate")
@@ -220,7 +220,7 @@ class AutoMemoryToolsAdvisorTest {
 				})
 				.build();
 
-			Prompt prompt = new Prompt(new UserMessage("hi"), new DefaultToolCallingChatOptions());
+			Prompt prompt = new Prompt(new UserMessage("hi"), DefaultToolCallingChatOptions.builder().build());
 			ChatClientRequest originalRequest = request(prompt);
 			a.before(originalRequest, advisorChain);
 
@@ -241,7 +241,7 @@ class AutoMemoryToolsAdvisorTest {
 		@Test
 		@DisplayName("Registers memory tools when ToolCallingChatOptions present")
 		void registersMemoryTools() {
-			Prompt prompt = new Prompt(new UserMessage("hi"), new DefaultToolCallingChatOptions());
+			Prompt prompt = new Prompt(new UserMessage("hi"), DefaultToolCallingChatOptions.builder().build());
 			ChatClientRequest request = request(prompt);
 
 			ChatClientRequest result = advisor("prompt").before(request, advisorChain);
@@ -253,7 +253,7 @@ class AutoMemoryToolsAdvisorTest {
 		@Test
 		@DisplayName("Registers all six MemoryTools by name")
 		void registersAllSixMemoryTools() {
-			Prompt prompt = new Prompt(new UserMessage("hi"), new DefaultToolCallingChatOptions());
+			Prompt prompt = new Prompt(new UserMessage("hi"), DefaultToolCallingChatOptions.builder().build());
 			ChatClientRequest request = request(prompt);
 
 			ChatClientRequest result = advisor("prompt").before(request, advisorChain);
@@ -281,7 +281,7 @@ class AutoMemoryToolsAdvisorTest {
 			AutoMemoryToolsAdvisor a = advisor("prompt");
 
 			// First pass: collect the memory callbacks the advisor registers
-			Prompt first = new Prompt(new UserMessage("hi"), new DefaultToolCallingChatOptions());
+			Prompt first = new Prompt(new UserMessage("hi"), DefaultToolCallingChatOptions.builder().build());
 			List<ToolCallback> memoryCallbacks = ((DefaultToolCallingChatOptions) a.before(request(first), advisorChain)
 				.prompt()
 				.getOptions()).getToolCallbacks();


### PR DESCRIPTION
- Bump spring-ai to 2.0.0-RC1, spring-framework to 7.0.7, library to 0.9.0
- Remove ToolCallAdvisor (now auto-configured by the framework)
- Replace defaultToolCallbacks() with defaultTools()
- Replace ModelOptionsUtils.toJsonString() with JsonHelper.toJson()
- Rename spring.ai.openai-sdk.* properties to spring.ai.openai.*
- Replace toolOptions.copy() with mutate().build() in AutoMemoryToolsAdvisor
- Add null guard for getToolCallbacks() in all MyLoggingAdvisor copies
- Add null guard for chatResponse() in subagent MyLoggingAdvisor.after()
- Add migration guide docs/tools/migration-0.9.md