### PR TITLE
Add CronTools for scheduling agent prompts via cron expressions

### DIFF
--- a/spring-ai-agent-utils/docs/CronTools.md
+++ b/spring-ai-agent-utils/docs/CronTools.md
@@ -1,0 +1,137 @@
+# CronTools
+
+Schedule prompts to be enqueued at future times using standard 5-field cron expressions. Supports recurring and one-shot tasks, durable (file-persisted) and session-only tasks.
+
+Reference: [Claude Code Cron](https://code.claude.com/docs/en/settings#tools-available-to-claude)
+
+## Quick Start
+
+```java
+ChatClient chatClient = chatClientBuilder
+    .defaultTools(CronTools.builder().build())
+    .defaultAdvisors(
+        ToolCallAdvisor.builder().conversationHistoryEnabled(false).build(),
+        MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
+    .build();
+```
+
+## Tools
+
+### CronCreate
+
+Schedule a new cron job. Returns a job ID for use with `CronDelete`.
+
+```
+@Tool(name = "CronCreate")
+```
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `cron` | yes | — | Standard 5-field cron: `M H DoM Mon DoW` |
+| `prompt` | yes | — | The prompt to enqueue at each fire time |
+| `recurring` | no | `true` | `true` = fire on every match until deleted; `false` = fire once then auto-delete |
+| `durable` | no | `false` | `true` = persist to file and survive restarts |
+
+**Cron expression format:** `minute hour day-of-month month day-of-week`
+
+Examples:
+- `*/5 * * * *` — Every 5 minutes
+- `0 9 * * *` — Daily at 9:00 AM
+- `0 9 * * 1-5` — Weekdays at 9:00 AM
+- `30 14 28 2 *` — Feb 28 at 2:30 PM (one-shot)
+
+### CronDelete
+
+Cancel a previously scheduled cron job.
+
+```
+@Tool(name = "CronDelete")
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `id` | yes | Job ID returned by `CronCreate` |
+
+### CronList
+
+List all scheduled cron jobs (both durable and session-only).
+
+```
+@Tool(name = "CronList")
+```
+
+No parameters required.
+
+## Task Types
+
+| Type | Storage | Lifecycle |
+|------|---------|-----------|
+| Session-only | In-memory | Dies when process exits |
+| Durable | `.claude/scheduled_tasks.json` (NDJSON) | Survives restarts; recurring auto-expires after 7 days |
+
+## Durable Persistence
+
+```java
+// With durable persistence enabled
+CronTools cronTools = CronTools.builder()
+    .durableTasksFile(Path.of(".claude/scheduled_tasks.json"))
+    .build();
+```
+
+Durable tasks are persisted in NDJSON format (one JSON object per line):
+
+```jsonl
+{"id":"abc123","cron":"0 9 * * 1-5","prompt":"standup reminder","recurring":true,"durable":true,"nextFireTime":"2026-06-01T09:00:00Z","createdAt":"2026-05-31T00:00:00Z"}
+```
+
+On startup, durable tasks are restored from the file:
+- **One-shot tasks** whose fire time has passed fire immediately (catch-up).
+- **Recurring tasks** get their next future fire time calculated from now.
+
+## Custom Event Handler
+
+By default, fired tasks are logged. Provide a custom handler to enqueue the prompt back into a `ChatClient` or publish events:
+
+```java
+CronTools cronTools = CronTools.builder()
+    .eventHandler(task -> {
+        // Feed the prompt back into the agent
+        String response = chatClient.prompt(task.prompt()).call().content();
+        return response;
+    })
+    .build();
+```
+
+## Jitter
+
+To avoid thundering-herd effects, recurring tasks whose minute field is exactly `0` or `30` receive a small random offset (±2 minutes). Interval-based schedules (`*/5`) and schedules with other minute values are not jittered.
+
+## Architecture
+
+```
+CronTools (@Tool methods)
+  ├── CronScheduler (single-threaded scheduling engine)
+  │     └── PriorityBlockingQueue<CronTask> (ordered by nextFireTime)
+  ├── CronTaskStore (NDJSON file persistence)
+  └── CronEventHandler (fire-time callback)
+```
+
+The scheduler runs as a single daemon thread that:
+1. Peeks at the earliest upcoming task
+2. Sleeps until its fire time (with `Object.wait()`)
+3. Fires the task via the event handler
+4. Re-enqueues recurring tasks with their next fire time
+
+New tasks and cancellations wake the scheduler via `Object.notify()`.
+
+## Best Practices
+
+1. **Default to session-only** — Most "remind me in 5 minutes" tasks don't need durability
+2. **Avoid :00 and :30** — Pick off-peak minutes (e.g., `3` or `57`) to spread load
+3. **One-shot for reminders** — Use `recurring: false` for one-time reminders
+4. **Durable for persistence** — Only use `durable: true` when explicitly asked
+
+## See Also
+
+- [Claude Code Cron Documentation](https://code.claude.com/docs/en/settings#tools-available-to-claude)
+- [Linux Crontab(5)](https://man7.org/linux/man-pages/man5/crontab.5.html)

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/CronTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/CronTools.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.agent.tools.cron.CronEventHandler;
+import org.springaicommunity.agent.tools.cron.CronScheduler;
+import org.springaicommunity.agent.tools.cron.CronTask;
+import org.springaicommunity.agent.tools.cron.CronTaskStore;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.scheduling.support.CronExpression;
+
+/**
+ * Spring AI tool implementation of cron-based task scheduling.
+ *
+ * <p>
+ * Exposes three tools ({@code CronCreate}, {@code CronDelete}, and
+ * {@code CronList}) that allow an agent to schedule prompts to be enqueued at
+ * future times using standard 5-field cron expressions. Supports recurring and
+ * one-shot tasks, durable (file-persisted) and session-only tasks, jitter for
+ * common top-of-the-hour schedules, and automatic expiry of durable recurring
+ * tasks after 7 days.
+ *
+ * @author Christian Tzolov
+ */
+public class CronTools implements AutoCloseable {
+
+	private static final Logger logger = LoggerFactory.getLogger(CronTools.class);
+
+	private final CronScheduler scheduler;
+
+	private final CronEventHandler eventHandler;
+
+	private final CronTaskStore taskStore;
+
+	private final Path durableTasksFile;
+
+	private final AtomicBoolean closed = new AtomicBoolean(false);
+
+	protected CronTools(CronEventHandler eventHandler, Path durableTasksFile) {
+		this.eventHandler = eventHandler;
+		this.durableTasksFile = durableTasksFile;
+		this.taskStore = durableTasksFile != null ? new CronTaskStore(durableTasksFile) : null;
+		this.scheduler = new CronScheduler(wrapEventHandler(eventHandler));
+		this.scheduler.start();
+		if (this.taskStore != null) {
+			loadDurableTasks();
+		}
+	}
+
+	private CronEventHandler wrapEventHandler(CronEventHandler handler) {
+		return task -> {
+			String result = handler.handle(task);
+			if (task.durable()) {
+				saveDurableTasks();
+			}
+			return result;
+		};
+	}
+
+	private void loadDurableTasks() {
+		List<CronTask> tasks = taskStore.load();
+		for (CronTask task : tasks) {
+			Instant nextFireTime = computeInitialNextFireTime(task);
+			if (nextFireTime == null) {
+				logger.info("Skipping expired durable task: {}", task.id());
+				continue;
+			}
+			scheduler.schedule(task.withNextFireTime(nextFireTime));
+		}
+		saveDurableTasks();
+	}
+
+	private Instant computeInitialNextFireTime(CronTask task) {
+		if (task.recurring()) {
+			return computeNextFromCron(task.cron());
+		}
+		// One-shot: preserve existing future fire time, otherwise compute from cron.
+		if (task.nextFireTime() != null && task.nextFireTime().isAfter(Instant.now())) {
+			return task.nextFireTime();
+		}
+		return task.nextFireTime() != null ? task.nextFireTime() : computeNextFromCron(task.cron());
+	}
+
+	private Instant computeNextFromCron(String cron) {
+		CronExpression expr = CronExpression.parse(CronScheduler.toSixField(cron));
+		ZonedDateTime next = expr.next(ZonedDateTime.now());
+		if (next == null) {
+			return null;
+		}
+		return CronScheduler.applyJitter(cron, next.toInstant());
+	}
+
+	private synchronized void saveDurableTasks() {
+		if (taskStore == null) {
+			return;
+		}
+		List<CronTask> durable = scheduler.listAll().stream().filter(CronTask::durable).toList();
+		if (durable.isEmpty()) {
+			taskStore.delete();
+		}
+		else {
+			taskStore.save(durable);
+		}
+	}
+
+	// @formatter:off
+	@Tool(name = "CronCreate", description = """
+		Schedule a new cron job. Returns a job ID for use with CronDelete.
+
+		Parameters:
+		- cron: Standard 5-field cron expression (minute hour day-of-month month day-of-week).
+		- prompt: The prompt to enqueue at each fire time.
+		- recurring: Optional. true = fire on every match until deleted (default); false = fire once then auto-delete.
+		- durable: Optional. true = persist to file and survive restarts; false = session-only (default).
+
+		Cron expression format: minute hour day-of-month month day-of-week
+		Examples:
+		- */5 * * * * — Every 5 minutes
+		- 0 9 * * * — Daily at 9:00 AM
+		- 0 9 * * 1-5 — Weekdays at 9:00 AM
+		- 30 14 28 2 * — Feb 28 at 2:30 PM (one-shot)
+		""")
+	public String cronCreate(
+			@ToolParam(description = "Standard 5-field cron expression: minute hour day-of-month month day-of-week") String cron,
+			@ToolParam(description = "The prompt to enqueue at each fire time") String prompt,
+			@ToolParam(description = "true = recurring, false = one-shot; defaults to true", required = false) Boolean recurring,
+			@ToolParam(description = "true = persist across restarts, false = session-only; defaults to false", required = false) Boolean durable) { // @formatter:on
+
+		if (cron == null || cron.isBlank()) {
+			return "Error: cron expression is required";
+		}
+		if (prompt == null || prompt.isBlank()) {
+			return "Error: prompt is required";
+		}
+
+		String normalizedCron = cron.trim();
+		try {
+			CronExpression.parse(CronScheduler.toSixField(normalizedCron));
+		}
+		catch (Exception e) {
+			return "Error: invalid cron expression '" + normalizedCron + "'";
+		}
+
+		boolean isRecurring = recurring == null || recurring;
+		boolean isDurable = durable != null && durable;
+		String id = "cron_" + UUID.randomUUID().toString().substring(0, 8);
+		Instant createdAt = Instant.now();
+		Instant nextFireTime = computeNextFromCron(normalizedCron);
+		if (nextFireTime == null) {
+			return "Error: cron expression has no future fire times: '" + normalizedCron + "'";
+		}
+
+		CronTask task = new CronTask(id, normalizedCron, prompt, isRecurring, isDurable, nextFireTime, createdAt);
+		scheduler.schedule(task);
+		if (isDurable) {
+			saveDurableTasks();
+		}
+
+		String typeLabel = isRecurring ? "recurring" : "one-shot";
+		String persistenceLabel = isDurable ? "durable" : "session-only";
+		return String.format(
+				"Job scheduled.\n  ID: %s\n  Cron: %s\n  Type: %s, %s\n  Prompt: %s",
+				id, normalizedCron, typeLabel, persistenceLabel, prompt);
+	}
+
+	// @formatter:off
+	@Tool(name = "CronDelete", description = """
+		Cancel a previously scheduled cron job.
+
+		Parameters:
+		- id: Job ID returned by CronCreate.
+		""")
+	public String cronDelete(
+			@ToolParam(description = "Job ID returned by CronCreate") String id) { // @formatter:on
+		if (id == null || id.isBlank()) {
+			return "Error: id is required";
+		}
+		String trimmedId = id.trim();
+		CronTask removed = scheduler.cancel(trimmedId);
+		if (removed == null) {
+			return "Error: no scheduled job found with id '" + trimmedId + "'";
+		}
+		if (removed.durable()) {
+			saveDurableTasks();
+		}
+		return "Successfully cancelled job: " + trimmedId;
+	}
+
+	// @formatter:off
+	@Tool(name = "CronList", description = """
+		List all scheduled cron jobs (both durable and session-only).
+
+		No parameters required.
+		""")
+	public String cronList() { // @formatter:on
+		List<CronTask> tasks = scheduler.listAll();
+		if (tasks.isEmpty()) {
+			return "No scheduled cron jobs.";
+		}
+
+		StringBuilder sb = new StringBuilder();
+		sb.append("Scheduled cron jobs (").append(tasks.size()).append(" total):\n");
+		for (CronTask task : tasks) {
+			String typeLabel = task.recurring() ? "recurring" : "one-shot";
+			String persistenceLabel = task.durable() ? "durable" : "session-only";
+			sb.append(String.format("\n  ID: %s\n  Cron: %s\n  Type: %s, %s\n  Next fire: %s\n  Prompt: %s\n",
+					task.id(), task.cron(), typeLabel, persistenceLabel, task.nextFireTime(), task.prompt()));
+		}
+		return sb.toString().trim();
+	}
+
+	/**
+	 * Shut down the scheduler. The current thread will finish its current sleep and
+	 * exit gracefully.
+	 */
+	@Override
+	public void close() {
+		if (closed.compareAndSet(false, true)) {
+			scheduler.shutdown();
+		}
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private CronEventHandler eventHandler = task -> {
+			logger.info("Cron task fired: {} (prompt: {})", task.id(), task.prompt());
+			return "fired";
+		};
+
+		private Path durableTasksFile;
+
+		private Builder() {
+		}
+
+		/**
+		 * Set the custom handler invoked when a cron task fires.
+		 * @param eventHandler the fire-time callback
+		 * @return this builder
+		 */
+		public Builder eventHandler(CronEventHandler eventHandler) {
+			this.eventHandler = eventHandler != null ? eventHandler : this.eventHandler;
+			return this;
+		}
+
+		/**
+		 * Set the file used to persist durable tasks.
+		 * @param durableTasksFile the persistence file path
+		 * @return this builder
+		 */
+		public Builder durableTasksFile(Path durableTasksFile) {
+			this.durableTasksFile = durableTasksFile;
+			return this;
+		}
+
+		/**
+		 * Set the file used to persist durable tasks using a string path.
+		 * @param durableTasksFile the persistence file path as string
+		 * @return this builder
+		 */
+		public Builder durableTasksFile(String durableTasksFile) {
+			this.durableTasksFile = durableTasksFile != null ? Paths.get(durableTasksFile) : null;
+			return this;
+		}
+
+		public CronTools build() {
+			return new CronTools(eventHandler, durableTasksFile);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronEventHandler.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronEventHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.cron;
+
+/**
+ * Callback invoked when a scheduled cron task fires.
+ *
+ * <p>
+ * Implementations receive the firing {@link CronTask} and can perform
+ * any action — such as printing the prompt, publishing a Spring event,
+ * or enqueuing a new agent conversation.
+ * </p>
+ *
+ * @author Christian Tzolov
+ */
+@FunctionalInterface
+public interface CronEventHandler {
+
+	/**
+	 * Handle a fired cron task.
+	 * @param task the task that just fired (never {@code null})
+	 * @return an optional result string describing what was done
+	 */
+	String handle(CronTask task);
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronScheduler.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronScheduler.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.cron;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.support.CronExpression;
+
+/**
+ * Single-threaded scheduling engine that fires {@link CronTask} instances according to
+ * their cron expressions.
+ *
+ * <p>
+ * Runs a daemon thread that continuously checks the earliest upcoming task, sleeps until
+ * its fire time, and then invokes the {@link CronEventHandler}. Recurring tasks are
+ * re-enqueued with their next computed fire time. The scheduler is notified of insertions
+ * and deletions via {@link Object#notify()} so it can immediately recalculate.
+ * </p>
+ *
+ * <p>
+ * <b>Jitter:</b> Recurring tasks whose minute field is exactly 0 or 30 receive a small
+ * random offset (±2 minutes) to avoid thundering-herd effects. Tasks using intervals
+ * ({@code *&#47;N}) or specific minutes are not jittered.
+ * </p>
+ *
+ * <p>
+ * <b>Expiry:</b> Durable recurring tasks auto-expire 7 days after creation.
+ * </p>
+ *
+ * @author Christian Tzolov
+ */
+public class CronScheduler implements Runnable {
+
+	private static final Logger logger = LoggerFactory.getLogger(CronScheduler.class);
+
+	private static final Duration EXPIRY_DURATION = Duration.ofDays(7);
+
+	private final PriorityBlockingQueue<CronTask> taskQueue;
+
+	private final CronEventHandler handler;
+
+	private final Object lock = new Object();
+
+	private final AtomicBoolean running = new AtomicBoolean(true);
+
+	public CronScheduler(CronEventHandler handler) {
+		this.handler = handler;
+		this.taskQueue = new PriorityBlockingQueue<>(11, (a, b) -> {
+			Instant aTime = a.nextFireTime();
+			Instant bTime = b.nextFireTime();
+			if (aTime == null && bTime == null)
+				return 0;
+			if (aTime == null)
+				return -1;
+			if (bTime == null)
+				return 1;
+			return aTime.compareTo(bTime);
+		});
+	}
+
+	/**
+	 * Start the scheduler in a daemon thread.
+	 */
+	public void start() {
+		Thread schedulerThread = new Thread(this, "cron-scheduler");
+		schedulerThread.setDaemon(true);
+		schedulerThread.start();
+		logger.debug("CronScheduler started");
+	}
+
+	/**
+	 * Add a task to the queue and wake the scheduler.
+	 */
+	public void schedule(CronTask task) {
+		taskQueue.offer(task);
+		synchronized (lock) {
+			lock.notify();
+		}
+		logger.debug("Scheduled task: {} (next fire: {})", task.id(), task.nextFireTime());
+	}
+
+	/**
+	 * Remove a task by id.
+	 * @return the removed task, or {@code null} if not found
+	 */
+	public CronTask cancel(String id) {
+		for (CronTask task : taskQueue) {
+			if (task.id().equals(id)) {
+				taskQueue.remove(task);
+				synchronized (lock) {
+					lock.notify();
+				}
+				logger.debug("Cancelled task: {}", id);
+				return task;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Return a snapshot of all currently queued tasks.
+	 */
+	public List<CronTask> listAll() {
+		return List.copyOf(taskQueue);
+	}
+
+	/**
+	 * Shut down the scheduler. The current thread will finish its current sleep and exit
+	 * gracefully.
+	 */
+	public void shutdown() {
+		running.set(false);
+		synchronized (lock) {
+			lock.notify();
+		}
+		logger.debug("CronScheduler shutdown requested");
+	}
+
+	@Override
+	public void run() {
+		while (running.get()) {
+			try {
+				CronTask next = taskQueue.peek();
+				if (next == null) {
+					synchronized (lock) {
+						lock.wait();
+					}
+					continue;
+				}
+
+				Instant fireTime = next.nextFireTime();
+				if (fireTime == null) {
+					// Task with no fire time — remove and skip
+					taskQueue.poll();
+					continue;
+				}
+
+				long delayMs = Duration.between(Instant.now(), fireTime).toMillis();
+				if (delayMs > 0) {
+					synchronized (lock) {
+						// Wait at most delayMs, but can be woken early by schedule()/cancel()
+						lock.wait(Math.min(delayMs, 60_000)); // Check every 60s max
+					}
+					continue;
+				}
+
+				// Time to fire
+				taskQueue.poll(); // Remove from queue
+
+				// Check expiry for durable recurring tasks
+				if (next.recurring() && next.durable() && next.createdAt() != null) {
+					if (Duration.between(next.createdAt(), Instant.now()).compareTo(EXPIRY_DURATION) > 0) {
+						logger.info("Task {} expired (created {}), removing", next.id(), next.createdAt());
+						continue;
+					}
+				}
+
+				// Fire the task
+				try {
+					logger.debug("Firing task: {} (prompt: {})", next.id(), next.prompt());
+					String result = handler.handle(next);
+					logger.debug("Task {} completed: {}", next.id(),
+							result != null ? result.substring(0, Math.min(100, result.length())) : "null");
+				}
+				catch (Exception e) {
+					logger.error("Error handling cron task: {}", next.id(), e);
+				}
+
+				// Re-enqueue if recurring
+				if (next.recurring()) {
+					CronExpression expr = CronExpression.parse(toSixField(next.cron()));
+					ZonedDateTime now = ZonedDateTime.now();
+					ZonedDateTime nextTimeZoned = expr.next(now);
+					Instant nextTime = nextTimeZoned != null ? nextTimeZoned.toInstant() : null;
+					if (nextTime != null) {
+						// Apply jitter for on-the-hour / on-the-half-hour tasks
+						nextTime = applyJitter(next.cron(), nextTime);
+						taskQueue.offer(next.withNextFireTime(nextTime));
+						logger.debug("Re-enqueued recurring task: {} (next: {})", next.id(), nextTime);
+					}
+					else {
+						logger.info("Recurring task {} has no future fire times, removing", next.id());
+					}
+				}
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				logger.debug("CronScheduler interrupted");
+				break;
+			}
+			catch (Exception e) {
+				logger.error("Unexpected error in CronScheduler loop", e);
+			}
+		}
+		logger.debug("CronScheduler stopped");
+	}
+
+	/**
+	 * Apply random jitter to avoid thundering-herd effects.
+	 *
+	 * <p>
+	 * Only applies when the user's cron specifies a single, fixed minute value of 0 or
+	 * 30. Interval-based schedules ({@code *&#47;N}) and schedules with non-0/30 minute
+	 * values pass through unchanged.
+	 * </p>
+	 */
+	public static Instant applyJitter(String cron, Instant nextFireTime) {
+		String minuteField = cron.trim().split("\\s+")[0];
+		// Only jitter when user specified an exact minute of 0 or 30
+		if (minuteField.equals("0") || minuteField.equals("30")) {
+			int offsetMinutes = ThreadLocalRandom.current().nextInt(-2, 3); // -2..+2
+			if (offsetMinutes != 0) {
+				return nextFireTime.plus(Duration.ofMinutes(offsetMinutes));
+			}
+		}
+		return nextFireTime;
+	}
+
+	/**
+	 * Convert a 5-field cron expression to Spring's required 6-field format by
+	 * prepending "0 " as the seconds field. If the expression already has 6 fields it is
+	 * returned unchanged.
+	 * @param cron the cron expression (5 or 6 fields)
+	 * @return a 6-field cron expression
+	 */
+	public static String toSixField(String cron) {
+		String trimmed = cron.trim();
+		String[] fields = trimmed.split("\\s+");
+		if (fields.length == 5) {
+			return "0 " + trimmed;
+		}
+		return trimmed;
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronTask.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronTask.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.cron;
+
+import java.time.Instant;
+
+/**
+ * Represents a scheduled cron task with its configuration and runtime state.
+ *
+ * @param id unique identifier (UUID)
+ * @param cron 5-field cron expression ({@code minute hour dom month dow})
+ * @param prompt the prompt to enqueue at each fire time
+ * @param recurring {@code true} for recurring tasks, {@code false} for one-shot
+ * @param durable {@code true} to persist across restarts
+ * @param nextFireTime the next time this task should fire (may be {@code null} if
+ * expired)
+ * @param createdAt when this task was originally created (used for expiry)
+ */
+public record CronTask(String id, String cron, String prompt, boolean recurring, boolean durable, Instant nextFireTime,
+		Instant createdAt) {
+
+	/**
+	 * Create a copy with an updated nextFireTime (used when recalculating for recurring
+	 * tasks).
+	 */
+	public CronTask withNextFireTime(Instant newNextFireTime) {
+		return new CronTask(this.id, this.cron, this.prompt, this.recurring, this.durable, newNextFireTime,
+				this.createdAt);
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronTaskStore.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/CronTaskStore.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.cron;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads and writes durable cron tasks to an NDJSON file on disk.
+ *
+ * <p>
+ * Each durable task is stored as a single JSON line. On save the file is written
+ * atomically (write to temp file then rename) to avoid corruption. On load, malformed
+ * lines are silently skipped.
+ * </p>
+ *
+ * @author Christian Tzolov
+ */
+public class CronTaskStore {
+
+	private static final Logger logger = LoggerFactory.getLogger(CronTaskStore.class);
+
+	private final Path file;
+
+	public CronTaskStore(Path file) {
+		this.file = file;
+	}
+
+	/**
+	 * Load all durable tasks from the persistence file. Returns an empty list if the file
+	 * does not exist or is unreadable.
+	 */
+	public List<CronTask> load() {
+		if (!Files.exists(file)) {
+			return List.of();
+		}
+		try {
+			List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+			List<CronTask> tasks = new ArrayList<>();
+			for (String line : lines) {
+				line = line.trim();
+				if (line.isEmpty()) {
+					continue;
+				}
+				try {
+					tasks.add(parseLine(line));
+				}
+				catch (Exception e) {
+					logger.warn("Skipping malformed cron task line: {}", line, e);
+				}
+			}
+			return List.copyOf(tasks);
+		}
+		catch (IOException e) {
+			logger.warn("Failed to read durable tasks file: {}", file, e);
+			return List.of();
+		}
+	}
+
+	/**
+	 * Persist all durable tasks to the file atomically.
+	 */
+	public void save(List<CronTask> tasks) {
+		Path parent = file.getParent();
+		if (parent != null) {
+			try {
+				Files.createDirectories(parent);
+			}
+			catch (IOException e) {
+				logger.warn("Failed to create parent directories for {}", file, e);
+				return;
+			}
+		}
+		Path tmp = file.resolveSibling(file.getFileName().toString() + ".tmp");
+		try {
+			String content = tasks.stream().map(this::formatLine).collect(Collectors.joining("\n"));
+			if (!content.isEmpty()) {
+				content += "\n";
+			}
+			Files.writeString(tmp, content, StandardCharsets.UTF_8);
+			Files.move(tmp, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		}
+		catch (IOException e) {
+			logger.warn("Failed to save durable tasks to {}", file, e);
+			try {
+				Files.deleteIfExists(tmp);
+			}
+			catch (IOException ignored) {
+			}
+		}
+	}
+
+	/**
+	 * Remove the persistence file entirely (used when all durable tasks are deleted).
+	 */
+	public void delete() {
+		try {
+			Files.deleteIfExists(file);
+		}
+		catch (IOException e) {
+			logger.warn("Failed to delete durable tasks file: {}", file, e);
+		}
+	}
+
+	private CronTask parseLine(String line) {
+		// Simple manual JSON parsing to avoid extra dependencies.
+		// Format: {"id":"...","cron":"...","prompt":"...","recurring":bool,"durable":bool,"nextFireTime":"..."}
+		// Validate the line looks like a JSON object
+		String trimmed = line.trim();
+		if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+			throw new IllegalArgumentException("Line does not look like a JSON object");
+		}
+		String id = extractString(line, "id");
+		if (id == null || id.isEmpty()) {
+			throw new IllegalArgumentException("Missing required field: id");
+		}
+		String cron = extractString(line, "cron");
+		if (cron == null || cron.isEmpty()) {
+			throw new IllegalArgumentException("Missing required field: cron");
+		}
+		String prompt = extractString(line, "prompt");
+		boolean recurring = extractBoolean(line, "recurring");
+		boolean durable = extractBoolean(line, "durable");
+		String nextFireTimeStr = extractString(line, "nextFireTime");
+		Instant nextFireTime = nextFireTimeStr != null ? Instant.parse(nextFireTimeStr) : null;
+		String createdAtStr = extractString(line, "createdAt");
+		Instant createdAt = createdAtStr != null ? Instant.parse(createdAtStr) : Instant.now();
+		return new CronTask(id, cron, prompt, recurring, durable, nextFireTime, createdAt);
+	}
+
+	private String formatLine(CronTask task) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("{\"id\":\"").append(escape(task.id())).append("\"");
+		sb.append(",\"cron\":\"").append(escape(task.cron())).append("\"");
+		sb.append(",\"prompt\":\"").append(escape(task.prompt())).append("\"");
+		sb.append(",\"recurring\":").append(task.recurring());
+		sb.append(",\"durable\":").append(task.durable());
+		if (task.nextFireTime() != null) {
+			sb.append(",\"nextFireTime\":\"").append(task.nextFireTime().toString()).append("\"");
+		}
+		if (task.createdAt() != null) {
+			sb.append(",\"createdAt\":\"").append(task.createdAt().toString()).append("\"");
+		}
+		sb.append("}");
+		return sb.toString();
+	}
+
+	private String extractString(String json, String key) {
+		String prefix = "\"" + key + "\":\"";
+		int start = json.indexOf(prefix);
+		if (start == -1) {
+			return null;
+		}
+		start += prefix.length();
+		StringBuilder value = new StringBuilder();
+		for (int i = start; i < json.length(); i++) {
+			char c = json.charAt(i);
+			if (c == '\\' && i + 1 < json.length()) {
+				value.append(json.charAt(i + 1));
+				i++;
+			}
+			else if (c == '"') {
+				break;
+			}
+			else {
+				value.append(c);
+			}
+		}
+		return value.toString();
+	}
+
+	private boolean extractBoolean(String json, String key) {
+		String prefix = "\"" + key + "\":";
+		int start = json.indexOf(prefix);
+		if (start == -1) {
+			return false;
+		}
+		start += prefix.length();
+		// Skip whitespace
+		while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+			start++;
+		}
+		if (start >= json.length()) {
+			return false;
+		}
+		return json.startsWith("true", start);
+	}
+
+	private String escape(String s) {
+		if (s == null) {
+			return "";
+		}
+		return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r");
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/package-info.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/cron/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Cron-based task scheduling for the Spring AI Agent Utils library.
+ *
+ * <p>
+ * Provides a self-contained scheduling engine that fires agent prompts according to
+ * 5-field cron expressions. Includes support for recurring and one-shot tasks, durable
+ * (file-persisted) and session-only tasks, jitter to avoid thundering herds, and
+ * automatic expiry.
+ * </p>
+ */
+package org.springaicommunity.agent.tools.cron;

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/CronToolsTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/CronToolsTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springaicommunity.agent.tools.cron.CronEventHandler;
+import org.springaicommunity.agent.tools.cron.CronTask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CronTools}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("CronTools Tests")
+class CronToolsTest {
+
+	@Nested
+	@DisplayName("CronCreate Tests")
+	class CronCreateTests {
+
+		private CronTools tools;
+
+		private List<String> fired;
+
+		@BeforeEach
+		void setUp() {
+			fired = new ArrayList<>();
+			tools = CronTools.builder().eventHandler((CronEventHandler) task -> {
+				fired.add(task.id());
+				return "fired";
+			}).build();
+		}
+
+		@Test
+		@DisplayName("Should create a valid recurring cron job")
+		void shouldCreateValidRecurringJob() {
+			String result = tools.cronCreate("*/5 * * * *", "test prompt", true, false);
+
+			assertThat(result).contains("Job scheduled");
+			assertThat(result).contains("*/5 * * * *");
+			assertThat(result).contains("recurring");
+			assertThat(result).contains("session-only");
+			assertThat(result).contains("test prompt");
+		}
+
+		@Test
+		@DisplayName("Should create a one-shot cron job")
+		void shouldCreateOneShotJob() {
+			String result = tools.cronCreate("30 14 31 5 *", "one-time task", false, false);
+
+			assertThat(result).contains("Job scheduled");
+			assertThat(result).contains("one-shot");
+		}
+
+		@Test
+		@DisplayName("Should create a durable cron job")
+		void shouldCreateDurableJob() {
+			String result = tools.cronCreate("0 9 * * 1-5", "weekday standup", true, true);
+
+			assertThat(result).contains("Job scheduled");
+			assertThat(result).contains("durable");
+		}
+
+		@Test
+		@DisplayName("Should default recurring to true when not specified")
+		void shouldDefaultRecurringToTrue() {
+			String result = tools.cronCreate("*/10 * * * *", "default recurring", null, false);
+
+			assertThat(result).contains("recurring");
+			assertThat(result).doesNotContain("one-shot");
+		}
+
+		@Test
+		@DisplayName("Should reject empty cron expression")
+		void shouldRejectEmptyCron() {
+			String result = tools.cronCreate("", "prompt", true, false);
+
+			assertThat(result).contains("Error");
+			assertThat(result).contains("cron expression is required");
+		}
+
+		@Test
+		@DisplayName("Should reject invalid cron expression")
+		void shouldRejectInvalidCron() {
+			String result = tools.cronCreate("not a valid cron expression at all", "prompt", true, false);
+
+			assertThat(result).contains("Error");
+		}
+
+		@Test
+		@DisplayName("Should generate unique IDs for each task")
+		void shouldGenerateUniqueIds() {
+			String result1 = tools.cronCreate("*/5 * * * *", "task1", true, false);
+			String result2 = tools.cronCreate("*/5 * * * *", "task2", true, false);
+
+			assertThat(result1).isNotEqualTo(result2);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("CronDelete Tests")
+	class CronDeleteTests {
+
+		private CronTools tools;
+
+		@BeforeEach
+		void setUp() {
+			tools = CronTools.builder().eventHandler((CronEventHandler) task -> "fired").build();
+		}
+
+		@Test
+		@DisplayName("Should delete an existing job")
+		void shouldDeleteExistingJob() {
+			// Create a job first
+			String createResult = tools.cronCreate("*/5 * * * *", "test", true, false);
+			// Extract the ID from the result (format: "ID: cron_XXXXXXXX")
+			String id = extractId(createResult);
+
+			String result = tools.cronDelete(id);
+
+			assertThat(result).contains("Successfully cancelled");
+			assertThat(result).contains(id);
+		}
+
+		@Test
+		@DisplayName("Should return error for non-existent job")
+		void shouldReturnErrorForNonExistentJob() {
+			String result = tools.cronDelete("no-such-id");
+
+			assertThat(result).contains("Error");
+			assertThat(result).contains("no-such-id");
+		}
+
+		@Test
+		@DisplayName("Should reject null or blank ID")
+		void shouldRejectNullOrBlankId() {
+			assertThat(tools.cronDelete(null)).contains("Error");
+			assertThat(tools.cronDelete("   ")).contains("Error");
+		}
+
+		private String extractId(String createResult) {
+			// Result format: "Job scheduled.\n  ID: cron_XXXXXXXX\n  ..."
+			int idStart = createResult.indexOf("ID: ") + 4;
+			int idEnd = createResult.indexOf("\n", idStart);
+			return createResult.substring(idStart, idEnd).trim();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("CronList Tests")
+	class CronListTests {
+
+		private CronTools tools;
+
+		@BeforeEach
+		void setUp() {
+			tools = CronTools.builder().eventHandler((CronEventHandler) task -> "fired").build();
+		}
+
+		@Test
+		@DisplayName("Should return empty message when no jobs")
+		void shouldReturnEmptyMessageWhenNoJobs() {
+			String result = tools.cronList();
+
+			assertThat(result).contains("No scheduled cron jobs");
+		}
+
+		@Test
+		@DisplayName("Should list all scheduled jobs")
+		void shouldListAllScheduledJobs() {
+			tools.cronCreate("*/5 * * * *", "task-a", true, false);
+			tools.cronCreate("0 9 * * 1-5", "task-b", true, false);
+
+			String result = tools.cronList();
+
+			assertThat(result).contains("Scheduled cron jobs (2 total)");
+			assertThat(result).contains("*/5 * * * *");
+			assertThat(result).contains("0 9 * * 1-5");
+			assertThat(result).contains("task-a");
+			assertThat(result).contains("task-b");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Durable Persistence Tests")
+	class DurablePersistenceTests {
+
+		@TempDir
+		Path tempDir;
+
+		@Test
+		@DisplayName("Should persist and restore durable tasks")
+		void shouldPersistAndRestoreDurableTasks() throws IOException {
+			Path file = tempDir.resolve("scheduled_tasks.json");
+
+			// Create tools with durable persistence
+			CronTools tools1 = CronTools.builder()
+				.durableTasksFile(file)
+				.eventHandler((CronEventHandler) task -> "fired")
+				.build();
+
+			tools1.cronCreate("0 9 * * 1-5", "daily standup", true, true);
+			tools1.cronCreate("*/5 * * * *", "session-only task", true, false); // not durable
+
+			// Verify file was written
+			assertThat(file).exists();
+			String content = Files.readString(file, StandardCharsets.UTF_8);
+			assertThat(content).contains("daily standup");
+			assertThat(content).doesNotContain("session-only task");
+
+			// Create new tools instance (simulating restart)
+			CronTools tools2 = CronTools.builder()
+				.durableTasksFile(file)
+				.eventHandler((CronEventHandler) task -> "fired")
+				.build();
+
+			// Should have restored the durable task
+			String listResult = tools2.cronList();
+			assertThat(listResult).contains("daily standup");
+			assertThat(listResult).doesNotContain("session-only task");
+		}
+
+		@Test
+		@DisplayName("Should delete file when all durable tasks are removed")
+		void shouldDeleteFileWhenAllDurableTasksRemoved() throws IOException {
+			Path file = tempDir.resolve("scheduled_tasks.json");
+
+			CronTools tools = CronTools.builder()
+				.durableTasksFile(file)
+				.eventHandler((CronEventHandler) task -> "fired")
+				.build();
+
+			String createResult = tools.cronCreate("0 9 * * 1-5", "to-be-deleted", true, true);
+			assertThat(file).exists();
+
+			String id = extractId(createResult);
+			tools.cronDelete(id);
+
+			assertThat(file).doesNotExist();
+		}
+
+		private String extractId(String createResult) {
+			int idStart = createResult.indexOf("ID: ") + 4;
+			int idEnd = createResult.indexOf("\n", idStart);
+			return createResult.substring(idStart, idEnd).trim();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Builder Tests")
+	class BuilderTests {
+
+		@Test
+		@DisplayName("Should create tools with default configuration")
+		void shouldCreateWithDefaults() {
+			CronTools tools = CronTools.builder().build();
+			assertThat(tools).isNotNull();
+			assertThat(tools.cronList()).contains("No scheduled cron jobs");
+		}
+
+		@Test
+		@DisplayName("Should create tools with custom event handler")
+		void shouldCreateWithCustomEventHandler() {
+			CronTools tools = CronTools.builder().eventHandler((CronEventHandler) task -> "custom handled").build();
+
+			assertThat(tools).isNotNull();
+		}
+
+		@Test
+		@DisplayName("Should create tools with durable file path as string")
+		void shouldCreateWithDurableFileAsString(@TempDir Path tempDir) {
+			String filePath = tempDir.resolve("tasks.json").toString();
+			CronTools tools = CronTools.builder().durableTasksFile(filePath).build();
+
+			assertThat(tools).isNotNull();
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/cron/CronSchedulerTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/cron/CronSchedulerTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.cron;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CronScheduler}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("CronScheduler Tests")
+class CronSchedulerTest {
+
+	private CronScheduler scheduler;
+
+	@BeforeEach
+	void setUp() {
+		scheduler = new CronScheduler(task -> "handled: " + task.id());
+		scheduler.start();
+	}
+
+	@AfterEach
+	void tearDown() {
+		scheduler.shutdown();
+	}
+
+	@Nested
+	@DisplayName("Schedule and List Tests")
+	class ScheduleAndListTests {
+
+		@Test
+		@DisplayName("Should schedule a task and list it")
+		void shouldScheduleTaskAndListIt() {
+			CronTask task = new CronTask("test-1", "*/5 * * * *", "test prompt", true, false,
+					Instant.now().plusSeconds(60), Instant.now());
+
+			scheduler.schedule(task);
+
+			List<CronTask> tasks = scheduler.listAll();
+			assertThat(tasks).hasSize(1);
+			assertThat(tasks.get(0).id()).isEqualTo("test-1");
+		}
+
+		@Test
+		@DisplayName("Should schedule multiple tasks")
+		void shouldScheduleMultipleTasks() {
+			scheduler.schedule(
+					new CronTask("t1", "0 * * * *", "p1", true, false, Instant.now().plusSeconds(30), Instant.now()));
+			scheduler
+				.schedule(new CronTask("t2", "30 * * * *", "p2", true, false, Instant.now().plusSeconds(60),
+						Instant.now()));
+			scheduler.schedule(
+					new CronTask("t3", "0 9 * * *", "p3", true, false, Instant.now().plusSeconds(90), Instant.now()));
+
+			assertThat(scheduler.listAll()).hasSize(3);
+		}
+
+		@Test
+		@DisplayName("Should return empty list when no tasks scheduled")
+		void shouldReturnEmptyListWhenNoTasks() {
+			assertThat(scheduler.listAll()).isEmpty();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Cancel Tests")
+	class CancelTests {
+
+		@Test
+		@DisplayName("Should cancel an existing task")
+		void shouldCancelExistingTask() {
+			CronTask task = new CronTask("to-cancel", "0 * * * *", "p", true, false, Instant.now().plusSeconds(120),
+					Instant.now());
+			scheduler.schedule(task);
+
+			CronTask removed = scheduler.cancel("to-cancel");
+
+			assertThat(removed).isNotNull();
+			assertThat(removed.id()).isEqualTo("to-cancel");
+			assertThat(scheduler.listAll()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("Should return null when cancelling non-existent task")
+		void shouldReturnNullForNonExistentTask() {
+			assertThat(scheduler.cancel("no-such-id")).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Fire Tests")
+	class FireTests {
+
+		@Test
+		@DisplayName("Should fire a task whose time has arrived")
+		void shouldFireTaskWhoseTimeHasArrived() throws InterruptedException {
+			List<String> fired = new CopyOnWriteArrayList<>();
+			CronScheduler fireScheduler = new CronScheduler(task -> {
+				fired.add(task.id());
+				return "done";
+			});
+			fireScheduler.start();
+
+			try {
+				// Schedule a task with fire time in the past (fires immediately)
+				CronTask task = new CronTask("fire-now", "*/5 * * * *", "prompt", false, false,
+						Instant.now().minusSeconds(1), Instant.now());
+				fireScheduler.schedule(task);
+
+				// Wait for fire
+				Thread.sleep(500);
+
+				assertThat(fired).contains("fire-now");
+				// One-shot task should NOT be re-enqueued
+				assertThat(fireScheduler.listAll()).isEmpty();
+			}
+			finally {
+				fireScheduler.shutdown();
+			}
+		}
+
+		@Test
+		@DisplayName("Should re-enqueue recurring task after firing")
+		void shouldReenqueueRecurringTask() throws InterruptedException {
+			List<String> fired = new CopyOnWriteArrayList<>();
+			CronScheduler fireScheduler = new CronScheduler(task -> {
+				fired.add(task.id());
+				return "done";
+			});
+			fireScheduler.start();
+
+			try {
+				// Schedule a recurring task with fire time in the past
+				CronTask task = new CronTask("recurring-1", "*/5 * * * *", "prompt", true, false,
+						Instant.now().minusSeconds(1), Instant.now());
+				fireScheduler.schedule(task);
+
+				// Wait for fire and re-enqueue
+				Thread.sleep(500);
+
+				assertThat(fired).contains("recurring-1");
+				// Recurring task SHOULD be re-enqueued with a future fire time
+				List<CronTask> remaining = fireScheduler.listAll();
+				assertThat(remaining).hasSize(1);
+				assertThat(remaining.get(0).id()).isEqualTo("recurring-1");
+				assertThat(remaining.get(0).nextFireTime()).isAfter(Instant.now());
+			}
+			finally {
+				fireScheduler.shutdown();
+			}
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Jitter Tests")
+	class JitterTests {
+
+		@Test
+		@DisplayName("Should apply jitter for minute 0")
+		void shouldApplyJitterForMinute0() {
+			Instant base = Instant.parse("2026-05-31T09:00:00Z");
+			// Run multiple times and check the result is within ±2 minutes
+			boolean foundOffset = false;
+			for (int i = 0; i < 20; i++) {
+				Instant result = CronScheduler.applyJitter("0 9 * * *", base);
+				long diffSeconds = result.getEpochSecond() - base.getEpochSecond();
+				assertThat(diffSeconds).isBetween(-120L, 120L);
+				if (diffSeconds != 0) {
+					foundOffset = true;
+				}
+			}
+			// At least some runs should have offset (probability ~80% per run with range -2..+2)
+			assertThat(foundOffset).as("Jitter should produce offset at least sometimes").isTrue();
+		}
+
+		@Test
+		@DisplayName("Should apply jitter for minute 30")
+		void shouldApplyJitterForMinute30() {
+			Instant base = Instant.parse("2026-05-31T09:30:00Z");
+			boolean foundOffset = false;
+			for (int i = 0; i < 20; i++) {
+				Instant result = CronScheduler.applyJitter("30 14 * * *", base);
+				long diffSeconds = result.getEpochSecond() - base.getEpochSecond();
+				assertThat(diffSeconds).isBetween(-120L, 120L);
+				if (diffSeconds != 0) {
+					foundOffset = true;
+				}
+			}
+			assertThat(foundOffset).isTrue();
+		}
+
+		@Test
+		@DisplayName("Should NOT apply jitter for interval cron (*/5)")
+		void shouldNotApplyJitterForIntervalCron() {
+			Instant base = Instant.parse("2026-05-31T09:00:00Z");
+			for (int i = 0; i < 10; i++) {
+				Instant result = CronScheduler.applyJitter("*/5 * * * *", base);
+				assertThat(result).isEqualTo(base);
+			}
+		}
+
+		@Test
+		@DisplayName("Should NOT apply jitter for non-0/30 minute")
+		void shouldNotApplyJitterForNonSpecialMinute() {
+			Instant base = Instant.parse("2026-05-31T09:15:00Z");
+			for (int i = 0; i < 10; i++) {
+				Instant result = CronScheduler.applyJitter("15 9 * * *", base);
+				assertThat(result).isEqualTo(base);
+			}
+		}
+
+		@Test
+		@DisplayName("Should NOT apply jitter for comma-separated minutes")
+		void shouldNotApplyJitterForCommaSeparatedMinutes() {
+			Instant base = Instant.parse("2026-05-31T09:00:00Z");
+			for (int i = 0; i < 10; i++) {
+				Instant result = CronScheduler.applyJitter("0,30 9 * * *", base);
+				assertThat(result).isEqualTo(base);
+			}
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Concurrency Tests")
+	class ConcurrencyTests {
+
+		@Test
+		@DisplayName("Should handle concurrent schedule and cancel")
+		void shouldHandleConcurrentScheduleAndCancel() throws InterruptedException {
+			int taskCount = 50;
+			CountDownLatch latch = new CountDownLatch(taskCount * 2);
+
+			for (int i = 0; i < taskCount; i++) {
+				final int index = i;
+				new Thread(() -> {
+					scheduler.schedule(new CronTask("t-" + index, "0 * * * *", "p", true, false,
+							Instant.now().plusSeconds(3600), Instant.now()));
+					latch.countDown();
+				}).start();
+
+				new Thread(() -> {
+					scheduler.listAll();
+					latch.countDown();
+				}).start();
+			}
+
+			assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+			// All tasks should be scheduled (no data loss from concurrency)
+			assertThat(scheduler.listAll()).hasSize(taskCount);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/cron/CronTaskStoreTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/cron/CronTaskStoreTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025 - 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springaicommunity.agent.tools.cron;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CronTaskStore}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("CronTaskStore Tests")
+class CronTaskStoreTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Nested
+	@DisplayName("Load Tests")
+	class LoadTests {
+
+		@Test
+		@DisplayName("Should return empty list when file does not exist")
+		void shouldReturnEmptyListWhenFileDoesNotExist() {
+			Path file = tempDir.resolve("nonexistent.json");
+			CronTaskStore store = new CronTaskStore(file);
+
+			List<CronTask> tasks = store.load();
+
+			assertThat(tasks).isEmpty();
+		}
+
+		@Test
+		@DisplayName("Should load tasks from valid NDJSON file")
+		void shouldLoadTasksFromValidFile() throws IOException {
+			Path file = tempDir.resolve("tasks.json");
+			String json = """
+					{"id":"abc","cron":"0 9 * * *","prompt":"daily standup","recurring":true,"durable":true,"nextFireTime":"2026-06-01T09:00:00Z","createdAt":"2026-05-31T00:00:00Z"}
+					{"id":"def","cron":"30 14 31 5 *","prompt":"one-time check","recurring":false,"durable":true,"nextFireTime":"2026-05-31T14:30:00Z","createdAt":"2026-05-31T00:00:00Z"}
+					""";
+			Files.writeString(file, json, StandardCharsets.UTF_8);
+			CronTaskStore store = new CronTaskStore(file);
+
+			List<CronTask> tasks = store.load();
+
+			assertThat(tasks).hasSize(2);
+			assertThat(tasks.get(0).id()).isEqualTo("abc");
+			assertThat(tasks.get(0).cron()).isEqualTo("0 9 * * *");
+			assertThat(tasks.get(0).prompt()).isEqualTo("daily standup");
+			assertThat(tasks.get(0).recurring()).isTrue();
+			assertThat(tasks.get(0).durable()).isTrue();
+			assertThat(tasks.get(0).nextFireTime()).isEqualTo(Instant.parse("2026-06-01T09:00:00Z"));
+
+			assertThat(tasks.get(1).id()).isEqualTo("def");
+			assertThat(tasks.get(1).recurring()).isFalse();
+			assertThat(tasks.get(1).prompt()).isEqualTo("one-time check");
+		}
+
+		@Test
+		@DisplayName("Should skip malformed lines gracefully")
+		void shouldSkipMalformedLines() throws IOException {
+			Path file = tempDir.resolve("tasks.json");
+			String json = """
+					{"id":"good","cron":"0 9 * * *","prompt":"ok","recurring":true,"durable":true,"nextFireTime":"2026-06-01T09:00:00Z","createdAt":"2026-05-31T00:00:00Z"}
+					this is not valid json at all
+					{"id":"also-good","cron":"*/5 * * * *","prompt":"another","recurring":false,"durable":true,"nextFireTime":"2026-06-01T10:00:00Z","createdAt":"2026-05-31T00:00:00Z"}
+					""";
+			Files.writeString(file, json, StandardCharsets.UTF_8);
+			CronTaskStore store = new CronTaskStore(file);
+
+			List<CronTask> tasks = store.load();
+
+			assertThat(tasks).hasSize(2);
+			assertThat(tasks.get(0).id()).isEqualTo("good");
+			assertThat(tasks.get(1).id()).isEqualTo("also-good");
+		}
+
+		@Test
+		@DisplayName("Should skip empty lines")
+		void shouldSkipEmptyLines() throws IOException {
+			Path file = tempDir.resolve("tasks.json");
+			String json = """
+					{"id":"only","cron":"0 9 * * *","prompt":"test","recurring":true,"durable":true,"nextFireTime":"2026-06-01T09:00:00Z","createdAt":"2026-05-31T00:00:00Z"}
+
+					""";
+			Files.writeString(file, json, StandardCharsets.UTF_8);
+			CronTaskStore store = new CronTaskStore(file);
+
+			List<CronTask> tasks = store.load();
+
+			assertThat(tasks).hasSize(1);
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Save Tests")
+	class SaveTests {
+
+		@Test
+		@DisplayName("Should save tasks to file")
+		void shouldSaveTasksToFile() throws IOException {
+			Path file = tempDir.resolve("tasks.json");
+			CronTaskStore store = new CronTaskStore(file);
+
+			List<CronTask> tasks = List.of(
+					new CronTask("save-1", "0 9 * * 1-5", "weekday", true, true,
+							Instant.parse("2026-06-01T09:00:00Z"), Instant.parse("2026-05-31T00:00:00Z")),
+					new CronTask("save-2", "30 14 31 5 *", "one-shot", false, true,
+							Instant.parse("2026-05-31T14:30:00Z"), Instant.parse("2026-05-31T00:00:00Z")));
+
+			store.save(tasks);
+
+			assertThat(file).exists();
+			String content = Files.readString(file, StandardCharsets.UTF_8);
+			assertThat(content).contains("\"id\":\"save-1\"");
+			assertThat(content).contains("\"id\":\"save-2\"");
+			assertThat(content).contains("\"cron\":\"0 9 * * 1-5\"");
+			assertThat(content).contains("\"prompt\":\"weekday\"");
+			assertThat(content).contains("\"recurring\":true");
+		}
+
+		@Test
+		@DisplayName("Should save and load round-trip correctly")
+		void shouldSaveAndLoadRoundTrip() {
+			Path file = tempDir.resolve("tasks.json");
+			CronTaskStore store = new CronTaskStore(file);
+
+			CronTask original = new CronTask("roundtrip", "*/10 * * * *", "test prompt with \"quotes\"", true, true,
+					Instant.parse("2026-06-01T12:00:00Z"), Instant.parse("2026-05-31T00:00:00Z"));
+			store.save(List.of(original));
+
+			List<CronTask> loaded = store.load();
+			assertThat(loaded).hasSize(1);
+			assertThat(loaded.get(0).id()).isEqualTo("roundtrip");
+			assertThat(loaded.get(0).cron()).isEqualTo("*/10 * * * *");
+			assertThat(loaded.get(0).prompt()).isEqualTo("test prompt with \"quotes\"");
+			assertThat(loaded.get(0).recurring()).isTrue();
+			assertThat(loaded.get(0).durable()).isTrue();
+		}
+
+		@Test
+		@DisplayName("Should save empty list (deletes the file)")
+		void shouldDeleteFileForEmptyList() throws IOException {
+			Path file = tempDir.resolve("tasks.json");
+			CronTaskStore store = new CronTaskStore(file);
+
+			// Save some tasks first
+			CronTask task = new CronTask("temp", "0 * * * *", "p", true, true, Instant.parse("2026-06-01T09:00:00Z"),
+					Instant.now());
+			store.save(List.of(task));
+			assertThat(file).exists();
+
+			// Now delete via the delete() method
+			store.delete();
+			assertThat(file).doesNotExist();
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR introduces CronTools, a set of Spring AI tools that allow agents to schedule prompts using standard 5-field cron expressions.

## Features

- **CronCreate**: Schedule recurring or one-shot cron jobs.
- **CronDelete**: Cancel a previously scheduled job.
- **CronList**: List all scheduled jobs.
- **Durable persistence**: Optional file-based persistence (NDJSON) so tasks survive restarts.
- **Jitter**: Recurring tasks scheduled at :00 or :30 receive a small random offset to avoid thundering herds.
- **Automatic expiry**: Durable recurring tasks expire 7 days after creation.

## Implementation

- `CronTools`: Spring AI `@Tool` facade with builder configuration.
- `CronScheduler`: Single-threaded scheduling engine using a priority queue ordered by next fire time.
- `CronTaskStore`: NDJSON file persistence with atomic writes.
- `CronEventHandler`: Callback interface for fired tasks.

## Testing

All 433 tests in the `spring-ai-agent-utils` module pass, including 37 new cron-related tests.

Resolves #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)