### PR TITLE
fix: handle A2A task update events and wait for completion

### DIFF
--- a/spring-ai-agent-utils-a2a/src/main/java/org/springaicommunity/agent/subagent/a2a/A2ASubagentExecutor.java
+++ b/spring-ai-agent-utils-a2a/src/main/java/org/springaicommunity/agent/subagent/a2a/A2ASubagentExecutor.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2026 - 2026 the original author or authors.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2026 - 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springaicommunity.agent.subagent.a2a;
 
 import java.util.List;
@@ -23,6 +23,7 @@ import java.util.function.BiConsumer;
 import io.a2a.client.Client;
 import io.a2a.client.ClientEvent;
 import io.a2a.client.TaskEvent;
+import io.a2a.client.TaskUpdateEvent;
 import io.a2a.client.config.ClientConfig;
 import io.a2a.client.transport.jsonrpc.JSONRPCTransport;
 import io.a2a.client.transport.jsonrpc.JSONRPCTransportConfig;
@@ -32,6 +33,7 @@ import io.a2a.spec.Message;
 import io.a2a.spec.Part;
 import io.a2a.spec.Task;
 import io.a2a.spec.TextPart;
+import io.a2a.spec.TaskState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springaicommunity.agent.common.task.subagent.SubagentDefinition;
@@ -47,71 +49,81 @@ import org.springaicommunity.agent.common.task.subagent.TaskCall;
  */
 public class A2ASubagentExecutor implements SubagentExecutor {
 
-	private static final Logger logger = LoggerFactory.getLogger(A2ASubagentExecutor.class);
+    private static final Logger logger = LoggerFactory.getLogger(A2ASubagentExecutor.class);
 
-	@Override
-	public String getKind() {
-		return A2ASubagentDefinition.KIND;
-	}
+    @Override
+    public String getKind() {
+        return A2ASubagentDefinition.KIND;
+    }
 
-	@Override
-	public String execute(TaskCall taskCall, SubagentDefinition subagent) {
+    @Override
+    public String execute(TaskCall taskCall, SubagentDefinition subagent) {
 
-		AgentCard agentCard = ((A2ASubagentDefinition) subagent).getAgentCard();
+        AgentCard agentCard = ((A2ASubagentDefinition) subagent).getAgentCard();
 
-		try {
-			// Create the message
-			Message message = new Message.Builder().role(Message.Role.USER)
-				.parts(List.of(new TextPart(taskCall.prompt(), null)))
-				.build();
+        try {
+            // Create the message
+            Message message = new Message.Builder().role(Message.Role.USER)
+                    .parts(List.of(new TextPart(taskCall.prompt(), null)))
+                    .build();
 
-			// Use CompletableFuture to wait for the response
-			CompletableFuture<String> responseFuture = new CompletableFuture<>();
-			AtomicReference<String> responseText = new AtomicReference<>("");
+            // Use CompletableFuture to wait for the response
+            CompletableFuture<String> responseFuture = new CompletableFuture<>();
+            AtomicReference<String> responseText = new AtomicReference<>("");
 
-			BiConsumer<ClientEvent, AgentCard> consumer = (event, card) -> {
-				if (event instanceof TaskEvent taskEvent) {
-					Task completedTask = taskEvent.getTask();
-					logger.info("Received task response: status={}", completedTask.getStatus().state());
+            BiConsumer<ClientEvent, AgentCard> consumer = (event, card) -> {
+                Task task;
 
-					// Extract text from artifacts
-					if (completedTask.getArtifacts() != null) {
-						StringBuilder sb = new StringBuilder();
-						for (Artifact artifact : completedTask.getArtifacts()) {
-							if (artifact.parts() != null) {
-								for (Part<?> part : artifact.parts()) {
-									if (part instanceof TextPart textPart) {
-										sb.append(textPart.getText());
-									}
-								}
-							}
-						}
-						responseText.set(sb.toString());
-					}
-					responseFuture.complete(responseText.get());
-				}
-			};
+                if (event instanceof TaskEvent taskEvent) {
+                    task = taskEvent.getTask();
+                } else if (event instanceof TaskUpdateEvent taskUpdateEvent) {
+                    task = taskUpdateEvent.getTask();
+                } else {
+                    return;
+                }
 
-			// Create client with consumer via builder
-			ClientConfig clientConfig = new ClientConfig.Builder().setAcceptedOutputModes(List.of("text")).build();
-			
-			Client client = Client.builder(agentCard)
-				.clientConfig(clientConfig)
-				.withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig())
-				.addConsumers(List.of(consumer))
-				.build();
+                TaskState taskState = task.getStatus().state();
+                logger.info("Received task response: status={}", taskState);
 
-			client.sendMessage(message);
+                // Extract text from artifacts
+                if (task.getArtifacts() != null) {
+                    StringBuilder sb = new StringBuilder();
+                    for (Artifact artifact : task.getArtifacts()) {
+                        if (artifact.parts() != null) {
+                            for (Part<?> part : artifact.parts()) {
+                                if (part instanceof TextPart textPart) {
+                                    sb.append(textPart.getText());
+                                }
+                            }
+                        }
+                    }
+                    responseText.set(sb.toString());
+                }
 
-			// Wait for response (with timeout)
-			String result = responseFuture.get(60, java.util.concurrent.TimeUnit.SECONDS);
-			logger.info("Agent '{}' response: {}", subagent.getName(), result);
-			return result;
-		}
-		catch (Exception e) {
-			logger.error("Error sending message to agent '{}': {}", subagent.getName(), e.getMessage());
-			return String.format("Error communicating with agent '%s': %s", subagent.getName(), e.getMessage());
-		}
-	}
+                if (taskState.isFinal()) {
+                    responseFuture.complete(responseText.get());
+                }
+            };
+
+            // Create client with consumer via builder
+            ClientConfig clientConfig = new ClientConfig.Builder().setAcceptedOutputModes(List.of("text")).build();
+
+            Client client = Client.builder(agentCard)
+                    .clientConfig(clientConfig)
+                    .withTransport(JSONRPCTransport.class, new JSONRPCTransportConfig())
+                    .addConsumers(List.of(consumer))
+                    .build();
+
+            client.sendMessage(message);
+
+            // Wait for response (with timeout)
+            String result = responseFuture.get(60, java.util.concurrent.TimeUnit.SECONDS);
+            logger.info("Agent '{}' response: {}", subagent.getName(), result);
+            return result;
+        } catch (Exception e) {
+            logger.error("Error sending message to agent '{}': {}", subagent.getName(), e.getMessage());
+            return String.format("Error communicating with agent '%s': %s", subagent.getName(), e.getMessage());
+        }
+    }
 
 }


