### PR TITLE
fix(doc): fix typo of AutoAutoMemoryToolsAdvisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ spring-ai-agent-utils/
     └── memory/
         ├── memory-tools-demo/           # Long-term memory with AutoMemoryTools (manual setup)
         ├── memory-filesystem-tools-demo/# Long-term memory with general FileSystemTools
-        └── memory-tools-advisor-demo/   # Long-term memory via AutoAutoMemoryToolsAdvisor
+        └── memory-tools-advisor-demo/   # Long-term memory via AutoMemoryToolsAdvisor
 ```
 
 ## Agentic Utils
@@ -62,7 +62,7 @@ These are the agent tools needed to implement any agentic behavior
 #### Long-term memory
 
 - **[AutoMemoryTools](spring-ai-agent-utils/docs/AutoMemoryTools.md)** - Persistent, file-based long-term memory that survives across conversations. Agents store typed memory files (`user`, `feedback`, `project`, `reference`) in a sandboxed directory and navigate them via a `MEMORY.md` index. Requires the companion `classpath:/prompt/AUTO_MEMORY_TOOLS_SYSTEM_PROMPT.md` system prompt (bundled in the jar) to instruct the agent on when and how to use the tools. Inspired by [Claude Code memory](https://code.claude.com/docs/en/memory) and the [Claude API SDK memory tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool).
-- **[AutoAutoMemoryToolsAdvisor](spring-ai-agent-utils/docs/AutoAutoMemoryToolsAdvisor.md)** - A `ChatClient` advisor that wires `AutoMemoryTools` and its companion system prompt into the request pipeline automatically. Eliminates manual tool and prompt registration, deduplicates callbacks, and supports an optional `memoryConsolidationTrigger` to prompt the model to summarise and clean up memories on a schedule.
+- **[AutoMemoryToolsAdvisor](spring-ai-agent-utils/docs/AutoMemoryToolsAdvisor.md)** - A `ChatClient` advisor that wires `AutoMemoryTools` and its companion system prompt into the request pipeline automatically. Eliminates manual tool and prompt registration, deduplicates callbacks, and supports an optional `memoryConsolidationTrigger` to prompt the model to summarise and clean up memories on a schedule.
 
 #### Task orchestration & multi-agent
 
@@ -234,7 +234,7 @@ mvn spring-boot:run
 | [ask-user-question-demo](examples/ask-user-question-demo) | Interactive agent-user communication with `AskUserQuestionTool` |
 | [memory/memory-tools-demo](examples/memory/memory-tools-demo) | Long-term memory across conversations using dedicated, sandboxed `AutoMemoryTools` (manual setup) |
 | [memory/memory-filesystem-tools-demo](examples/memory/memory-filesystem-tools-demo) | Long-term memory using general-purpose `FileSystemTools` — no dedicated memory tooling required |
-| [memory/memory-tools-advisor-demo](examples/memory/memory-tools-advisor-demo) | Long-term memory via `AutoAutoMemoryToolsAdvisor` — advisor-based setup with consolidation trigger |
+| [memory/memory-tools-advisor-demo](examples/memory/memory-tools-advisor-demo) | Long-term memory via `AutoMemoryToolsAdvisor` — advisor-based setup with consolidation trigger |
 
 See [examples/README.md](examples/README.md) for setup and usage details.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ spring-ai-agent-utils/
     └── memory/
         ├── memory-tools-demo/           # Long-term memory with AutoMemoryTools (manual setup)
         ├── memory-filesystem-tools-demo/# Long-term memory with general FileSystemTools
-        └── memory-tools-advisor-demo/   # Long-term memory via AutoAutoMemoryToolsAdvisor
+        └── memory-tools-advisor-demo/   # Long-term memory via AutoMemoryToolsAdvisor
 ```
 
 ## Quick Start
@@ -171,7 +171,7 @@ mvn spring-boot:run
 | `ask-user-question-demo` | Interactive agent-user communication with `AskUserQuestionTool` |
 | `memory/memory-tools-demo` | Long-term memory across conversations using dedicated, sandboxed `AutoMemoryTools` (manual setup) |
 | `memory/memory-filesystem-tools-demo` | Long-term memory using general-purpose `FileSystemTools` — no dedicated memory tooling required |
