### PR TITLE
feat: Add ToolContext to AskUserQuestionTool and TodoWriteTool

### DIFF
--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/AskUserQuestionTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/AskUserQuestionTool.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.util.json.JsonParser;
@@ -53,6 +54,7 @@ import org.springframework.util.Assert;
  * has to be set for this behavior.
  *
  * @author Christian Tzolov
+ * @author zz_zhi
  * @see <a href=
  * "https://platform.claude.com/docs/en/agent-sdk/user-input#question-format"> Claude
  * Agent SDK - Question Format</a>
@@ -75,7 +77,13 @@ public class AskUserQuestionTool {
 	 */
 	@FunctionalInterface
 	public interface QuestionHandler {
+
 		Map<String, String> handle(List<Question> questions);
+
+		default Map<String, String> handle(List<Question> questions, ToolContext toolContext) {
+			return handle(questions);
+		}
+
 	}
 
 	private final QuestionHandler questionHandler;
@@ -191,7 +199,8 @@ public class AskUserQuestionTool {
 	public String askUserQuestion(
 			@ToolParam(description = "Questions to ask the user (1-4 questions)") List<Question> questions,
 			@ToolParam(description = "User answers collected by the permission component",
-					required = false) Map<String, String> answers) {
+					required = false) Map<String, String> answers,
+			ToolContext toolContext) {
 
 		// Validate the questions list
 		this.validateQuestions(questions);
@@ -201,7 +210,7 @@ public class AskUserQuestionTool {
 			questions.forEach(q -> logger.trace("Question: {}", q.question()));
 		}
 
-		Map<String, String> result = this.questionHandler.handle(questions);
+		Map<String, String> result = this.questionHandler.handle(questions, toolContext);
 
 		// Validate the answer map
 		if (this.answersValidation) {
@@ -213,6 +222,14 @@ public class AskUserQuestionTool {
 		}
 
 		return "User has answered your questions: " + JsonParser.toJson(result);
+	}
+
+	/**
+	 * Backward-compatible overload without {@link ToolContext}. Delegates to
+	 * {@link #askUserQuestion(List, Map, ToolContext)} with a {@code null} context.
+	 */
+	public String askUserQuestion(List<Question> questions, Map<String, String> answers) {
+		return askUserQuestion(questions, answers, null);
 	}
 
 	/**

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/TodoWriteTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/TodoWriteTool.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.annotation.Tool;
 
 /**
@@ -31,6 +32,7 @@ import org.springframework.ai.tool.annotation.Tool;
  * time and that all task data is properly formatted.
  *
  * @author Christian Tzolov
+ * @author zz_zhi
  */
 public class TodoWriteTool {
 
@@ -42,6 +44,10 @@ public class TodoWriteTool {
 	public interface TodoEventHandler {
 
 		void handle(Todos todos);
+
+		default void handle(Todos todos, ToolContext toolContext) {
+			handle(todos);
+		}
 
 	}
 
@@ -241,14 +247,22 @@ public class TodoWriteTool {
 
 		When in doubt, use this tool. Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully.
 		""")
-	public String todoWrite(Todos todos) { // @formatter:on
+	public String todoWrite(Todos todos, ToolContext toolContext) { // @formatter:on
 
 		// Validate the todos
 		this.validateTodos(todos);
 
-		this.todoListConsumer.handle(todos);
+		this.todoListConsumer.handle(todos, toolContext);
 
 		return "Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable";
+	}
+
+	/**
+	 * Backward-compatible overload without {@link ToolContext}. Delegates to
+	 * {@link #todoWrite(Todos, ToolContext)} with a {@code null} context.
+	 */
+	public String todoWrite(Todos todos) {
+		return todoWrite(todos, null);
 	}
 
 	/**

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/AskUserQuestionToolTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/AskUserQuestionToolTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.springaicommunity.agent.tools.AskUserQuestionTool.Question;
 import org.springaicommunity.agent.tools.AskUserQuestionTool.Question.Option;
 
+import org.springframework.ai.chat.model.ToolContext;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -40,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for {@link AskUserQuestionTool}.
  *
  * @author Christian Tzolov
+ * @author zz_zhi
  */
 @DisplayName("AskUserQuestionTool Tests")
 class AskUserQuestionToolTest {
@@ -600,6 +603,103 @@ class AskUserQuestionToolTest {
 			executor.shutdown();
 
 			assertThat(callCount.get()).isEqualTo(threadCount);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("ToolContext Tests")
+	class ToolContextTests {
+
+		@Test
+		@DisplayName("Should pass ToolContext to QuestionHandler")
+		void shouldPassToolContextToQuestionHandler() {
+			AtomicReference<ToolContext> capturedContext = new AtomicReference<>();
+			AskUserQuestionTool.QuestionHandler handler = new AskUserQuestionTool.QuestionHandler() {
+				@Override
+				public Map<String, String> handle(List<Question> questions) {
+					Map<String, String> answers = new HashMap<>();
+					for (Question q : questions) {
+						answers.put(q.question(), q.options().get(0).label());
+					}
+					return answers;
+				}
+
+				@Override
+				public Map<String, String> handle(List<Question> questions, ToolContext toolContext) {
+					capturedContext.set(toolContext);
+					return handle(questions);
+				}
+			};
+			AskUserQuestionTool contextTool = AskUserQuestionTool.builder().questionHandler(handler).build();
+
+			List<Option> options = List.of(new Option("A", "First"), new Option("B", "Second"));
+			List<Question> questions = List.of(new Question("Question?", "Header", options, false));
+			ToolContext toolContext = new ToolContext(Map.of("key", "value"));
+
+			String result = contextTool.askUserQuestion(questions, null, toolContext);
+
+			assertThat(result).isNotNull();
+			assertThat(capturedContext.get()).isSameAs(toolContext);
+			assertThat(capturedContext.get().getContext()).containsEntry("key", "value");
+		}
+
+		@Test
+		@DisplayName("Should pass null ToolContext when using overloaded method")
+		void shouldPassNullToolContextWhenUsingOverloadedMethod() {
+			AtomicReference<ToolContext> capturedContext = new AtomicReference<>();
+			AskUserQuestionTool.QuestionHandler handler = new AskUserQuestionTool.QuestionHandler() {
+				@Override
+				public Map<String, String> handle(List<Question> questions) {
+					Map<String, String> answers = new HashMap<>();
+					for (Question q : questions) {
+						answers.put(q.question(), q.options().get(0).label());
+					}
+					return answers;
+				}
+
+				@Override
+				public Map<String, String> handle(List<Question> questions, ToolContext toolContext) {
+					capturedContext.set(toolContext);
+					return handle(questions);
+				}
+			};
+			AskUserQuestionTool contextTool = AskUserQuestionTool.builder().questionHandler(handler).build();
+
+			List<Option> options = List.of(new Option("A", "First"), new Option("B", "Second"));
+			List<Question> questions = List.of(new Question("Question?", "Header", options, false));
+
+			String result = contextTool.askUserQuestion(questions, null);
+
+			assertThat(result).isNotNull();
+			assertThat(capturedContext.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("Should work with old-style QuestionHandler lambda (backward compatibility)")
+		void shouldWorkWithOldStyleQuestionHandlerLambda() {
+			// Old-style lambda: questions -> ... (single argument)
+			AtomicReference<List<Question>> capturedQuestions = new AtomicReference<>();
+			AskUserQuestionTool oldStyleTool = AskUserQuestionTool.builder()
+				.questionHandler(questions -> {
+					capturedQuestions.set(questions);
+					Map<String, String> answers = new HashMap<>();
+					for (Question q : questions) {
+						answers.put(q.question(), q.options().get(0).label());
+					}
+					return answers;
+				})
+				.build();
+
+			List<Option> options = List.of(new Option("A", "First"), new Option("B", "Second"));
+			List<Question> questions = List.of(new Question("Question?", "Header", options, false));
+			ToolContext toolContext = new ToolContext(Map.of("key", "value"));
+
+			String result = oldStyleTool.askUserQuestion(questions, null, toolContext);
+
+			assertThat(result).isNotNull();
+			assertThat(result).contains("User has answered your questions");
+			assertThat(capturedQuestions.get()).hasSize(1);
 		}
 
 	}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/TodoWriteToolTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/TodoWriteToolTest.java
@@ -17,6 +17,7 @@ package org.springaicommunity.agent.tools;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,8 @@ import org.springaicommunity.agent.tools.TodoWriteTool.Todos;
 import org.springaicommunity.agent.tools.TodoWriteTool.Todos.Status;
 import org.springaicommunity.agent.tools.TodoWriteTool.Todos.TodoItem;
 
+import org.springframework.ai.chat.model.ToolContext;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for {@link TodoWriteTool}.
  *
  * @author Christian Tzolov
+ * @author zz_zhi
  */
 @DisplayName("TodoWriteTool Tests")
 class TodoWriteToolTest {
@@ -385,6 +389,83 @@ class TodoWriteToolTest {
 			String result = TodoWriteToolTest.this.tool.todoWrite(todos4);
 
 			assertThat(result).contains("Todos have been modified successfully");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("ToolContext Tests")
+	class ToolContextTests {
+
+		@Test
+		@DisplayName("Should pass ToolContext to TodoEventHandler")
+		void shouldPassToolContextToTodoEventHandler() {
+			AtomicReference<ToolContext> capturedContext = new AtomicReference<>();
+			TodoWriteTool.TodoEventHandler handler = new TodoWriteTool.TodoEventHandler() {
+				@Override
+				public void handle(Todos todos) {
+					// no-op
+				}
+
+				@Override
+				public void handle(Todos todos, ToolContext toolContext) {
+					capturedContext.set(toolContext);
+				}
+			};
+			TodoWriteTool contextTool = TodoWriteTool.builder().todoEventHandler(handler).build();
+
+			List<TodoItem> items = List.of(new TodoItem("Task 1", Status.pending, "Doing task 1"));
+			Todos todos = new Todos(items);
+			ToolContext toolContext = new ToolContext(Map.of("channelId", "test-channel"));
+
+			contextTool.todoWrite(todos, toolContext);
+
+			assertThat(capturedContext.get()).isSameAs(toolContext);
+			assertThat(capturedContext.get().getContext()).containsEntry("channelId", "test-channel");
+		}
+
+		@Test
+		@DisplayName("Should pass null ToolContext when using overloaded method")
+		void shouldPassNullToolContextWhenUsingOverloadedMethod() {
+			AtomicReference<ToolContext> capturedContext = new AtomicReference<>();
+			TodoWriteTool.TodoEventHandler handler = new TodoWriteTool.TodoEventHandler() {
+				@Override
+				public void handle(Todos todos) {
+					// no-op
+				}
+
+				@Override
+				public void handle(Todos todos, ToolContext toolContext) {
+					capturedContext.set(toolContext);
+				}
+			};
+			TodoWriteTool contextTool = TodoWriteTool.builder().todoEventHandler(handler).build();
+
+			List<TodoItem> items = List.of(new TodoItem("Task 1", Status.pending, "Doing task 1"));
+			Todos todos = new Todos(items);
+
+			contextTool.todoWrite(todos);
+
+			assertThat(capturedContext.get()).isNull();
+		}
+
+		@Test
+		@DisplayName("Should work with old-style TodoEventHandler lambda (backward compatibility)")
+		void shouldWorkWithOldStyleTodoEventHandlerLambda() {
+			// Old-style lambda: todos -> ... (single argument)
+			AtomicReference<Todos> capturedTodos = new AtomicReference<>();
+			TodoWriteTool oldStyleTool = TodoWriteTool.builder()
+				.todoEventHandler(capturedTodos::set)
+				.build();
+
+			List<TodoItem> items = List.of(new TodoItem("Task 1", Status.pending, "Doing task 1"));
+			Todos todos = new Todos(items);
+			ToolContext toolContext = new ToolContext(Map.of("key", "value"));
+
+			String result = oldStyleTool.todoWrite(todos, toolContext);
+
+			assertThat(result).contains("Todos have been modified successfully");
+			assertThat(capturedTodos.get()).isEqualTo(todos);
 		}
 
 	}


### PR DESCRIPTION
## Changes

Add Spring AI `ToolContext` support to `AskUserQuestionTool` and `TodoWriteTool`, enabling tool methods to receive context information.

### Details

- Add `ToolContext` parameter to `askUserQuestion` and `todoWrite` methods
- Add default `ToolContext`-aware methods to `QuestionHandler` and `TodoEventHandler` interfaces, keeping the original single-arg methods as abstract for `@FunctionalInterface` backward compatibility
- Add backward-compatible overloaded methods without `ToolContext`

### Backward Compatibility

- Existing implementations like `CommandLineQuestionHandler` remain unchanged and still work as lambdas
- All existing test cases are preserved, new ToolContext tests added