### PR DESCRIPTION
# Fix A2ASubagentExecutor to handle asynchronous task lifecycle events

## Problem
The current implementation of `A2ASubagentExecutor` completes the `CompletableFuture` upon receiving the first `TaskEvent`, assuming that this event already contains the final result.

However, many remote A2A agents follow an asynchronous lifecycle and emit multiple intermediate states before delivering the actual output, such as:
- `submitted` → `working` → `completed`

Because the original code does not wait for the terminal state, the executor returns an **empty string** (`""`) for any agent that does not send the `completed` state in the very first event. This breaks integrations with real-world A2A agents that require longer processing times.

## Solution
- The event consumer now handles both `TaskEvent` and `TaskUpdateEvent` (the latter is used for state transitions).
- The `Task` object is extracted from either event type.
- The response text is still aggregated from `Artifacts` as before.
- The `responseFuture.complete()` call is now gated by `taskState.isFinal()`, ensuring that the future only completes when the remote task has reached a **terminal state** (e.g., `completed` or `failed`).
- Added the missing import for `io.a2a.spec.TaskState`.

## Impact
- ✅ Fixes empty responses when integrating with asynchronous A2A agents that emit multiple lifecycle events.
- ✅ Maintains full backward compatibility with agents that directly emit a `completed` state (the future completes correctly in that case as well).
- ✅ Improves logging visibility by printing each intermediate task state, making debugging easier.

## Testing
- Validated against a mock agent emitting the sequence `submitted` → `working` → `completed`. The executor now correctly waits for the final state and returns the aggregated text.
- Also tested against agents returning a direct `completed` event — behavior remains unchanged and the result is returned as expected.
- Timeout handling (60 seconds) remains intact and prevents infinite hangs.

## Checklist
- [x] Handles both `TaskEvent` and `TaskUpdateEvent`.
- [x] Only completes the response future when the task state is final.
- [x] No breaking changes to the public API or existing consumers.
- [x] Logging updated to reflect intermediate statuses for better traceability.