-| `memory/memory-tools-advisor-demo` | Long-term memory via `AutoAutoMemoryToolsAdvisor` — advisor-based setup with consolidation trigger |
+| `memory/memory-tools-advisor-demo` | Long-term memory via `AutoMemoryToolsAdvisor` — advisor-based setup with consolidation trigger |
 
 ## License
 

--- a/docs/tools/AutoMemoryToolsAdvisor.md
+++ b/docs/tools/AutoMemoryToolsAdvisor.md
@@ -1,8 +1,8 @@
-# AutoAutoMemoryToolsAdvisor
+# AutoMemoryToolsAdvisor
 
 A Spring AI `ChatClient` advisor that gives any agent **automatic long-term memory** by wiring [`AutoMemoryTools`](AutoMemoryTools.md) and its companion system prompt into the request pipeline as a single, self-contained unit.
 
-![AutoAutoMemoryToolsAdvisor](../images/spring-ai-auto-memory-tools-advisor.png)
+![AutoMemoryToolsAdvisor](../images/spring-ai-auto-memory-tools-advisor.png)
 
 ## What it does
 
@@ -18,9 +18,9 @@ If the prompt carries no `ToolCallingChatOptions` the request is returned unchan
 
 ## Long-term memory vs. session memory
 
-`AutoAutoMemoryToolsAdvisor` is a **long-term memory** mechanism. It is designed to complement, not replace, Spring AI's built-in short-term conversation memory (e.g. `MessageChatMemoryAdvisor` + `MessageWindowChatMemory`). The two layers serve fundamentally different purposes and should normally be used together:
+`AutoMemoryToolsAdvisor` is a **long-term memory** mechanism. It is designed to complement, not replace, Spring AI's built-in short-term conversation memory (e.g. `MessageChatMemoryAdvisor` + `MessageWindowChatMemory`). The two layers serve fundamentally different purposes and should normally be used together:
 
-| | Session memory (`MessageChatMemoryAdvisor`) | Long-term memory (`AutoAutoMemoryToolsAdvisor`) |
+| | Session memory (`MessageChatMemoryAdvisor`) | Long-term memory (`AutoMemoryToolsAdvisor`) |
 |---|---|---|
 | **Scope** | Current conversation only | Persists across conversations |
 | **Storage** | In-process (`ChatMemory`) | Files on disk via `AutoMemoryTools` |
