### PR TITLE
GH-54: Propagate ToolCallingManager to Claude subagents

### DIFF
--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentExecutor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentExecutor.java
@@ -28,8 +28,9 @@ import org.springaicommunity.agent.common.task.subagent.TaskCall;
 import org.springaicommunity.agent.utils.Skills;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.ToolCallAdvisor;
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -51,8 +52,16 @@ public class ClaudeSubagentExecutor implements SubagentExecutor {
 
 	private final List<String> skillsDirectories;
 
+	private final ToolCallingManager toolCallingManager;
+
 	public ClaudeSubagentExecutor(Map<String, ChatClient.Builder> chatClientBuilderMap, List<ToolCallback> tools,
 			List<String> skillsDirectories) {
+
+		this(chatClientBuilderMap, tools, skillsDirectories, null);
+	}
+
+	public ClaudeSubagentExecutor(Map<String, ChatClient.Builder> chatClientBuilderMap, List<ToolCallback> tools,
+			List<String> skillsDirectories, ToolCallingManager toolCallingManager) {
 
 		Assert.notEmpty(chatClientBuilderMap, "chatClientBuilderMap must not be empty");
 		Assert.isTrue(chatClientBuilderMap.containsKey("default"),
@@ -63,6 +72,7 @@ public class ClaudeSubagentExecutor implements SubagentExecutor {
 		this.chatClientBuilderMap = chatClientBuilderMap;
 		this.tools = tools;
 		this.skillsDirectories = skillsDirectories;
+		this.toolCallingManager = toolCallingManager;
 	}
 
 	@Override
@@ -130,7 +140,11 @@ public class ClaudeSubagentExecutor implements SubagentExecutor {
 
 		// TODO Add ToolCallAdvisors only if not already present in the
 		// ChatClient.Builder.
-		return builder.defaultAdvisors(ToolCallAdvisor.builder().build()).build();
+		var toolCallingAdvisorBuilder = ToolCallingAdvisor.builder();
+		if (this.toolCallingManager != null) {
+			toolCallingAdvisorBuilder.toolCallingManager(this.toolCallingManager);
+		}
+		return builder.defaultAdvisors(toolCallingAdvisorBuilder.build()).build();
 	}
 
 	private static final Map<String, String> MODEL_NAME_MAPPER = Map.of("opus", "claude-opus-4-64k", "haiku",

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentType.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentType.java
@@ -31,6 +31,7 @@ import org.springaicommunity.agent.tools.SmartWebFetchTool;
 import org.springaicommunity.agent.tools.TodoWriteTool;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.core.io.Resource;
@@ -55,6 +56,8 @@ public class ClaudeSubagentType {
 
 		private List<String> skillsDirectories = new ArrayList<>();
 
+		private ToolCallingManager toolCallingManager;
+
 		public Builder braveApiKey(String braveApiKey) {
 			Assert.notNull(braveApiKey, "braveApiKey must not be null");
 			this.braveApiKey = braveApiKey;
@@ -71,6 +74,12 @@ public class ClaudeSubagentType {
 		public Builder chatClientBuilders(Map<String, ChatClient.Builder> chatClientBuilderMap) {
 			Assert.notNull(chatClientBuilderMap, "chatClientBuilderMap must not be null");
 			this.chatClientBuilderMap.putAll(chatClientBuilderMap);
+			return this;
+		}
+
+		public Builder toolCallingManager(ToolCallingManager toolCallingManager) {
+			Assert.notNull(toolCallingManager, "toolCallingManager must not be null");
+			this.toolCallingManager = toolCallingManager;
 			return this;
 		}
 
@@ -112,7 +121,7 @@ public class ClaudeSubagentType {
 					"chatClientBuilderMap must contain a 'default' builder for the SmartWebFetchTool");
 
 			ClaudeSubagentExecutor executor = new ClaudeSubagentExecutor(this.chatClientBuilderMap,
-					this.defaultClaudeSubagentTools(), this.skillsDirectories);
+					this.defaultClaudeSubagentTools(), this.skillsDirectories, this.toolCallingManager);
 
 			return new SubagentType(new ClaudeSubagentResolver(), executor);
 		}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentTypeTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/task/claude/ClaudeSubagentTypeTest.java
@@ -15,19 +15,35 @@
  */
 package org.springaicommunity.agent.tools.task.claude;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
+import org.springaicommunity.agent.common.task.subagent.SubagentReference;
 import org.springaicommunity.agent.common.task.subagent.SubagentType;
+import org.springaicommunity.agent.common.task.subagent.TaskCall;
 import org.springaicommunity.agent.tools.task.claude.ClaudeSubagentDefinition;
 import org.springaicommunity.agent.tools.task.claude.ClaudeSubagentExecutor;
 import org.springaicommunity.agent.tools.task.claude.ClaudeSubagentResolver;
 import org.springaicommunity.agent.tools.task.claude.ClaudeSubagentType;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingManager;
+import org.springframework.ai.model.tool.ToolExecutionResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link ClaudeSubagentType}.
@@ -70,6 +86,48 @@ class ClaudeSubagentTypeTest {
 			.build();
 
 		assertThat(result).isNotNull();
+	}
+
+	@Test
+	void shouldUseConfiguredToolCallingManagerForSubagentToolCalls() {
+		ChatModel chatModel = mock(ChatModel.class);
+		when(chatModel.getOptions()).thenReturn(ToolCallingChatOptions.builder().build());
+		when(chatModel.call(any(Prompt.class))).thenReturn(toolCallResponse(), textResponse("done"));
+
+		ToolCallingManager toolCallingManager = mock(ToolCallingManager.class);
+		when(toolCallingManager.resolveToolDefinitions(any())).thenReturn(List.of());
+		when(toolCallingManager.executeToolCalls(any(Prompt.class), any(ChatResponse.class)))
+			.thenReturn(ToolExecutionResult.builder()
+				.conversationHistory(List.of(new UserMessage("tool result")))
+				.build());
+
+		SubagentType result = ClaudeSubagentType.builder()
+			.chatClientBuilder("default", ChatClient.builder(chatModel))
+			.toolCallingManager(toolCallingManager)
+			.build();
+
+		String content = result.executor()
+			.execute(new TaskCall("desc", "prompt", "test-agent", null, null, null), testSubagent());
+
+		assertThat(content).isEqualTo("done");
+		verify(toolCallingManager).executeToolCalls(any(Prompt.class), any(ChatResponse.class));
+	}
+
+	private static ClaudeSubagentDefinition testSubagent() {
+		return new ClaudeSubagentDefinition(new SubagentReference("file:test.md", ClaudeSubagentDefinition.KIND, null),
+				Map.of("name", "test-agent", "description", "desc"), "system prompt");
+	}
+
+	private static ChatResponse toolCallResponse() {
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call-1", "function", "fetch_rss", "{}")))
+			.build();
+		return new ChatResponse(List.of(new Generation(assistantMessage)));
+	}
+
+	private static ChatResponse textResponse(String content) {
+		return new ChatResponse(List.of(new Generation(new AssistantMessage(content))));
 	}
 
 }


### PR DESCRIPTION
## Summary
- Add `ClaudeSubagentType.Builder.toolCallingManager(...)` so applications can pass their configured Spring AI `ToolCallingManager` into Claude subagents
- Use that manager when creating the subagent `ToolCallingAdvisor`, while preserving the existing default behavior when no manager is supplied
- Add a regression test that exercises a subagent tool-call response and verifies the configured manager handles tool execution

Fixes #54

## Testing
- `./mvnw -pl spring-ai-agent-utils -Dtest=ClaudeSubagentTypeTest test`
- `./mvnw -q -pl spring-ai-agent-utils -am verify`
- `./mvnw -q verify`