@@ -34,7 +34,7 @@ A typical agent setup combines both:
 ChatClient chatClient = ChatClient.builder(chatModel)
     .defaultAdvisors(
         // Long-term memory — facts that survive across sessions
-        AutoAutoMemoryToolsAdvisor.builder()
+        AutoMemoryToolsAdvisor.builder()
             .memoriesRootDirectory("/home/user/.agent/memories")
             .build(),
 
@@ -54,7 +54,7 @@ In this setup the model has the best of both worlds: the full context of the cur
 ## Quick Start
 
 ```java
-AutoAutoMemoryToolsAdvisor memoryAdvisor = AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor memoryAdvisor = AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/home/user/.agent/memories")
     .build();
 
@@ -68,7 +68,7 @@ That's all. On the first turn the model reads `MEMORY.md` via `MemoryView`, load
 ## Builder Configuration
 
 ```java
-AutoAutoMemoryToolsAdvisor advisor = AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor advisor = AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/path/to/memories")          // required
     .order(BaseAdvisor.HIGHEST_PRECEDENCE + 200)         // optional
     .memorySystemPrompt(customPromptResource)            // optional
@@ -95,7 +95,7 @@ Over time the memory store can accumulate redundant or outdated entries. The `me
 
 ```java
 // Trigger consolidation roughly every 20 requests (stateless approximation)
-AutoAutoMemoryToolsAdvisor advisor = AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor advisor = AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/path/to/memories")
     .memoryConsolidationTrigger((req, instant) ->
         Math.random() < 0.05)   // ~5 % of requests
@@ -170,7 +170,7 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 // Advisor setup — equivalent, less boilerplate
 ChatClient chatClient = ChatClient.builder(chatModel)
     .defaultAdvisors(
-        AutoAutoMemoryToolsAdvisor.builder()
+        AutoMemoryToolsAdvisor.builder()
             .memoriesRootDirectory("/path/to/memories")
             .build())
     .build();
@@ -194,7 +194,7 @@ To use a custom prompt, provide any `Resource` that contains the same placeholde
 @Value("classpath:/my-custom-memory-prompt.md")
 Resource customPrompt;
 
-AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/path/to/memories")
     .memorySystemPrompt(customPrompt)
     .build();
@@ -202,7 +202,7 @@ AutoAutoMemoryToolsAdvisor.builder()
 
 ## Demo Application
 
-See [`memory-tools-advisor-demo`](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-advisor-demo) for a complete runnable example showing `AutoAutoMemoryToolsAdvisor` combined with `MessageChatMemoryAdvisor` and a custom logging advisor.
+See [`memory-tools-advisor-demo`](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-advisor-demo) for a complete runnable example showing `AutoMemoryToolsAdvisor` combined with `MessageChatMemoryAdvisor` and a custom logging advisor.
 
 ## See Also
 

--- a/docs/tools/migration-0.9.md
+++ b/docs/tools/migration-0.9.md
@@ -202,7 +202,7 @@ chatClientBuilder
 
 ## `ToolCallingAdvisor` Requires at Least One Registered Tool (spring-ai #6325)
 
-When using `AutoAutoMemoryToolsAdvisor` without any other tools pre-registered on the `ChatClient`, the auto-configured `ToolCallingAdvisor` may not activate because there are no tools in the default configuration to trigger it. The advisor injects memory tools at request time, but the framework checks for tools at build time.
+When using `AutoMemoryToolsAdvisor` without any other tools pre-registered on the `ChatClient`, the auto-configured `ToolCallingAdvisor` may not activate because there are no tools in the default configuration to trigger it. The advisor injects memory tools at request time, but the framework checks for tools at build time.
 
 **Workaround** — register a dummy tool on the `ChatClient` until the upstream issue is resolved:
 
@@ -214,7 +214,7 @@ public static class DummyTools {
 
 chatClientBuilder
     .defaultTools(new DummyTools())  // workaround for spring-ai#6325
-    .defaultAdvisors(AutoAutoMemoryToolsAdvisor.builder()
+    .defaultAdvisors(AutoMemoryToolsAdvisor.builder()
         .memoriesRootDirectory("/path/to/memories")
         .build())
     .build();

--- a/spring-ai-agent-utils/docs/AutoMemoryToolsAdvisor.md
+++ b/spring-ai-agent-utils/docs/AutoMemoryToolsAdvisor.md
@@ -1,8 +1,8 @@
-# AutoAutoMemoryToolsAdvisor
+# AutoMemoryToolsAdvisor
 
 A Spring AI `ChatClient` advisor that gives any agent **automatic long-term memory** by wiring [`AutoMemoryTools`](AutoMemoryTools.md) and its companion system prompt into the request pipeline as a single, self-contained unit.
 
-![AutoAutoMemoryToolsAdvisor](../images/spring-ai-auto-memory-tools-advisor.png)
+![AutoMemoryToolsAdvisor](../images/spring-ai-auto-memory-tools-advisor.png)
 
 ## What it does
 
@@ -18,9 +18,9 @@ If the prompt carries no `ToolCallingChatOptions` the request is returned unchan
 
 ## Long-term memory vs. session memory
 
-`AutoAutoMemoryToolsAdvisor` is a **long-term memory** mechanism. It is designed to complement, not replace, Spring AI's built-in short-term conversation memory (e.g. `MessageChatMemoryAdvisor` + `MessageWindowChatMemory`). The two layers serve fundamentally different purposes and should normally be used together:
+`AutoMemoryToolsAdvisor` is a **long-term memory** mechanism. It is designed to complement, not replace, Spring AI's built-in short-term conversation memory (e.g. `MessageChatMemoryAdvisor` + `MessageWindowChatMemory`). The two layers serve fundamentally different purposes and should normally be used together:
 
-| | Session memory (`MessageChatMemoryAdvisor`) | Long-term memory (`AutoAutoMemoryToolsAdvisor`) |
+| | Session memory (`MessageChatMemoryAdvisor`) | Long-term memory (`AutoMemoryToolsAdvisor`) |
 |---|---|---|
 | **Scope** | Current conversation only | Persists across conversations |
 | **Storage** | In-process (`ChatMemory`) | Files on disk via `AutoMemoryTools` |
@@ -34,7 +34,7 @@ A typical agent setup combines both:
 ChatClient chatClient = ChatClient.builder(chatModel)
     .defaultAdvisors(
         // Long-term memory — facts that survive across sessions
-        AutoAutoMemoryToolsAdvisor.builder()
+        AutoMemoryToolsAdvisor.builder()
             .memoriesRootDirectory("/home/user/.agent/memories")
             .build(),
 
@@ -54,7 +54,7 @@ In this setup the model has the best of both worlds: the full context of the cur
 ## Quick Start
 
 ```java
-AutoAutoMemoryToolsAdvisor memoryAdvisor = AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor memoryAdvisor = AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/home/user/.agent/memories")
     .build();
 
@@ -68,7 +68,7 @@ That's all. On the first turn the model reads `MEMORY.md` via `MemoryView`, load
 ## Builder Configuration
 
 ```java
-AutoAutoMemoryToolsAdvisor advisor = AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor advisor = AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/path/to/memories")          // required
     .order(BaseAdvisor.HIGHEST_PRECEDENCE + 200)         // optional
     .memorySystemPrompt(customPromptResource)            // optional
@@ -95,7 +95,7 @@ Over time the memory store can accumulate redundant or outdated entries. The `me
 
 ```java
 // Trigger consolidation roughly every 20 requests (stateless approximation)
-AutoAutoMemoryToolsAdvisor advisor = AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor advisor = AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/path/to/memories")
     .memoryConsolidationTrigger((req, instant) ->
         Math.random() < 0.05)   // ~5 % of requests
@@ -170,7 +170,7 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 // Advisor setup — equivalent, less boilerplate
 ChatClient chatClient = ChatClient.builder(chatModel)
     .defaultAdvisors(
-        AutoAutoMemoryToolsAdvisor.builder()
+        AutoMemoryToolsAdvisor.builder()
             .memoriesRootDirectory("/path/to/memories")
             .build())
     .build();
@@ -194,7 +194,7 @@ To use a custom prompt, provide any `Resource` that contains the same placeholde
 @Value("classpath:/my-custom-memory-prompt.md")
 Resource customPrompt;
 
-AutoAutoMemoryToolsAdvisor.builder()
+AutoMemoryToolsAdvisor.builder()
     .memoriesRootDirectory("/path/to/memories")
     .memorySystemPrompt(customPrompt)
     .build();
@@ -202,7 +202,7 @@ AutoAutoMemoryToolsAdvisor.builder()
 
 ## Demo Application
 
-See [`memory-tools-advisor-demo`](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-advisor-demo) for a complete runnable example showing `AutoAutoMemoryToolsAdvisor` combined with `MessageChatMemoryAdvisor` and a custom logging advisor.
+See [`memory-tools-advisor-demo`](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-advisor-demo) for a complete runnable example showing `AutoMemoryToolsAdvisor` combined with `MessageChatMemoryAdvisor` and a custom logging advisor.
 
 ## See Also
 

--- a/spring-ai-agent-utils/docs/migration-0.9.md
+++ b/spring-ai-agent-utils/docs/migration-0.9.md
@@ -202,7 +202,7 @@ chatClientBuilder
 
 ## `ToolCallingAdvisor` Requires at Least One Registered Tool (spring-ai #6325)
 
-When using `AutoAutoMemoryToolsAdvisor` without any other tools pre-registered on the `ChatClient`, the auto-configured `ToolCallingAdvisor` may not activate because there are no tools in the default configuration to trigger it. The advisor injects memory tools at request time, but the framework checks for tools at build time.
+When using `AutoMemoryToolsAdvisor` without any other tools pre-registered on the `ChatClient`, the auto-configured `ToolCallingAdvisor` may not activate because there are no tools in the default configuration to trigger it. The advisor injects memory tools at request time, but the framework checks for tools at build time.
 
 **Workaround** — register a dummy tool on the `ChatClient` until the upstream issue is resolved:
 
@@ -214,7 +214,7 @@ public static class DummyTools {
 
 chatClientBuilder
     .defaultTools(new DummyTools())  // workaround for spring-ai#6325
-    .defaultAdvisors(AutoAutoMemoryToolsAdvisor.builder()
+    .defaultAdvisors(AutoMemoryToolsAdvisor.builder()
         .memoriesRootDirectory("/path/to/memories")
         .build())
     .build();


### PR DESCRIPTION
The typo is somewhat misleading that I checked again and again the version if I need to bump to latest version to get `AutoAutoMemoryToolsAdvisor` and turns out it’s a typo 😅 