### PR TITLE
Add Auto-Dream memory consolidation with cross-session recall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ build/
 .DS_Store
 
 .flattened-pom.xml
+
+/docs/design/**

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,8 @@ spring-ai-agent-utils/
     └── memory/
         ├── memory-tools-demo/           # Long-term memory with AutoMemoryTools (manual setup)
         ├── memory-filesystem-tools-demo/# Long-term memory with general FileSystemTools
-        └── memory-tools-advisor-demo/   # Long-term memory via AutoMemoryToolsAdvisor
+        ├── memory-tools-advisor-demo/   # Long-term memory via AutoAutoMemoryToolsAdvisor
+        └── memory-tools-dream-demo/     # Out-of-band consolidation via AutoDreamAdvisor/AutoDreamService
 ```
 
 ## Quick Start
@@ -171,7 +172,8 @@ mvn spring-boot:run
 | `ask-user-question-demo` | Interactive agent-user communication with `AskUserQuestionTool` |
 | `memory/memory-tools-demo` | Long-term memory across conversations using dedicated, sandboxed `AutoMemoryTools` (manual setup) |
 | `memory/memory-filesystem-tools-demo` | Long-term memory using general-purpose `FileSystemTools` — no dedicated memory tooling required |
-| `memory/memory-tools-advisor-demo` | Long-term memory via `AutoMemoryToolsAdvisor` — advisor-based setup with consolidation trigger |
+| `memory/memory-tools-advisor-demo` | Long-term memory via `AutoAutoMemoryToolsAdvisor` — advisor-based setup with consolidation trigger |
+| `memory/memory-tools-dream-demo` | Out-of-band memory consolidation via `AutoDreamAdvisor`/`AutoDreamService` — automatic and on-demand dream cycles, with optional cross-session recall |
 
 ## License
 

--- a/docs/tools/AutoDreamAdvisor.md
+++ b/docs/tools/AutoDreamAdvisor.md
@@ -1,0 +1,77 @@
+# AutoDreamAdvisor
+
+A `ChatClient` advisor that schedules periodic, out-of-band [`AutoDreamService`](AutoDreamService.md) memory-consolidation cycles on top of an [`AutoMemoryTools`](AutoMemoryTools.md) memory store — the same relationship [`AutoMemoryToolsAdvisor`](AutoMemoryToolsAdvisor.md) has to `AutoMemoryTools`, but for background dreaming instead of live-turn tool injection.
+
+## What it does
+
+Unlike `AutoMemoryToolsAdvisor`, which injects tools and augments the system prompt on every request, `AutoDreamAdvisor` never touches the live request or response:
+
+- **`before()` is a no-op.** Dreaming never adds latency or tokens to the turn the user is waiting on.
+- **`after()`** loads the persisted `DreamState`, increments its turn counter, evaluates the configured `DreamTrigger`, and — only if it fires — submits the dream cycle to a background task and returns immediately. The dream cycle itself runs off the calling thread.
+
+Because it fires from `after()` rather than `before()`, `AutoDreamAdvisor` is order-insensitive relative to other advisors in practice: it doesn't depend on what any other advisor did to the response, and nothing downstream depends on it having run yet.
+
+## Quick Start
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder.clone()).build();
+
+AutoDreamAdvisor dreamAdvisor = AutoDreamAdvisor.builder()
+    .memoriesRootDirectory("/home/user/.agent/memories")
+    .dreamService(dreamService)
+    .dreamTrigger(DreamTriggers.hoursAndSessions(24, 5))
+    .build();
+
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        AutoMemoryToolsAdvisor.builder().memoriesRootDirectory(dir).build(),
+        dreamAdvisor,
+        MessageChatMemoryAdvisor.builder(chatMemory).build())
+    .build();
+```
+
+Point `AutoDreamAdvisor` and `AutoMemoryToolsAdvisor` at the same `memoriesRootDirectory` — one gives the live agent read/write memory tools, the other schedules the Dreamer that periodically cleans that same store up.
+
+## Builder Configuration
+
+```java
+AutoDreamAdvisor advisor = AutoDreamAdvisor.builder()
+    .memoriesRootDirectory("/path/to/memories")          // required
+    .dreamService(dreamService)                           // required
+    .dreamTrigger(DreamTriggers.hoursAndSessions(24, 5))  // optional
+    .userId("alice")                                      // optional — enables cross-session recall
+    .taskRepository(customTaskRepository)                 // optional
+    .order(BaseAdvisor.HIGHEST_PRECEDENCE + 150)          // optional
+    .build();
+```
+
+| Builder method | Type | Default | Description |
+|---|---|---|---|
+| `memoriesRootDirectory(String)` | `String` | — (**required**) | Same memory store an `AutoMemoryToolsAdvisor` is pointed at. |
+| `dreamService(AutoDreamService)` | `AutoDreamService` | — (**required**) | The service that actually runs dream cycles. |
+| `dreamTrigger(DreamTrigger)` | `DreamTrigger` | `DreamTriggers.manualOnly()` | Decides whether a cycle should fire on each turn. See [AutoDreamService — Dream Triggers](AutoDreamService.md#dream-triggers). |
+| `userId(String)` | `String` | none | Optional. When set, triggered cycles call the cross-session-aware `runDreamCycle(dir, userId)` overload instead of the memory-only one — see below. |
+| `taskRepository(TaskRepository)` | `TaskRepository` | a fresh `DefaultTaskRepository` | Where the background dream task is submitted. Override to share a `TaskRepository` with `TaskTool` or other background work. |
+| `order(int)` | `int` | `HIGHEST_PRECEDENCE + 150` | Advisor order — higher precedence than `AutoMemoryToolsAdvisor`'s default (`+200`). |
+
+### `userId(String)` and cross-session recall
+
+Setting `.userId(...)` only has an effect if the advisor's `dreamService` was itself built with `.sessionService(...)` configured (see [AutoDreamService — Cross-Session Recall](AutoDreamService.md#cross-session-recall-optional)). If the service has no `sessionService`, `userId` is passed through but ignored — the Dreamer still only sees the memory store. There's no error in either misconfiguration direction; both degrade gracefully to memory-only dreaming.
+
+## Turn counting
+
+`DreamState.sessionsSinceLastDream()` counts **conversation turns processed by this advisor instance** — every call to `after()` increments it, regardless of whether the turn involved memory tools at all. This is not the same thing as a `spring-ai-session` "session": there is no dependency on session-transcript storage for the trigger itself, only (optionally) for what the Dreamer can search once a cycle starts.
+
+## Relationship to `memoryConsolidationTrigger`
+
+`AutoDreamAdvisor` and `AutoMemoryToolsAdvisor`'s `memoryConsolidationTrigger` are complementary, not alternatives — see the comparison table in [AutoDreamService](AutoDreamService.md#in-band-nudge-vs-out-of-band-dreaming). A typical setup uses both: the in-band nudge for cheap, frequent tidy-ups, and `AutoDreamAdvisor` for periodic, deeper background cleanup.
+
+## Demo Application
+
+See [memory-tools-dream-demo](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-dream-demo) — combines `AutoMemoryToolsAdvisor`, `AutoDreamAdvisor`, and `SessionMemoryAdvisor` in one runnable example.
+
+## See Also
+
+- [AutoDreamService](AutoDreamService.md) — the service this advisor schedules; dream cycle mechanics, `DreamTrigger`/`DreamMode`, cross-session recall
+- [AutoMemoryToolsAdvisor](AutoMemoryToolsAdvisor.md) — the live-turn counterpart this advisor complements
+- [AutoMemoryTools](AutoMemoryTools.md) — the memory store both advisors operate on

--- a/docs/tools/AutoDreamService.md
+++ b/docs/tools/AutoDreamService.md
@@ -1,0 +1,154 @@
+# AutoDreamService
+
+An out-of-band memory-consolidation ("dream") capability for [`AutoMemoryTools`](AutoMemoryTools.md). A dedicated background subagent — the **Dreamer** — periodically reviews an agent's entire memory store (and, optionally, its owner's full conversation history) to deduplicate, prune, merge, and reorganize memories, without ever blocking or adding latency to the live agent's turn.
+
+## In-band nudge vs. out-of-band dreaming
+
+[`AutoMemoryToolsAdvisor`](AutoMemoryToolsAdvisor.md) already ships a `memoryConsolidationTrigger` — a cheap, stateless nudge appended to the *live* agent's *current* turn, asking it to tidy up whatever memory is already in its context. `AutoDreamService` (with [`AutoDreamAdvisor`](AutoDreamAdvisor.md)) is a different, complementary mechanism:
+
+| | `memoryConsolidationTrigger` | Auto-Dream |
+|---|---|---|
+| Where it runs | In-band, the live agent, same turn | Out-of-band, a dedicated Dreamer subagent, background |
+| Blocks the user | Adds to the current turn's latency/tokens | Never — fires after the response is returned |
+| What it sees | Whatever's already in the live agent's context this turn | The entire memory store, and (optionally) the user's full cross-session history |
+| State | Stateless approximation, re-evaluated per call | Persisted `DreamState` — real elapsed-time/turn-count conditions survive restarts |
+| Cost | Cheap, frequent, shallow | Heavier, periodic, deep |
+
+Use both together: `memoryConsolidationTrigger` for cheap, frequent tidy-nudges; Auto-Dream as the periodic deep-clean layer.
+
+## Quick Start
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder.clone())
+    .build();
+
+DreamResult result = dreamService.runDreamCycle("/path/to/memories");
+System.out.println(result.status() + ": " + result.summary());
+```
+
+!!! warning "Always clone the builder"
+    Pass a **cloned, unconfigured** `ChatClient.Builder` — one that has not had the main agent's system prompt or tools chained onto it. `AutoDreamService` builds its own `ChatClient` for the Dreamer, scoped to exactly the tools it's allowed to use. If you pass the main agent's already-configured builder, the Dreamer inherits its tools too.
+
+In practice, pair it with [`AutoDreamAdvisor`](AutoDreamAdvisor.md) so dream cycles fire automatically instead of only on demand:
+
+```java
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        AutoMemoryToolsAdvisor.builder().memoriesRootDirectory(memoryDir).build(),
+        AutoDreamAdvisor.builder()
+            .memoriesRootDirectory(memoryDir)
+            .dreamService(dreamService)
+            .dreamTrigger(DreamTriggers.hoursAndSessions(24, 5))
+            .build())
+    .build();
+```
+
+## The Dream Cycle
+
+Each call to `runDreamCycle(...)`:
+
+1. **Acquires a lock** (`.dream.lock` in the memories directory) so two cycles never run concurrently against the same store. A lock older than `staleLockAfter` (default 15 minutes) is treated as abandoned — e.g. from a crashed cycle — and reclaimed.
+2. **Builds a dedicated `ChatClient`** for the Dreamer, scoped to `AutoMemoryTools` (and, optionally, a read-only cross-session search tool — see below) — never the caller's own tools.
+3. **Runs the four-phase pipeline** described in the Dreamer's system prompt:
+    1. **Orient** — reads `MEMORY.md` and the memory directory to see the current shape of the store.
+    2. **Gather signal** — reads through memory files (and, if available, searches cross-session history) for duplicates, contradictions, staleness, and dangling `MEMORY.md` links.
+    3. **Consolidate** — merges duplicates, deletes confirmed-stale/contradicted entries (biased toward merge-and-flag over delete, since this runs unsupervised), normalizes dates.
+    4. **Prune & reindex** — fixes dangling links, keeps `MEMORY.md` under 200 lines.
+4. **Persists `DreamState`** — records when the cycle ran, its outcome, and a summary — and releases the lock.
+
+A model failure during the cycle is captured as a failed `DreamResult` rather than propagated as an exception.
+
+## Builder Configuration
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder)
+    .dreamMode(DreamMode.AUTO_APPLY)                 // optional, default AUTO_APPLY
+    .dreamSystemPrompt(customPromptResource)          // optional
+    .staleLockAfter(Duration.ofMinutes(15))           // optional, default 15 minutes
+    .sessionService(sessionService)                   // optional — enables cross-session recall
+    .build();
+```
+
+| Builder method | Type | Default | Description |
+|---|---|---|---|
+| `builder(ChatClient.Builder)` | `ChatClient.Builder` | — (**required**) | Base builder the Dreamer's `ChatClient` is cloned from. Must not already carry the main agent's system prompt/tools. |
+| `dreamMode(DreamMode)` | `DreamMode` | `AUTO_APPLY` | `AUTO_APPLY` edits memory files in place. `PROPOSE` edits a timestamped copy instead — see [Dream Modes](#dream-modes). |
+| `dreamSystemPrompt(Resource)` | `Resource` | `classpath:/prompt/AUTO_DREAM_SYSTEM_PROMPT.md` | Override the Dreamer's operating instructions. |
+| `staleLockAfter(Duration)` | `Duration` | `15 minutes` | Age at which an unreleased `.dream.lock` is treated as abandoned and reclaimed. |
+| `sessionService(SessionService)` | `SessionService` | none | Optional. See [Cross-Session Recall](#cross-session-recall-optional). |
+
+### Running a cycle
+
+```java
+// Memory-only
+DreamResult result = dreamService.runDreamCycle(memoriesRootDirectory);
+
+// With cross-session recall (requires sessionService(...) configured on the builder)
+DreamResult result = dreamService.runDreamCycle(memoriesRootDirectory, userId);
+```
+
+`DreamResult` is a small record: `status()` is `"completed"`, `"failed"`, or `"skipped"` (already locked), and `summary()` is the Dreamer's own account of what it changed.
+
+## Dream Triggers
+
+`DreamTrigger` decides whether a background dream cycle should fire, evaluated against **persisted** `DreamState` rather than in-memory counters — so the decision survives process restarts, unlike a stateless `BiPredicate`.
+
+```java
+public interface DreamTrigger {
+    boolean shouldDream(DreamState state, Instant now);
+}
+```
+
+`DreamTriggers` provides two factories:
+
+| Factory | Behavior |
+|---|---|
+| `DreamTriggers.hoursAndSessions(hours, sessions)` | Fires only once **both** conditions hold: at least `hours` elapsed since the last dream, and at least `sessions` conversation turns processed since then. A store that has never been dreamed on satisfies the time condition immediately. |
+| `DreamTriggers.manualOnly()` | Never fires automatically — dream cycles only run when `runDreamCycle(...)` is called explicitly. |
+
+Write a custom trigger for anything else — it's a single-method functional interface.
+
+## Dream Modes
+
+| Mode | Behavior | When to use |
+|---|---|---|
+| `AUTO_APPLY` (default) | The Dreamer edits memory files directly. | Single-user/single-agent memory store — the common case. |
+| `PROPOSE` | The entire memory tree (minus dream bookkeeping files) is copied into `<memoriesDir>/.dream-proposals/<timestamp>/` first, and the Dreamer edits the copy instead. The live memory files are left untouched. | Shared/multi-agent memory stores where blind auto-merge is riskier — review the proposal, then apply changes manually via the ordinary `Memory*` tools if you agree with them. |
+
+`PROPOSE` mode produces a plain directory copy — no diff is generated. Compare it against the live directory yourself (e.g. `diff -r`), or read the Dreamer's summary in the returned `DreamResult`.
+
+## Cross-Session Recall (optional)
+
+When [`spring-ai-session`](https://github.com/spring-ai-community/spring-ai-session) is on the classpath and `sessionService(...)` is configured, `runDreamCycle(memoriesRootDirectory, userId)` additionally gives the Dreamer a **read-only** `cross_session_search` tool (spring-ai-session's `CrossSessionRecallTools`), scoped to that one user's entire session history — not just the memory store.
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder.clone())
+    .sessionService(sessionService)   // any SessionService — in-memory, JDBC, etc.
+    .build();
+
+dreamService.runDreamCycle(memoriesRootDirectory, "alice");
+```
+
+Both conditions must hold for cross-session recall to activate: `sessionService(...)` configured on the builder, **and** a non-empty `userId` passed to `runDreamCycle(...)`. Omit either and the Dreamer falls back to memory-only dreaming — no error, no behavior change from the base case.
+
+!!! note "Optional dependency"
+    `spring-ai-agent-utils` declares `spring-ai-session` as `provided` + `optional`. Consumers who never call `.sessionService(...)` don't need it on their own classpath — it's never pulled in transitively. Add it directly to your own project's dependencies to use this feature.
+
+The Dreamer's kickoff prompt automatically tells it when `cross_session_search` is available and scopes its queries with `since = <last dream's timestamp>`, so each cycle only mines history since the previous one. See spring-ai-session's [Cross-Session Recall](https://spring-ai-community.github.io/spring-ai-session/session-management/cross-session-recall/) docs for the tool itself.
+
+## System Prompt
+
+The default companion prompt is bundled at `classpath:/prompt/AUTO_DREAM_SYSTEM_PROMPT.md`. It encodes the four-phase pipeline described above, and — when cross-session recall is available — instructs the Dreamer to run a handful of *targeted* queries (not an exhaustive history read) for three signal categories: corrections ("no,", "don't", "actually", "instead"), explicit save requests ("remember that", "keep in mind"), and decisions ("we decided", "let's go with").
+
+Provide your own via `.dreamSystemPrompt(customResource)` if you need different phases or tone.
+
+## Demo Application
+
+See [memory-tools-dream-demo](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-dream-demo) for a complete runnable example: seeded overlapping memories and a seeded past session (decision + correction) give both the memory-only and cross-session-recall phases of a dream cycle real signal to find, with both an automatic every-3rd-turn trigger and an on-demand `/dream` REPL command.
+
+## See Also
+
+- [AutoDreamAdvisor](AutoDreamAdvisor.md) — the `ChatClient` advisor that schedules dream cycles automatically
+- [AutoMemoryTools](AutoMemoryTools.md) — the memory store the Dreamer consolidates
+- [AutoMemoryToolsAdvisor](AutoMemoryToolsAdvisor.md) — `memoryConsolidationTrigger`, the in-band complement to Auto-Dream
+- [TaskTools](TaskTools.md) — the background-execution infrastructure Auto-Dream reuses for async cycles

--- a/docs/tools/AutoMemoryTools.md
+++ b/docs/tools/AutoMemoryTools.md
@@ -348,3 +348,4 @@ See [memory-tools-demo](https://github.com/spring-ai-community/spring-ai-agent-u
 - [Claude API SDK — Memory Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool) — the official tool specification
 - [FileSystemTools](FileSystemTools.md) — general-purpose file read/write/edit (not scoped to a sandbox)
 - [TodoWriteTool](TodoWriteTool.md) — task tracking within a single conversation
+- [AutoDreamService](AutoDreamService.md) — out-of-band background consolidation for this memory store

--- a/docs/tools/AutoMemoryToolsAdvisor.md
+++ b/docs/tools/AutoMemoryToolsAdvisor.md
@@ -207,6 +207,7 @@ See [`memory-tools-advisor-demo`](https://github.com/spring-ai-community/spring-
 ## See Also
 
 - [AutoMemoryTools](AutoMemoryTools.md) — the underlying tool implementations, file conventions, and security model
+- [AutoDreamAdvisor](AutoDreamAdvisor.md) — schedules out-of-band background consolidation, complementing `memoryConsolidationTrigger`
 - [FileSystemTools](FileSystemTools.md) — general-purpose file read/write/edit (not sandboxed)
 - [Claude Code — Memory](https://code.claude.com/docs/en/memory) — the file-based memory design this library is modelled after
 - [Claude API SDK — Memory Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool) — the official tool specification

--- a/examples/memory/memory-tools-dream-demo/README.md
+++ b/examples/memory/memory-tools-dream-demo/README.md
@@ -1,0 +1,69 @@
+# memory-tools-dream-demo
+
+A runnable Spring Boot console agent demonstrating [`AutoDreamAdvisor` / `AutoDreamService`](../../../spring-ai-agent-utils/docs/design/AutoDream-Design.md) — **both Phase 1 and Phase 2 of Auto-Dream** — running an out-of-band memory-consolidation cycle on top of [`AutoMemoryToolsAdvisor`](../../../spring-ai-agent-utils/docs/AutoMemoryToolsAdvisor.md), with cross-session recall backed by `spring-ai-session`.
+
+## What it demonstrates
+
+- **Seeded, deliberately messy memory (Phase 1 signal)** — on first run the memory directory is seeded with two overlapping `feedback` memories (same fact, worded differently) and one dangling `MEMORY.md` link (points at a file that doesn't exist), so the first dream cycle has real signal to consolidate.
+- **Seeded past session (Phase 2 signal)** — on every run (the in-memory session store doesn't persist), a past session is seeded for user `alice` containing a "decision" ("we decided to use PostgreSQL...") and a "correction" ("actually, let's go with blue-green instead of canary...") timestamped two days ago — exactly the kind of signal the Dreamer's `cross_session_search` tool is instructed to look for.
+- **`AutoDreamAdvisor` firing automatically** — wired with a demo trigger that fires every 3 conversation turns (`state.sessionsSinceLastDream() >= 3`), independent of the production-realistic `DreamTriggers.hoursAndSessions(24, 5)` default, and with `.userId("alice")` so triggered cycles get cross-session recall too. Watch the console for a `Dream cycle [...] finished with status=...` log line appearing **on its own, in the background**, while you keep chatting — that's the point: dreaming never blocks the conversation.
+- **`AutoDreamService` on demand** — type `/dream` in the REPL to run a synchronous dream cycle immediately (via `runDreamCycle(memoryDir, userId)`) and print its result, without waiting for the trigger.
+- **A separate `ChatClient.Builder` for the Dreamer** — the demo clones the builder *before* the main agent's system prompt/tools are chained onto it, so the Dreamer only ever sees `AutoMemoryTools` + (when configured) `cross_session_search`, never the main agent's own tools.
+- **`AutoMemoryToolsAdvisor`** — the live agent's own read/write long-term memory, unchanged from the other memory demos.
+- **`SessionMemoryAdvisor`** — short-term conversation history for the live agent, backed by the *same* `SessionService` the Dreamer's `cross_session_search` reads from. This is what makes the two phases share one substrate: chat here, and it becomes material the next dream cycle can find. Bounded with `TurnCountTrigger(20)` + `SlidingWindowCompactionStrategy.maxEvents(10)` — the same combo used in spring-ai-session's own quickstart — so a long demo session can't grow the live prompt without limit. Compacted-out events are archived, not deleted, and stay searchable via `conversation_search`/`cross_session_search`.
+
+## Advisor stack
+
+```
+AutoMemoryToolsAdvisor   (HIGHEST_PRECEDENCE + 200)  ← long-term memory (live agent)
+AutoDreamAdvisor         (HIGHEST_PRECEDENCE + 150)  ← schedules background dream cycles, userId="alice"
+SessionMemoryAdvisor     (HIGHEST_PRECEDENCE + 1000) ← short-term conversation window, backed by SessionService
+MyLoggingAdvisor         (order = 0)                 ← dev console logger
+```
+
+## Key source files
+
+| File | Purpose |
+|---|---|
+| [`Application.java`](src/main/java/org/springaicommunity/agent/Application.java) | Spring Boot entry point — seeds demo memories and a past session, builds the `ChatClient`, `SessionService`, and `AutoDreamService`, runs the console chat loop |
+| [`MyLoggingAdvisor.java`](src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java) | Development advisor logging user messages, tool calls, and assistant responses |
+| [`application.properties`](src/main/resources/application.properties) | Model credentials, model selection, memory directory path, and demo user ID |
+
+## Running
+
+```bash
+cd examples/memory/memory-tools-dream-demo
+ANTHROPIC_API_KEY=sk-... mvn spring-boot:run
+```
+
+The agent starts a REPL loop:
+
+1. Say hello, mention a preference or two, chat for a few turns.
+2. After the 3rd turn, a dream cycle fires automatically in the background — watch for the `AutoDreamAdvisor` log line reporting what it merged. With `cross_session_search` available, expect it to also surface the seeded decision/correction from the "past session," not just the two `feedback_testing_*.md` entries.
+3. At any point, type `/dream` to force a dream cycle immediately and see its result printed synchronously.
+4. Inspect `${user.home}/.spring-ai-agent/memory-tools-dream-demo/memory` on disk — after a dream cycle you should see the duplicate feedback entries merged, the dangling `MEMORY.md` link removed, and a `.dream-state.json` recording when the last cycle ran.
+
+## Configuration
+
+Memory is stored at `${user.home}/.spring-ai-agent/memory-tools-dream-demo/memory` by default, and the demo user ID defaults to `alice`. Change either in `application.properties`:
+
+```properties
+agent.memory.dir=/path/to/your/memories
+agent.demo.user-id=alice
+```
+
+To try `DreamMode.PROPOSE` instead of the default `AUTO_APPLY` (edits redirected to a reviewable `.dream-proposals/<timestamp>/` copy rather than the live memory files), add `.dreamMode(DreamMode.PROPOSE)` to the `AutoDreamService.builder(...)` call in `Application.java`.
+
+The `application.properties` contains commented-out sections for Anthropic and OpenAI SDK. To switch models, uncomment the relevant starter dependency in `pom.xml` and update the model property — no other Java changes required.
+
+### Session store is in-memory
+
+`InMemorySessionRepository` backs the demo's `SessionService` — the seeded past session (and anything you chat about) resets every time you restart the app. Swap in `spring-ai-session-jdbc` for a persistent store; nothing else in `Application.java` would need to change, since `AutoDreamService`/`SessionMemoryAdvisor` only depend on the `SessionService` interface.
+
+## Resetting the demo
+
+Delete the memory directory to re-seed the file-based memory store on the next run (the session store resets automatically on every restart, since it's in-memory):
+
+```bash
+rm -rf "${HOME}/.spring-ai-agent/memory-tools-dream-demo"
+```

--- a/examples/memory/memory-tools-dream-demo/pom.xml
+++ b/examples/memory/memory-tools-dream-demo/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>4.0.2</version>
+		<relativePath /> <!-- lookup parent from repository -->
+	</parent>
+
+	<groupId>org.springaicommunity</groupId>
+	<artifactId>memory-tools-dream-demo</artifactId>
+	<version>0.1.0-SNAPSHOT</version>
+	<name>memory-tools-dream-demo</name>
+	<description>Demo project for Spring Boot</description>
+
+	<properties>
+		<java.version>17</java.version>
+		<maven.deploy.skip>true</maven.deploy.skip>
+		<spring-ai.version>2.0.0</spring-ai.version>
+		<spring-ai-session.version>0.7.0</spring-ai-session.version>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springaicommunity</groupId>
+			<artifactId>spring-ai-agent-utils</artifactId>
+			<version>0.11.0-SNAPSHOT</version>
+		</dependency>
+
+		<!-- spring-ai-session is `provided` + `optional` on spring-ai-agent-utils itself,
+			so consumers who want Phase 2 (cross-session recall) must declare it directly. -->
+		<dependency>
+			<groupId>org.springaicommunity</groupId>
+			<artifactId>spring-ai-session</artifactId>
+			<version>${spring-ai-session.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- <dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-anthropic</artifactId>
+		</dependency> -->
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
+		</dependency>
+
+		<!-- <dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-google-genai</artifactId>
+		</dependency> -->
+
+		<!-- Netty DNS resolver for macOS -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-resolver-dns-native-macos</artifactId>
+			<classifier>osx-aarch_64</classifier>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<name>Central Portal Snapshots</name>
+			<id>central-portal-snapshots</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+</project>

--- a/examples/memory/memory-tools-dream-demo/src/main/java/org/springaicommunity/agent/Application.java
+++ b/examples/memory/memory-tools-dream-demo/src/main/java/org/springaicommunity/agent/Application.java
@@ -1,0 +1,244 @@
+package org.springaicommunity.agent;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Scanner;
+
+import org.springaicommunity.agent.advisors.AutoMemoryToolsAdvisor;
+import org.springaicommunity.agent.dream.AutoDreamAdvisor;
+import org.springaicommunity.agent.dream.AutoDreamService;
+import org.springaicommunity.agent.dream.DreamResult;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.session.CreateSessionRequest;
+import org.springframework.ai.session.DefaultSessionService;
+import org.springframework.ai.session.InMemorySessionRepository;
+import org.springframework.ai.session.SessionEvent;
+import org.springframework.ai.session.SessionService;
+import org.springframework.ai.session.advisor.SessionMemoryAdvisor;
+import org.springframework.ai.session.compaction.SlidingWindowCompactionStrategy;
+import org.springframework.ai.session.compaction.TurnCountTrigger;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+
+/**
+ * Demonstrates {@code AutoDreamAdvisor} / {@code AutoDreamService} running an
+ * out-of-band memory-consolidation ("dream") cycle on top of {@code AutoMemoryToolsAdvisor},
+ * including the Phase 2 cross-session recall capability (spring-ai-session's
+ * {@code SessionService} + {@code CrossSessionRecallTools}).
+ *
+ * <p>
+ * On first run the memory directory is seeded with two deliberately overlapping memory
+ * files (Phase 1 signal), and an in-memory session store is seeded with a past session
+ * containing a "decision" and a "correction" (Phase 2 signal) — both are real material a
+ * dream cycle can find. Three ways to see a dream cycle run:
+ * <ul>
+ * <li>Automatically — {@code AutoDreamAdvisor} is wired with a trigger that fires every
+ * three conversation turns; watch the console log for a "Dream cycle [...] finished"
+ * line appearing on its own, in the background, while you keep chatting.</li>
+ * <li>On demand — type {@code /dream} in the REPL to run a synchronous dream cycle and
+ * print its result immediately.</li>
+ * </ul>
+ *
+ * <p>
+ * The session store is {@code InMemorySessionRepository} — it resets on every run, unlike
+ * the file-based memory store, which persists across runs. Swap in
+ * {@code spring-ai-session-jdbc} for a persistent store; nothing else in this demo would
+ * need to change.
+ *
+ * @author Christian Tzolov
+ */
+@SpringBootApplication
+public class Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+
+	@Bean
+	CommandLineRunner commandLineRunner(ChatClient.Builder chatClientBuilder,
+			@Value("${agent.memory.dir}") String memoryDir, @Value("${agent.demo.user-id:alice}") String userId)
+			throws IOException {
+
+		return args -> {
+
+			Path memoriesDir = Paths.get(memoryDir);
+			seedDemoMemoriesIfAbsent(memoriesDir);
+
+			SessionService sessionService = DefaultSessionService.builder()
+				.sessionRepository(InMemorySessionRepository.builder().build())
+				.build();
+			seedDemoSessionHistory(sessionService, userId);
+
+			// A separate, unconfigured clone of the builder for the Dreamer — it must
+			// never inherit the main agent's system prompt or tools, only its own.
+			AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder.clone())
+				.sessionService(sessionService)
+				.build();
+
+			ChatClient chatClient = chatClientBuilder // @formatter:off
+
+				.defaultSystem("""
+						You are a helpful assistant with a persistent long-term memory. Use your
+						memory tools to recall relevant facts at the start of a conversation and to
+						save new durable facts about the user as you learn them.
+						""")
+
+				.defaultAdvisors(
+					// Long-term memory — read/write tools for the live agent
+					AutoMemoryToolsAdvisor.builder()
+						.memoriesRootDirectory(memoryDir)
+						.build(),
+
+					// Out-of-band dream cycles — fires automatically every 3 turns in this demo.
+					// userId enables cross-session recall for the cycles this advisor triggers.
+					AutoDreamAdvisor.builder()
+						.memoriesRootDirectory(memoryDir)
+						.dreamService(dreamService)
+						.dreamTrigger((state, now) -> state.sessionsSinceLastDream() >= 3)
+						.userId(userId)
+						.build(),
+
+					// Short-term conversation window, backed by the same SessionService the
+					// Dreamer's cross_session_search reads from — this is what feeds it.
+					// Bounded via the same trigger+strategy combo as the project's own
+					// quickstart, so a long demo session can't grow the live prompt without
+					// limit — compacted-out events stay archived and remain searchable via
+					// conversation_search/cross_session_search, they are not deleted.
+					SessionMemoryAdvisor.builder(sessionService)
+						.defaultUserId(userId)
+						.compactionTrigger(new TurnCountTrigger(20))
+						.compactionStrategy(SlidingWindowCompactionStrategy.builder().maxEvents(10).build())
+						.order(Ordered.HIGHEST_PRECEDENCE + 1000)
+						.build(),
+
+					MyLoggingAdvisor.builder()
+						.showAvailableTools(true)
+						.showSystemMessage(false)
+						.order(Ordered.HIGHEST_PRECEDENCE + 1100)
+						.build())
+				.build();
+				// @formatter:on
+
+			System.out.println("\nI am your assistant. Memory is stored at " + memoriesDir);
+			System.out.println("Session history (user '" + userId + "') is in-memory and resets each run.");
+			System.out.println("Type /dream to run an on-demand dream cycle. Every 3rd turn triggers one automatically.\n");
+
+			try (Scanner scanner = new Scanner(System.in)) {
+				while (true) {
+					System.out.print("\n\033[1;34mUSER>\033[0m ");
+					String userInput = scanner.nextLine();
+
+					if ("/dream".equalsIgnoreCase(userInput.trim())) {
+						System.out.println("\n\033[1;35mDREAM>\033[0m running an on-demand dream cycle...");
+						DreamResult result = dreamService.runDreamCycle(memoryDir, userId);
+						System.out.println("\033[1;35mDREAM>\033[0m status=" + result.status() + " — " + result.summary());
+						continue;
+					}
+
+					System.out.println("\n\033[1;34mASSISTANT>\033[0m " + chatClient.prompt(userInput)
+						.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "session-1"))
+						.call()
+						.content());
+				}
+			}
+		};
+
+	}
+
+	/**
+	 * Seeds the memory directory with two deliberately overlapping feedback memories and
+	 * a dangling {@code MEMORY.md} entry, so the first dream cycle has real signal to
+	 * consolidate. Only runs once — subsequent launches leave the memory store as the
+	 * previous session (and any dream cycles) left it.
+	 */
+	private static void seedDemoMemoriesIfAbsent(Path memoriesDir) throws IOException {
+		Path memoryIndex = memoriesDir.resolve("MEMORY.md");
+		if (Files.exists(memoryIndex)) {
+			return;
+		}
+
+		Files.createDirectories(memoriesDir);
+
+		Files.writeString(memoriesDir.resolve("feedback_testing_a.md"), """
+				---
+				name: testing-preference-a
+				description: Prefer a real database in integration tests
+				type: feedback
+				---
+
+				Always use a real database in integration tests, never mock it.
+
+				**Why:** Mocked tests passed but the prod migration failed last quarter.
+				**How to apply:** Any new integration test touching persistence.
+				""", StandardCharsets.UTF_8);
+
+		Files.writeString(memoriesDir.resolve("feedback_testing_b.md"), """
+				---
+				name: testing-preference-b
+				description: Integration tests must hit a real database, not mocks
+				type: feedback
+				---
+
+				Integration tests must hit a real database, not mocks.
+
+				**Why:** A mock/prod divergence masked a broken migration once.
+				**How to apply:** Whenever writing or reviewing integration tests.
+				""", StandardCharsets.UTF_8);
+
+		Files.writeString(memoryIndex, """
+				- [Testing Preference A](feedback_testing_a.md) — always use a real DB in integration tests
+				- [Testing Preference B](feedback_testing_b.md) — integration tests must hit a real database, not mocks
+				- [Old Sprint Notes](project_old_sprint.md) — sprint 12 deadline notes (file intentionally missing — dangling link)
+				""", StandardCharsets.UTF_8);
+
+		System.out.println("Seeded demo memories at " + memoriesDir
+				+ " — two overlapping feedback entries and one dangling MEMORY.md link.");
+	}
+
+	/**
+	 * Seeds a past session for {@code userId} containing a "decision" and a "correction"
+	 * — exactly the kind of signal {@code AUTO_DREAM_SYSTEM_PROMPT.md} tells the Dreamer
+	 * to search for via {@code cross_session_search}. The in-memory session store starts
+	 * empty on every run, so this always seeds (unlike the file-based memory store, which
+	 * only seeds once).
+	 */
+	private static void seedDemoSessionHistory(SessionService sessionService, String userId) {
+		var pastSession = sessionService.create(CreateSessionRequest.builder().userId(userId).build());
+
+		Instant twoDaysAgo = Instant.now().minus(Duration.ofDays(2));
+
+		sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(pastSession.id())
+			.timestamp(twoDaysAgo)
+			.message(new UserMessage("We decided to use PostgreSQL instead of MySQL for the new service."))
+			.build());
+		sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(pastSession.id())
+			.timestamp(twoDaysAgo.plusSeconds(30))
+			.message(new AssistantMessage("Got it — noted that Postgres is the choice going forward."))
+			.build());
+		sessionService.appendEvent(SessionEvent.builder()
+			.sessionId(pastSession.id())
+			.timestamp(twoDaysAgo.plusSeconds(120))
+			.message(new UserMessage(
+					"Actually, let's go with the blue-green deployment strategy instead of canary."))
+			.build());
+
+		System.out.println(
+				"Seeded a past session for user '" + userId + "' with a decision and a correction (2 days ago).");
+	}
+
+}

--- a/examples/memory/memory-tools-dream-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
+++ b/examples/memory/memory-tools-dream-demo/src/main/java/org/springaicommunity/agent/MyLoggingAdvisor.java
@@ -1,0 +1,153 @@
+package org.springaicommunity.agent;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.MessageType;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.util.JsonHelper;
+import org.springframework.util.StringUtils;
+
+public class MyLoggingAdvisor implements BaseAdvisor {
+
+	private static final String ORANGE = "\033[38;5;208m";
+
+	private static final String RESET = "\033[0m";
+
+	private final int order;
+
+	public final boolean showSystemMessage;
+
+	public final boolean showAvailableTools;
+
+	private MyLoggingAdvisor(int order, boolean showSystemMessage, boolean showAvailableTools) {
+		this.order = order;
+		this.showSystemMessage = showSystemMessage;
+		this.showAvailableTools = showAvailableTools;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+
+		StringBuilder sb = new StringBuilder("\nUSER: ");
+
+		if (this.showSystemMessage && chatClientRequest.prompt().getSystemMessage() != null) {
+			sb.append("\n - SYSTEM: " + first(chatClientRequest.prompt().getSystemMessage().getText(), 60));
+		}
+
+		if (this.showAvailableTools) {
+			Object tools = "No Tools";
+
+			if (chatClientRequest.prompt().getOptions() instanceof ToolCallingChatOptions toolOptions
+					&& toolOptions.getToolCallbacks() != null) {
+				tools = toolOptions.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
+			}
+
+			sb.append("\n - TOOLS: " + new JsonHelper().toJson(tools));
+		}
+
+		Message lastMessage = chatClientRequest.prompt().getLastUserOrToolResponseMessage();
+
+		if (lastMessage.getMessageType() == MessageType.TOOL) {
+			ToolResponseMessage toolResponseMessage = (ToolResponseMessage) lastMessage;
+			for (var toolResponse : toolResponseMessage.getResponses()) {
+				var tr = toolResponse.name() + ": " + first(toolResponse.responseData(), 300);
+				sb.append("\n - TOOL-RESPONSE: " + tr);
+			}
+		}
+		else if (lastMessage.getMessageType() == MessageType.USER) {
+			if (StringUtils.hasText(lastMessage.getText())) {
+				sb.append("\n - TEXT: " + first(lastMessage.getText(), 300));
+			}
+		}
+
+		System.out.println(ORANGE + sb + RESET);
+
+		return chatClientRequest;
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		StringBuilder sb = new StringBuilder("\nASSISTANT: ");
+
+		if (chatClientResponse.chatResponse() == null || chatClientResponse.chatResponse().getResults() == null) {
+			sb.append(" No chat response ");
+			System.out.println(ORANGE + sb + RESET);
+			return chatClientResponse;
+		}
+
+		for (var generation : chatClientResponse.chatResponse().getResults()) {
+			var message = generation.getOutput();
+			if (message.getToolCalls() != null) {
+				for (var toolCall : message.getToolCalls()) {
+					sb.append("\n - TOOL-CALL: ")
+						.append(toolCall.name())
+						.append(" (")
+						.append(toolCall.arguments())
+						.append(")");
+				}
+			}
+
+			if (message.getText() != null) {
+				if (StringUtils.hasText(message.getText())) {
+					sb.append("\n - TEXT: " + first(message.getText(), 200));
+				}
+			}
+		}
+
+		System.out.println(ORANGE + sb + RESET);
+
+		return chatClientResponse;
+	}
+
+	private String first(String text, int n) {
+		if (text.length() <= n) {
+			return text;
+		}
+		return text.substring(0, n) + "...";
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private int order = 0;
+
+		private boolean showSystemMessage = true;
+
+		private boolean showAvailableTools = true;
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder showSystemMessage(boolean showSystemMessage) {
+			this.showSystemMessage = showSystemMessage;
+			return this;
+		}
+
+		public Builder showAvailableTools(boolean showAvailableTools) {
+			this.showAvailableTools = showAvailableTools;
+			return this;
+		}
+
+		public MyLoggingAdvisor build() {
+			MyLoggingAdvisor advisor = new MyLoggingAdvisor(this.order, this.showSystemMessage,
+					this.showAvailableTools);
+			return advisor;
+		}
+
+	}
+
+}

--- a/examples/memory/memory-tools-dream-demo/src/main/resources/application.properties
+++ b/examples/memory/memory-tools-dream-demo/src/main/resources/application.properties
@@ -1,0 +1,29 @@
+spring.application.name=memory-tools-dream-demo
+spring.main.web-application-type=none
+
+## Show AutoDreamAdvisor's background dream-cycle log line in the console
+logging.level.org.springaicommunity.agent.dream=INFO
+
+## Anthropic Claude SDK
+spring.ai.anthropic.api-key=${ANTHROPIC_API_KEY}
+spring.ai.anthropic.chat.options.model=claude-sonnet-4-5-20250929
+spring.ai.anthropic.chat.options.max-tokens=1000
+
+
+## OpenAI SDK
+spring.ai.openai-sdk.api-key=${OPENAI_API_KEY}
+spring.ai.openai-sdk.chat.options.model=gpt-5-mini-2025-08-07
+spring.ai.openai-sdk.chat.options.temperature=1.0
+
+## Google GenAI SDK
+spring.ai.google.genai.project-id=${GOOGLE_CLOUD_PROJECT}
+# spring.ai.google.genai.location=${GOOGLE_CLOUD_LOCATION}
+spring.ai.google.genai.location=global
+spring.ai.google.genai.chat.options.model=gemini-3.1-pro-preview
+
+
+## Memory tools configuration
+agent.memory.dir=${user.home}/.spring-ai-agent/memory-tools-dream-demo/memory
+
+## Demo user ID — scopes both the seeded session history and cross_session_search
+agent.demo.user-id=alice

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -40,6 +40,7 @@
         <module>memory/memory-tools-demo</module>
         <module>memory/memory-tools-advisor-demo</module>
         <module>memory/memory-filesystem-tools-demo</module>
+        <module>memory/memory-tools-dream-demo</module>
     </modules>
 
     <repositories>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,8 @@ nav:
   - Memory:
     - AutoMemoryTools: tools/AutoMemoryTools.md
     - AutoMemoryToolsAdvisor: tools/AutoMemoryToolsAdvisor.md
+    - AutoDreamService: tools/AutoDreamService.md
+    - AutoDreamAdvisor: tools/AutoDreamAdvisor.md
   - Multi-Agent:
     - Task Tools: tools/TaskTools.md
     - Subagent Framework: tools/Subagent.md

--- a/spring-ai-agent-utils/docs/AutoDreamAdvisor.md
+++ b/spring-ai-agent-utils/docs/AutoDreamAdvisor.md
@@ -1,0 +1,77 @@
+# AutoDreamAdvisor
+
+A `ChatClient` advisor that schedules periodic, out-of-band [`AutoDreamService`](AutoDreamService.md) memory-consolidation cycles on top of an [`AutoMemoryTools`](AutoMemoryTools.md) memory store — the same relationship [`AutoMemoryToolsAdvisor`](AutoMemoryToolsAdvisor.md) has to `AutoMemoryTools`, but for background dreaming instead of live-turn tool injection.
+
+## What it does
+
+Unlike `AutoMemoryToolsAdvisor`, which injects tools and augments the system prompt on every request, `AutoDreamAdvisor` never touches the live request or response:
+
+- **`before()` is a no-op.** Dreaming never adds latency or tokens to the turn the user is waiting on.
+- **`after()`** loads the persisted `DreamState`, increments its turn counter, evaluates the configured `DreamTrigger`, and — only if it fires — submits the dream cycle to a background task and returns immediately. The dream cycle itself runs off the calling thread.
+
+Because it fires from `after()` rather than `before()`, `AutoDreamAdvisor` is order-insensitive relative to other advisors in practice: it doesn't depend on what any other advisor did to the response, and nothing downstream depends on it having run yet.
+
+## Quick Start
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder.clone()).build();
+
+AutoDreamAdvisor dreamAdvisor = AutoDreamAdvisor.builder()
+    .memoriesRootDirectory("/home/user/.agent/memories")
+    .dreamService(dreamService)
+    .dreamTrigger(DreamTriggers.hoursAndSessions(24, 5))
+    .build();
+
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        AutoMemoryToolsAdvisor.builder().memoriesRootDirectory(dir).build(),
+        dreamAdvisor,
+        MessageChatMemoryAdvisor.builder(chatMemory).build())
+    .build();
+```
+
+Point `AutoDreamAdvisor` and `AutoMemoryToolsAdvisor` at the same `memoriesRootDirectory` — one gives the live agent read/write memory tools, the other schedules the Dreamer that periodically cleans that same store up.
+
+## Builder Configuration
+
+```java
+AutoDreamAdvisor advisor = AutoDreamAdvisor.builder()
+    .memoriesRootDirectory("/path/to/memories")          // required
+    .dreamService(dreamService)                           // required
+    .dreamTrigger(DreamTriggers.hoursAndSessions(24, 5))  // optional
+    .userId("alice")                                      // optional — enables cross-session recall
+    .taskRepository(customTaskRepository)                 // optional
+    .order(BaseAdvisor.HIGHEST_PRECEDENCE + 150)          // optional
+    .build();
+```
+
+| Builder method | Type | Default | Description |
+|---|---|---|---|
+| `memoriesRootDirectory(String)` | `String` | — (**required**) | Same memory store an `AutoMemoryToolsAdvisor` is pointed at. |
+| `dreamService(AutoDreamService)` | `AutoDreamService` | — (**required**) | The service that actually runs dream cycles. |
+| `dreamTrigger(DreamTrigger)` | `DreamTrigger` | `DreamTriggers.manualOnly()` | Decides whether a cycle should fire on each turn. See [AutoDreamService — Dream Triggers](AutoDreamService.md#dream-triggers). |
+| `userId(String)` | `String` | none | Optional. When set, triggered cycles call the cross-session-aware `runDreamCycle(dir, userId)` overload instead of the memory-only one — see below. |
+| `taskRepository(TaskRepository)` | `TaskRepository` | a fresh `DefaultTaskRepository` | Where the background dream task is submitted. Override to share a `TaskRepository` with `TaskTool` or other background work. |
+| `order(int)` | `int` | `HIGHEST_PRECEDENCE + 150` | Advisor order — higher precedence than `AutoMemoryToolsAdvisor`'s default (`+200`). |
+
+### `userId(String)` and cross-session recall
+
+Setting `.userId(...)` only has an effect if the advisor's `dreamService` was itself built with `.sessionService(...)` configured (see [AutoDreamService — Cross-Session Recall](AutoDreamService.md#cross-session-recall-optional)). If the service has no `sessionService`, `userId` is passed through but ignored — the Dreamer still only sees the memory store. There's no error in either misconfiguration direction; both degrade gracefully to memory-only dreaming.
+
+## Turn counting
+
+`DreamState.sessionsSinceLastDream()` counts **conversation turns processed by this advisor instance** — every call to `after()` increments it, regardless of whether the turn involved memory tools at all. This is not the same thing as a `spring-ai-session` "session": there is no dependency on session-transcript storage for the trigger itself, only (optionally) for what the Dreamer can search once a cycle starts.
+
+## Relationship to `memoryConsolidationTrigger`
+
+`AutoDreamAdvisor` and `AutoMemoryToolsAdvisor`'s `memoryConsolidationTrigger` are complementary, not alternatives — see the comparison table in [AutoDreamService](AutoDreamService.md#in-band-nudge-vs-out-of-band-dreaming). A typical setup uses both: the in-band nudge for cheap, frequent tidy-ups, and `AutoDreamAdvisor` for periodic, deeper background cleanup.
+
+## Demo Application
+
+See [memory-tools-dream-demo](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-dream-demo) — combines `AutoMemoryToolsAdvisor`, `AutoDreamAdvisor`, and `SessionMemoryAdvisor` in one runnable example.
+
+## See Also
+
+- [AutoDreamService](AutoDreamService.md) — the service this advisor schedules; dream cycle mechanics, `DreamTrigger`/`DreamMode`, cross-session recall
+- [AutoMemoryToolsAdvisor](AutoMemoryToolsAdvisor.md) — the live-turn counterpart this advisor complements
+- [AutoMemoryTools](AutoMemoryTools.md) — the memory store both advisors operate on

--- a/spring-ai-agent-utils/docs/AutoDreamService.md
+++ b/spring-ai-agent-utils/docs/AutoDreamService.md
@@ -1,0 +1,154 @@
+# AutoDreamService
+
+An out-of-band memory-consolidation ("dream") capability for [`AutoMemoryTools`](AutoMemoryTools.md). A dedicated background subagent — the **Dreamer** — periodically reviews an agent's entire memory store (and, optionally, its owner's full conversation history) to deduplicate, prune, merge, and reorganize memories, without ever blocking or adding latency to the live agent's turn.
+
+## In-band nudge vs. out-of-band dreaming
+
+[`AutoMemoryToolsAdvisor`](AutoMemoryToolsAdvisor.md) already ships a `memoryConsolidationTrigger` — a cheap, stateless nudge appended to the *live* agent's *current* turn, asking it to tidy up whatever memory is already in its context. `AutoDreamService` (with [`AutoDreamAdvisor`](AutoDreamAdvisor.md)) is a different, complementary mechanism:
+
+| | `memoryConsolidationTrigger` | Auto-Dream |
+|---|---|---|
+| Where it runs | In-band, the live agent, same turn | Out-of-band, a dedicated Dreamer subagent, background |
+| Blocks the user | Adds to the current turn's latency/tokens | Never — fires after the response is returned |
+| What it sees | Whatever's already in the live agent's context this turn | The entire memory store, and (optionally) the user's full cross-session history |
+| State | Stateless approximation, re-evaluated per call | Persisted `DreamState` — real elapsed-time/turn-count conditions survive restarts |
+| Cost | Cheap, frequent, shallow | Heavier, periodic, deep |
+
+Use both together: `memoryConsolidationTrigger` for cheap, frequent tidy-nudges; Auto-Dream as the periodic deep-clean layer.
+
+## Quick Start
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder.clone())
+    .build();
+
+DreamResult result = dreamService.runDreamCycle("/path/to/memories");
+System.out.println(result.status() + ": " + result.summary());
+```
+
+!!! warning "Always clone the builder"
+    Pass a **cloned, unconfigured** `ChatClient.Builder` — one that has not had the main agent's system prompt or tools chained onto it. `AutoDreamService` builds its own `ChatClient` for the Dreamer, scoped to exactly the tools it's allowed to use. If you pass the main agent's already-configured builder, the Dreamer inherits its tools too.
+
+In practice, pair it with [`AutoDreamAdvisor`](AutoDreamAdvisor.md) so dream cycles fire automatically instead of only on demand:
+
+```java
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        AutoMemoryToolsAdvisor.builder().memoriesRootDirectory(memoryDir).build(),
+        AutoDreamAdvisor.builder()
+            .memoriesRootDirectory(memoryDir)
+            .dreamService(dreamService)
+            .dreamTrigger(DreamTriggers.hoursAndSessions(24, 5))
+            .build())
+    .build();
+```
+
+## The Dream Cycle
+
+Each call to `runDreamCycle(...)`:
+
+1. **Acquires a lock** (`.dream.lock` in the memories directory) so two cycles never run concurrently against the same store. A lock older than `staleLockAfter` (default 15 minutes) is treated as abandoned — e.g. from a crashed cycle — and reclaimed.
+2. **Builds a dedicated `ChatClient`** for the Dreamer, scoped to `AutoMemoryTools` (and, optionally, a read-only cross-session search tool — see below) — never the caller's own tools.
+3. **Runs the four-phase pipeline** described in the Dreamer's system prompt:
+    1. **Orient** — reads `MEMORY.md` and the memory directory to see the current shape of the store.
+    2. **Gather signal** — reads through memory files (and, if available, searches cross-session history) for duplicates, contradictions, staleness, and dangling `MEMORY.md` links.
+    3. **Consolidate** — merges duplicates, deletes confirmed-stale/contradicted entries (biased toward merge-and-flag over delete, since this runs unsupervised), normalizes dates.
+    4. **Prune & reindex** — fixes dangling links, keeps `MEMORY.md` under 200 lines.
+4. **Persists `DreamState`** — records when the cycle ran, its outcome, and a summary — and releases the lock.
+
+A model failure during the cycle is captured as a failed `DreamResult` rather than propagated as an exception.
+
+## Builder Configuration
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder)
+    .dreamMode(DreamMode.AUTO_APPLY)                 // optional, default AUTO_APPLY
+    .dreamSystemPrompt(customPromptResource)          // optional
+    .staleLockAfter(Duration.ofMinutes(15))           // optional, default 15 minutes
+    .sessionService(sessionService)                   // optional — enables cross-session recall
+    .build();
+```
+
+| Builder method | Type | Default | Description |
+|---|---|---|---|
+| `builder(ChatClient.Builder)` | `ChatClient.Builder` | — (**required**) | Base builder the Dreamer's `ChatClient` is cloned from. Must not already carry the main agent's system prompt/tools. |
+| `dreamMode(DreamMode)` | `DreamMode` | `AUTO_APPLY` | `AUTO_APPLY` edits memory files in place. `PROPOSE` edits a timestamped copy instead — see [Dream Modes](#dream-modes). |
+| `dreamSystemPrompt(Resource)` | `Resource` | `classpath:/prompt/AUTO_DREAM_SYSTEM_PROMPT.md` | Override the Dreamer's operating instructions. |
+| `staleLockAfter(Duration)` | `Duration` | `15 minutes` | Age at which an unreleased `.dream.lock` is treated as abandoned and reclaimed. |
+| `sessionService(SessionService)` | `SessionService` | none | Optional. See [Cross-Session Recall](#cross-session-recall-optional). |
+
+### Running a cycle
+
+```java
+// Memory-only
+DreamResult result = dreamService.runDreamCycle(memoriesRootDirectory);
+
+// With cross-session recall (requires sessionService(...) configured on the builder)
+DreamResult result = dreamService.runDreamCycle(memoriesRootDirectory, userId);
+```
+
+`DreamResult` is a small record: `status()` is `"completed"`, `"failed"`, or `"skipped"` (already locked), and `summary()` is the Dreamer's own account of what it changed.
+
+## Dream Triggers
+
+`DreamTrigger` decides whether a background dream cycle should fire, evaluated against **persisted** `DreamState` rather than in-memory counters — so the decision survives process restarts, unlike a stateless `BiPredicate`.
+
+```java
+public interface DreamTrigger {
+    boolean shouldDream(DreamState state, Instant now);
+}
+```
+
+`DreamTriggers` provides two factories:
+
+| Factory | Behavior |
+|---|---|
+| `DreamTriggers.hoursAndSessions(hours, sessions)` | Fires only once **both** conditions hold: at least `hours` elapsed since the last dream, and at least `sessions` conversation turns processed since then. A store that has never been dreamed on satisfies the time condition immediately. |
+| `DreamTriggers.manualOnly()` | Never fires automatically — dream cycles only run when `runDreamCycle(...)` is called explicitly. |
+
+Write a custom trigger for anything else — it's a single-method functional interface.
+
+## Dream Modes
+
+| Mode | Behavior | When to use |
+|---|---|---|
+| `AUTO_APPLY` (default) | The Dreamer edits memory files directly. | Single-user/single-agent memory store — the common case. |
+| `PROPOSE` | The entire memory tree (minus dream bookkeeping files) is copied into `<memoriesDir>/.dream-proposals/<timestamp>/` first, and the Dreamer edits the copy instead. The live memory files are left untouched. | Shared/multi-agent memory stores where blind auto-merge is riskier — review the proposal, then apply changes manually via the ordinary `Memory*` tools if you agree with them. |
+
+`PROPOSE` mode produces a plain directory copy — no diff is generated. Compare it against the live directory yourself (e.g. `diff -r`), or read the Dreamer's summary in the returned `DreamResult`.
+
+## Cross-Session Recall (optional)
+
+When [`spring-ai-session`](https://github.com/spring-ai-community/spring-ai-session) is on the classpath and `sessionService(...)` is configured, `runDreamCycle(memoriesRootDirectory, userId)` additionally gives the Dreamer a **read-only** `cross_session_search` tool (spring-ai-session's `CrossSessionRecallTools`), scoped to that one user's entire session history — not just the memory store.
+
+```java
+AutoDreamService dreamService = AutoDreamService.builder(chatClientBuilder.clone())
+    .sessionService(sessionService)   // any SessionService — in-memory, JDBC, etc.
+    .build();
+
+dreamService.runDreamCycle(memoriesRootDirectory, "alice");
+```
+
+Both conditions must hold for cross-session recall to activate: `sessionService(...)` configured on the builder, **and** a non-empty `userId` passed to `runDreamCycle(...)`. Omit either and the Dreamer falls back to memory-only dreaming — no error, no behavior change from the base case.
+
+!!! note "Optional dependency"
+    `spring-ai-agent-utils` declares `spring-ai-session` as `provided` + `optional`. Consumers who never call `.sessionService(...)` don't need it on their own classpath — it's never pulled in transitively. Add it directly to your own project's dependencies to use this feature.
+
+The Dreamer's kickoff prompt automatically tells it when `cross_session_search` is available and scopes its queries with `since = <last dream's timestamp>`, so each cycle only mines history since the previous one. See spring-ai-session's [Cross-Session Recall](https://spring-ai-community.github.io/spring-ai-session/session-management/cross-session-recall/) docs for the tool itself.
+
+## System Prompt
+
+The default companion prompt is bundled at `classpath:/prompt/AUTO_DREAM_SYSTEM_PROMPT.md`. It encodes the four-phase pipeline described above, and — when cross-session recall is available — instructs the Dreamer to run a handful of *targeted* queries (not an exhaustive history read) for three signal categories: corrections ("no,", "don't", "actually", "instead"), explicit save requests ("remember that", "keep in mind"), and decisions ("we decided", "let's go with").
+
+Provide your own via `.dreamSystemPrompt(customResource)` if you need different phases or tone.
+
+## Demo Application
+
+See [memory-tools-dream-demo](https://github.com/spring-ai-community/spring-ai-agent-utils/tree/main/examples/memory/memory-tools-dream-demo) for a complete runnable example: seeded overlapping memories and a seeded past session (decision + correction) give both the memory-only and cross-session-recall phases of a dream cycle real signal to find, with both an automatic every-3rd-turn trigger and an on-demand `/dream` REPL command.
+
+## See Also
+
+- [AutoDreamAdvisor](AutoDreamAdvisor.md) — the `ChatClient` advisor that schedules dream cycles automatically
+- [AutoMemoryTools](AutoMemoryTools.md) — the memory store the Dreamer consolidates
+- [AutoMemoryToolsAdvisor](AutoMemoryToolsAdvisor.md) — `memoryConsolidationTrigger`, the in-band complement to Auto-Dream
+- [TaskTools](TaskTools.md) — the background-execution infrastructure Auto-Dream reuses for async cycles

--- a/spring-ai-agent-utils/docs/AutoMemoryTools.md
+++ b/spring-ai-agent-utils/docs/AutoMemoryTools.md
@@ -348,3 +348,4 @@ See [memory-tools-demo](https://github.com/spring-ai-community/spring-ai-agent-u
 - [Claude API SDK — Memory Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool) — the official tool specification
 - [FileSystemTools](FileSystemTools.md) — general-purpose file read/write/edit (not scoped to a sandbox)
 - [TodoWriteTool](TodoWriteTool.md) — task tracking within a single conversation
+- [AutoDreamService](AutoDreamService.md) — out-of-band background consolidation for this memory store

--- a/spring-ai-agent-utils/docs/AutoMemoryToolsAdvisor.md
+++ b/spring-ai-agent-utils/docs/AutoMemoryToolsAdvisor.md
@@ -207,6 +207,7 @@ See [`memory-tools-advisor-demo`](https://github.com/spring-ai-community/spring-
 ## See Also
 
 - [AutoMemoryTools](AutoMemoryTools.md) — the underlying tool implementations, file conventions, and security model
+- [AutoDreamAdvisor](AutoDreamAdvisor.md) — schedules out-of-band background consolidation, complementing `memoryConsolidationTrigger`
 - [FileSystemTools](FileSystemTools.md) — general-purpose file read/write/edit (not sandboxed)
 - [Claude Code — Memory](https://code.claude.com/docs/en/memory) — the file-based memory design this library is modelled after
 - [Claude API SDK — Memory Tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool) — the official tool specification

--- a/spring-ai-agent-utils/pom.xml
+++ b/spring-ai-agent-utils/pom.xml
@@ -53,6 +53,7 @@
 	<properties>
 		<maven.compiler.target>17</maven.compiler.target>
 		<maven.compiler.source>17</maven.compiler.source>
+		<spring-ai-session.version>0.7.0</spring-ai-session.version>
 	</properties>
 
 	<dependencies>
@@ -74,6 +75,17 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-client-chat</artifactId>
 			<scope>provided</scope>
+		</dependency>
+
+		<!-- Optional: Auto-Dream Phase 2 cross-session recall (AutoDreamService.sessionService(...)).
+			Provided + optional — consumers who don't wire session-integrated dreaming
+			never pull this in transitively. -->
+		<dependency>
+			<groupId>org.springaicommunity</groupId>
+			<artifactId>spring-ai-session</artifactId>
+			<version>${spring-ai-session.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/AutoDreamAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/AutoDreamAdvisor.java
@@ -1,0 +1,191 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.agent.tools.task.repository.DefaultTaskRepository;
+import org.springaicommunity.agent.tools.task.repository.TaskRepository;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.client.advisor.api.BaseChatMemoryAdvisor;
+import org.springframework.util.Assert;
+
+/**
+ * A {@code ChatClient} advisor that schedules periodic, out-of-band Auto-Dream memory
+ * consolidation on top of an {@code AutoMemoryTools} memory store.
+ *
+ * <p>
+ * Unlike {@code AutoMemoryToolsAdvisor.memoryConsolidationTrigger} — an in-band nudge that
+ * asks the <em>live</em> agent to tidy up during its <em>current</em> turn —
+ * {@code AutoDreamAdvisor} never touches the live request/response. {@link #before} is a
+ * no-op, and {@link #after} only ever updates persisted trigger state and, when the
+ * configured {@link DreamTrigger} fires, submits a background task via
+ * {@link TaskRepository} that runs the dream cycle off the calling thread. The two
+ * mechanisms are complementary and are meant to be used together, both pointed at the
+ * same memories root directory.
+ *
+ * <p>
+ * {@link DreamState#sessionsSinceLastDream()} here counts conversation turns processed
+ * by this advisor instance, not multi-turn "sessions" in any broader sense — there is no
+ * dependency on session-transcript storage for triggering.
+ *
+ * <p>
+ * Optionally set {@link Builder#userId(String)} to also enable cross-session recall for
+ * the dream cycles this advisor triggers, provided the {@code dreamService} was built
+ * with {@code AutoDreamService.Builder#sessionService(...)} configured — see
+ * {@link AutoDreamService#runDreamCycle(String, String)}.
+ *
+ * @author Christian Tzolov
+ */
+public class AutoDreamAdvisor implements BaseChatMemoryAdvisor {
+
+	private static final Logger logger = LoggerFactory.getLogger(AutoDreamAdvisor.class);
+
+	private final int order;
+
+	private final String memoriesRootDirectory;
+
+	private final DreamTrigger dreamTrigger;
+
+	private final AutoDreamService dreamService;
+
+	private final TaskRepository taskRepository;
+
+	private final String userId;
+
+	private AutoDreamAdvisor(int order, String memoriesRootDirectory, DreamTrigger dreamTrigger,
+			AutoDreamService dreamService, TaskRepository taskRepository, String userId) {
+		this.order = order;
+		this.memoriesRootDirectory = memoriesRootDirectory;
+		this.dreamTrigger = dreamTrigger;
+		this.dreamService = dreamService;
+		this.taskRepository = taskRepository;
+		this.userId = userId;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		// Dreaming is entirely out-of-band — the live request is never modified.
+		return chatClientRequest;
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+
+		Path memoriesDir = Paths.get(this.memoriesRootDirectory);
+		DreamState state = DreamState.load(memoriesDir).withSessionIncrement();
+		state.save(memoriesDir);
+
+		if (this.dreamTrigger.shouldDream(state, Instant.now())) {
+			String taskId = "dream_" + UUID.randomUUID();
+			this.taskRepository.putTask(taskId, () -> {
+				DreamResult result = this.dreamService.runDreamCycle(this.memoriesRootDirectory, this.userId);
+				logger.info("Dream cycle [{}] for '{}' finished with status={}: {}", taskId,
+						this.memoriesRootDirectory, result.status(), result.summary());
+				return result.summary();
+			});
+		}
+
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		// Higher precedence than AutoMemoryToolsAdvisor's default (+200) so this
+		// advisor's after() — which only fires a background task — wraps outermost.
+		private int order = BaseAdvisor.HIGHEST_PRECEDENCE + 150;
+
+		private String memoriesRootDirectory = "";
+
+		private DreamTrigger dreamTrigger = DreamTriggers.manualOnly();
+
+		private AutoDreamService dreamService;
+
+		private TaskRepository taskRepository = new DefaultTaskRepository();
+
+		private String userId;
+
+		private Builder() {
+		}
+
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public Builder memoriesRootDirectory(String memoriesRootDirectory) {
+			this.memoriesRootDirectory = memoriesRootDirectory;
+			return this;
+		}
+
+		public Builder dreamTrigger(DreamTrigger dreamTrigger) {
+			Assert.notNull(dreamTrigger, "dreamTrigger must not be null");
+			this.dreamTrigger = dreamTrigger;
+			return this;
+		}
+
+		public Builder dreamService(AutoDreamService dreamService) {
+			Assert.notNull(dreamService, "dreamService must not be null");
+			this.dreamService = dreamService;
+			return this;
+		}
+
+		public Builder taskRepository(TaskRepository taskRepository) {
+			Assert.notNull(taskRepository, "taskRepository must not be null");
+			this.taskRepository = taskRepository;
+			return this;
+		}
+
+		/**
+		 * Optional. When set, dream cycles triggered by this advisor call
+		 * {@code AutoDreamService.runDreamCycle(memoriesRootDirectory, userId)} instead of
+		 * the single-argument overload, enabling cross-session recall for the Dreamer —
+		 * provided {@code dreamService} was itself built with a {@code sessionService}
+		 * configured. Has no effect otherwise.
+		 */
+		public Builder userId(String userId) {
+			this.userId = userId;
+			return this;
+		}
+
+		public AutoDreamAdvisor build() {
+			Assert.hasText(this.memoriesRootDirectory, "memoriesRootDirectory must not be empty");
+			Assert.notNull(this.dreamService, "dreamService must be provided");
+			return new AutoDreamAdvisor(this.order, this.memoriesRootDirectory, this.dreamTrigger, this.dreamService,
+					this.taskRepository, this.userId);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/AutoDreamService.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/AutoDreamService.java
@@ -26,9 +26,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -37,11 +34,8 @@ import org.slf4j.LoggerFactory;
 import org.springaicommunity.agent.tools.AutoMemoryTools;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
 import org.springframework.ai.session.SessionService;
 import org.springframework.ai.session.tool.CrossSessionRecallTools;
-import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.method.MethodToolCallbackProvider;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
@@ -53,14 +47,14 @@ import org.springframework.util.StringUtils;
  * reorganizes it, independently of any live conversation.
  *
  * <p>
- * Each call to {@link #runDreamCycle(String)} builds its own short-lived {@link ChatClient}
- * scoped to exactly the tools the Dreamer is allowed to use — never the caller's tools —
- * guarded by a {@link DreamLock} so two cycles never run concurrently against the same
- * memory store.
+ * Each call to {@link #runDreamCycle(String)} builds its own short-lived
+ * {@link ChatClient} scoped to exactly the tools the Dreamer is allowed to use — never
+ * the caller's tools — guarded by a {@link DreamLock} so two cycles never run
+ * concurrently against the same memory store.
  *
  * <p>
- * When {@link Builder#sessionService(SessionService)} is configured, {@link
- * #runDreamCycle(String, String)} additionally gives the Dreamer a read-only
+ * When {@link Builder#sessionService(SessionService)} is configured,
+ * {@link #runDreamCycle(String, String)} additionally gives the Dreamer a read-only
  * {@code cross_session_search} tool ({@link CrossSessionRecallTools}) scoped to the given
  * {@code userId}, so it can mine historical conversation signal in addition to
  * self-consolidating the memory store. Without a configured {@code sessionService} (or
@@ -102,8 +96,8 @@ public class AutoDreamService {
 
 	/**
 	 * Runs one memory-only dream cycle against {@code memoriesRootDirectory} — equivalent
-	 * to {@code runDreamCycle(memoriesRootDirectory, null)}. Safe to call synchronously or
-	 * from a background task — this method blocks until the Dreamer finishes.
+	 * to {@code runDreamCycle(memoriesRootDirectory, null)}. Safe to call synchronously
+	 * or from a background task — this method blocks until the Dreamer finishes.
 	 * @param memoriesRootDirectory the memories root directory to consolidate
 	 * @return the outcome of the cycle; {@link DreamResult#skipped(String)} if another
 	 * cycle already holds the lock for this directory
@@ -129,6 +123,7 @@ public class AutoDreamService {
 
 		Path liveMemoriesDir = Paths.get(memoriesRootDirectory);
 		try {
+			// Create directory if not exists, ignore otherwise.
 			Files.createDirectories(liveMemoriesDir);
 		}
 		catch (IOException e) {
@@ -152,22 +147,14 @@ public class AutoDreamService {
 
 		boolean crossSessionRecallAvailable = this.sessionService != null && StringUtils.hasText(userId);
 
-		List<ToolCallback> toolCallbacks = new ArrayList<>(Arrays.asList(MethodToolCallbackProvider.builder()
-			.toolObjects(AutoMemoryTools.builder().memoriesDir(dreamTargetDir).build())
-			.build()
-			.getToolCallbacks()));
+		var chatClientBuilder = this.chatClientBuilder.clone()
+			.defaultTools(AutoMemoryTools.builder().memoriesDir(dreamTargetDir).build());
 
 		if (crossSessionRecallAvailable) {
-			toolCallbacks.addAll(Arrays.asList(MethodToolCallbackProvider.builder()
-				.toolObjects(CrossSessionRecallTools.builder(this.sessionService, userId).build())
-				.build()
-				.getToolCallbacks()));
+			chatClientBuilder.defaultTools(CrossSessionRecallTools.builder(this.sessionService, userId).build());
 		}
 
-		ChatClient dreamerChatClient = this.chatClientBuilder.clone()
-			.defaultTools(toolCallbacks)
-			// .defaultAdvisors(ToolCallingAdvisor.builder().build()) // toolcalling advisor is auto-enabled by default.
-			.build();
+		ChatClient dreamerChatClient = chatClientBuilder.build();
 
 		String status;
 		String summary;

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/AutoDreamService.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/AutoDreamService.java
@@ -1,0 +1,346 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springaicommunity.agent.tools.AutoMemoryTools;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.ToolCallingAdvisor;
+import org.springframework.ai.session.SessionService;
+import org.springframework.ai.session.tool.CrossSessionRecallTools;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.method.MethodToolCallbackProvider;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Runs an out-of-band memory-consolidation ("dream") cycle: a dedicated subagent — the
+ * Dreamer — reviews an {@code AutoMemoryTools} memory store and deduplicates, prunes, and
+ * reorganizes it, independently of any live conversation.
+ *
+ * <p>
+ * Each call to {@link #runDreamCycle(String)} builds its own short-lived {@link ChatClient}
+ * scoped to exactly the tools the Dreamer is allowed to use — never the caller's tools —
+ * guarded by a {@link DreamLock} so two cycles never run concurrently against the same
+ * memory store.
+ *
+ * <p>
+ * When {@link Builder#sessionService(SessionService)} is configured, {@link
+ * #runDreamCycle(String, String)} additionally gives the Dreamer a read-only
+ * {@code cross_session_search} tool ({@link CrossSessionRecallTools}) scoped to the given
+ * {@code userId}, so it can mine historical conversation signal in addition to
+ * self-consolidating the memory store. Without a configured {@code sessionService} (or
+ * without a {@code userId}), the Dreamer only ever sees {@code AutoMemoryTools} — this is
+ * an additive, opt-in capability, not a requirement.
+ *
+ * @author Christian Tzolov
+ */
+public class AutoDreamService {
+
+	private static final Logger logger = LoggerFactory.getLogger(AutoDreamService.class);
+
+	private static final Resource DEFAULT_DREAM_SYSTEM_PROMPT = new DefaultResourceLoader()
+		.getResource("classpath:/prompt/AUTO_DREAM_SYSTEM_PROMPT.md");
+
+	static final String PROPOSALS_DIR_NAME = ".dream-proposals";
+
+	private static final DateTimeFormatter PROPOSAL_STAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssSSS")
+		.withZone(ZoneOffset.UTC);
+
+	private final ChatClient.Builder chatClientBuilder;
+
+	private final String dreamSystemPrompt;
+
+	private final DreamMode dreamMode;
+
+	private final Duration staleLockAfter;
+
+	private final SessionService sessionService;
+
+	private AutoDreamService(ChatClient.Builder chatClientBuilder, String dreamSystemPrompt, DreamMode dreamMode,
+			Duration staleLockAfter, SessionService sessionService) {
+		this.chatClientBuilder = chatClientBuilder;
+		this.dreamSystemPrompt = dreamSystemPrompt;
+		this.dreamMode = dreamMode;
+		this.staleLockAfter = staleLockAfter;
+		this.sessionService = sessionService;
+	}
+
+	/**
+	 * Runs one memory-only dream cycle against {@code memoriesRootDirectory} — equivalent
+	 * to {@code runDreamCycle(memoriesRootDirectory, null)}. Safe to call synchronously or
+	 * from a background task — this method blocks until the Dreamer finishes.
+	 * @param memoriesRootDirectory the memories root directory to consolidate
+	 * @return the outcome of the cycle; {@link DreamResult#skipped(String)} if another
+	 * cycle already holds the lock for this directory
+	 */
+	public DreamResult runDreamCycle(String memoriesRootDirectory) {
+		return this.runDreamCycle(memoriesRootDirectory, null);
+	}
+
+	/**
+	 * Runs one dream cycle against {@code memoriesRootDirectory}. When both a
+	 * {@code sessionService} was configured on the builder and {@code userId} is
+	 * non-empty, the Dreamer additionally gets a read-only {@code cross_session_search}
+	 * tool scoped to that user's session history; otherwise this behaves exactly like
+	 * {@link #runDreamCycle(String)}.
+	 * @param memoriesRootDirectory the memories root directory to consolidate
+	 * @param userId whose session history to make searchable, or {@code null}/empty for
+	 * memory-only dreaming
+	 * @return the outcome of the cycle; {@link DreamResult#skipped(String)} if another
+	 * cycle already holds the lock for this directory
+	 */
+	public DreamResult runDreamCycle(String memoriesRootDirectory, String userId) {
+		Assert.hasText(memoriesRootDirectory, "memoriesRootDirectory must not be empty");
+
+		Path liveMemoriesDir = Paths.get(memoriesRootDirectory);
+		try {
+			Files.createDirectories(liveMemoriesDir);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Failed to create memories directory: " + liveMemoriesDir, e);
+		}
+
+		Optional<DreamLock> lock = DreamLock.tryAcquire(liveMemoriesDir, this.staleLockAfter);
+		if (lock.isEmpty()) {
+			return DreamResult.skipped("A dream cycle is already running for " + memoriesRootDirectory);
+		}
+
+		try (DreamLock acquired = lock.get()) {
+			return this.doDream(liveMemoriesDir, userId);
+		}
+	}
+
+	private DreamResult doDream(Path liveMemoriesDir, String userId) {
+
+		DreamState state = DreamState.load(liveMemoriesDir);
+		Path dreamTargetDir = this.prepareTargetMemoriesDir(liveMemoriesDir);
+
+		boolean crossSessionRecallAvailable = this.sessionService != null && StringUtils.hasText(userId);
+
+		List<ToolCallback> toolCallbacks = new ArrayList<>(Arrays.asList(MethodToolCallbackProvider.builder()
+			.toolObjects(AutoMemoryTools.builder().memoriesDir(dreamTargetDir).build())
+			.build()
+			.getToolCallbacks()));
+
+		if (crossSessionRecallAvailable) {
+			toolCallbacks.addAll(Arrays.asList(MethodToolCallbackProvider.builder()
+				.toolObjects(CrossSessionRecallTools.builder(this.sessionService, userId).build())
+				.build()
+				.getToolCallbacks()));
+		}
+
+		ChatClient dreamerChatClient = this.chatClientBuilder.clone()
+			.defaultTools(toolCallbacks)
+			// .defaultAdvisors(ToolCallingAdvisor.builder().build()) // toolcalling advisor is auto-enabled by default.
+			.build();
+
+		String status;
+		String summary;
+		try {
+			summary = dreamerChatClient.prompt()
+				.system(this.dreamSystemPrompt)
+				.user(this.buildKickoffPrompt(state, crossSessionRecallAvailable))
+				.call()
+				.content();
+			status = "completed";
+		}
+		catch (Exception ex) {
+			logger.error("Dream cycle failed for {}", liveMemoriesDir, ex);
+			summary = "Dream cycle failed: " + ex.getMessage();
+			status = "failed";
+		}
+
+		DreamState updated = state.withDreamCompleted(Instant.now(), status, summary);
+		updated.save(liveMemoriesDir);
+
+		return new DreamResult(status, summary);
+	}
+
+	/**
+	 * In {@link DreamMode#AUTO_APPLY} the Dreamer edits the live memory store directly.
+	 * In {@link DreamMode#PROPOSE} it edits a timestamped copy instead, leaving the live
+	 * store untouched.
+	 */
+	private Path prepareTargetMemoriesDir(Path liveMemoriesDir) {
+		if (this.dreamMode == DreamMode.AUTO_APPLY) {
+			return liveMemoriesDir;
+		}
+		String stamp = PROPOSAL_STAMP_FORMAT.format(Instant.now());
+		Path proposalDir = liveMemoriesDir.resolve(PROPOSALS_DIR_NAME).resolve(stamp);
+		this.copyMemoriesTree(liveMemoriesDir, proposalDir);
+		return proposalDir;
+	}
+
+	private void copyMemoriesTree(Path source, Path target) {
+		try {
+			Files.createDirectories(target);
+			try (Stream<Path> walk = Files.walk(source)) {
+				for (Path path : walk.filter(p -> !this.isDreamInternal(source, p)).toList()) {
+					Path relative = source.relativize(path);
+					if (relative.toString().isEmpty()) {
+						continue;
+					}
+					Path destination = target.resolve(relative.toString());
+					if (Files.isDirectory(path)) {
+						Files.createDirectories(destination);
+					}
+					else {
+						Files.copy(path, destination, StandardCopyOption.REPLACE_EXISTING);
+					}
+				}
+			}
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Failed to prepare dream proposal directory: " + target, e);
+		}
+	}
+
+	/**
+	 * Excludes the dream bookkeeping files themselves (and the proposals directory) from
+	 * the copy made for {@link DreamMode#PROPOSE}.
+	 */
+	private boolean isDreamInternal(Path root, Path path) {
+		Path relative = root.relativize(path);
+		if (relative.toString().isEmpty()) {
+			return false;
+		}
+		String top = relative.getName(0).toString();
+		return top.equals(DreamState.STATE_FILE_NAME) || top.equals(DreamLock.LOCK_FILE_NAME)
+				|| top.equals(PROPOSALS_DIR_NAME);
+	}
+
+	private String buildKickoffPrompt(DreamState state, boolean crossSessionRecallAvailable) {
+		String lastDream = state.lastDreamAt() != null ? state.lastDreamAt() : "never (this is the first dream cycle)";
+		String base = """
+				Begin a memory-dream consolidation cycle now.
+				Last dream completed at: %s
+				Conversation turns processed since then: %d
+
+				Follow the four-phase process from your operating instructions and finish by \
+				returning a short summary of what you changed (or "no changes needed" if the \
+				memory store was already clean).
+				""".formatted(lastDream, state.sessionsSinceLastDream());
+
+		if (!crossSessionRecallAvailable) {
+			return base;
+		}
+
+		String sinceGuidance = state.lastDreamAt() != null
+				? "scope your queries with since = " + state.lastDreamAt()
+						+ " so you only see history from after the last dream"
+				: "this is the first dream cycle, so omit 'since' and search the full history";
+
+		return base + """
+
+				The cross_session_search tool is available this cycle. Use it during the \
+				"gather signal" phase to look for corrections, explicit "remember this" \
+				requests, and decisions across past sessions — %s.
+				""".formatted(sinceGuidance);
+	}
+
+	public static Builder builder(ChatClient.Builder chatClientBuilder) {
+		return new Builder(chatClientBuilder);
+	}
+
+	public static final class Builder {
+
+		private final ChatClient.Builder chatClientBuilder;
+
+		private Resource dreamSystemPrompt = DEFAULT_DREAM_SYSTEM_PROMPT;
+
+		private DreamMode dreamMode = DreamMode.AUTO_APPLY;
+
+		private Duration staleLockAfter = Duration.ofMinutes(15);
+
+		private SessionService sessionService;
+
+		private Builder(ChatClient.Builder chatClientBuilder) {
+			Assert.notNull(chatClientBuilder, "chatClientBuilder must not be null");
+			this.chatClientBuilder = chatClientBuilder;
+		}
+
+		public Builder dreamSystemPrompt(Resource dreamSystemPrompt) {
+			Assert.notNull(dreamSystemPrompt, "dreamSystemPrompt must not be null");
+			this.dreamSystemPrompt = dreamSystemPrompt;
+			return this;
+		}
+
+		public Builder dreamMode(DreamMode dreamMode) {
+			Assert.notNull(dreamMode, "dreamMode must not be null");
+			this.dreamMode = dreamMode;
+			return this;
+		}
+
+		/**
+		 * Age at which an unreleased {@code .dream.lock} is treated as abandoned (e.g.
+		 * left behind by a crashed dream cycle) and reclaimed by the next attempt.
+		 * Defaults to 15 minutes.
+		 */
+		public Builder staleLockAfter(Duration staleLockAfter) {
+			Assert.notNull(staleLockAfter, "staleLockAfter must not be null");
+			this.staleLockAfter = staleLockAfter;
+			return this;
+		}
+
+		/**
+		 * Optional. When set, {@link AutoDreamService#runDreamCycle(String, String)}
+		 * gives the Dreamer a read-only {@code cross_session_search} tool scoped to
+		 * whichever {@code userId} is passed to that call, in addition to
+		 * {@code AutoMemoryTools}. Leave unset for memory-only dreaming.
+		 */
+		public Builder sessionService(SessionService sessionService) {
+			Assert.notNull(sessionService, "sessionService must not be null");
+			this.sessionService = sessionService;
+			return this;
+		}
+
+		public AutoDreamService build() {
+			String promptText;
+			try {
+				promptText = this.dreamSystemPrompt.getContentAsString(StandardCharsets.UTF_8);
+			}
+			catch (IOException e) {
+				throw new IllegalStateException("Failed to read dream system prompt", e);
+			}
+			return new AutoDreamService(this.chatClientBuilder, promptText, this.dreamMode, this.staleLockAfter,
+					this.sessionService);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamLock.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamLock.java
@@ -1,0 +1,107 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * A file-based lock at {@code <memoriesDir>/.dream.lock} that prevents two dream cycles
+ * from running concurrently against the same memory store.
+ *
+ * <p>
+ * Acquisition is atomic ({@code CREATE_NEW}), so it is safe across threads and processes
+ * sharing the same filesystem. A lock older than the configured staleness threshold is
+ * reclaimed automatically — this covers the case where a previous dream cycle crashed
+ * without releasing the lock.
+ *
+ * @author Christian Tzolov
+ */
+public final class DreamLock implements AutoCloseable {
+
+	static final String LOCK_FILE_NAME = ".dream.lock";
+
+	private final Path lockFile;
+
+	private DreamLock(Path lockFile) {
+		this.lockFile = lockFile;
+	}
+
+	/**
+	 * Attempts to acquire the dream lock for {@code memoriesDir}.
+	 * @param memoriesDir the memories root directory to lock
+	 * @param staleAfter a lock older than this age is treated as abandoned and reclaimed
+	 * @return the acquired lock, or {@link Optional#empty()} if another dream cycle
+	 * already holds it
+	 */
+	public static Optional<DreamLock> tryAcquire(Path memoriesDir, Duration staleAfter) {
+		Path lockFile = memoriesDir.resolve(LOCK_FILE_NAME);
+
+		if (Files.exists(lockFile) && isStale(lockFile, staleAfter)) {
+			try {
+				Files.deleteIfExists(lockFile);
+			}
+			catch (IOException ignored) {
+				// Best-effort reclamation — if the delete fails, the create attempt
+				// below will simply fail too and the caller treats it as "locked".
+			}
+		}
+
+		try {
+			Files.writeString(lockFile, Long.toString(Instant.now().toEpochMilli()), StandardOpenOption.CREATE_NEW);
+			return Optional.of(new DreamLock(lockFile));
+		}
+		catch (FileAlreadyExistsException e) {
+			return Optional.empty();
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Failed to acquire dream lock at " + lockFile, e);
+		}
+	}
+
+	private static boolean isStale(Path lockFile, Duration staleAfter) {
+		try {
+			long acquiredAtMillis = Long.parseLong(Files.readString(lockFile).trim());
+			return Instant.now().toEpochMilli() - acquiredAtMillis > staleAfter.toMillis();
+		}
+		catch (IOException | NumberFormatException e) {
+			// Unreadable lock file — treat as stale so a corrupted lock can't strand
+			// the feature forever.
+			return true;
+		}
+	}
+
+	/**
+	 * Releases the lock by deleting the lock file.
+	 */
+	@Override
+	public void close() {
+		try {
+			Files.deleteIfExists(this.lockFile);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Failed to release dream lock at " + this.lockFile, e);
+		}
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamMode.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamMode.java
@@ -1,0 +1,39 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+/**
+ * Controls whether a dream cycle edits the live memory store directly, or writes its
+ * edits to a reviewable shadow copy.
+ *
+ * @author Christian Tzolov
+ */
+public enum DreamMode {
+
+	/**
+	 * The Dreamer edits memory files directly via {@code AutoMemoryTools}. The default —
+	 * appropriate for a single-user/single-agent memory store.
+	 */
+	AUTO_APPLY,
+
+	/**
+	 * The Dreamer's edits are redirected to a timestamped copy under
+	 * {@code <memoriesDir>/.dream-proposals/}, leaving the live memory store untouched.
+	 * The proposal can be reviewed and applied later via the ordinary memory tools.
+	 */
+	PROPOSE
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamResult.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamResult.java
@@ -1,0 +1,40 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+/**
+ * Outcome of a single {@code AutoDreamService.runDreamCycle(...)} invocation.
+ *
+ * @param status one of {@code "completed"}, {@code "failed"}, or {@code "skipped"}
+ * @param summary the Dreamer's own summary of what changed, the failure message, or the
+ * reason the cycle was skipped
+ * @author Christian Tzolov
+ */
+public record DreamResult(String status, String summary) {
+
+	public static DreamResult completed(String summary) {
+		return new DreamResult("completed", summary);
+	}
+
+	public static DreamResult failed(String summary) {
+		return new DreamResult("failed", summary);
+	}
+
+	public static DreamResult skipped(String reason) {
+		return new DreamResult("skipped", reason);
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamState.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamState.java
@@ -1,0 +1,112 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+import org.springframework.ai.util.JsonHelper;
+
+/**
+ * Persisted state for the Auto-Dream trigger, stored as {@code .dream-state.json} inside
+ * the memories root directory so it survives process restarts.
+ *
+ * @param lastDreamAt ISO-8601 instant the last dream cycle completed, or {@code null} if
+ * a dream cycle has never run
+ * @param sessionsSinceLastDream number of conversation turns {@code AutoDreamAdvisor} has
+ * processed since the last dream cycle completed
+ * @param lastDreamStatus outcome of the last dream cycle ({@code "completed"},
+ * {@code "failed"}, or {@code null} if none has run yet)
+ * @param lastDreamSummary short summary returned by the Dreamer at the end of the last
+ * dream cycle
+ * @author Christian Tzolov
+ */
+public record DreamState(String lastDreamAt, int sessionsSinceLastDream, String lastDreamStatus,
+		String lastDreamSummary) {
+
+	static final String STATE_FILE_NAME = ".dream-state.json";
+
+	private static final JsonHelper JSON = new JsonHelper();
+
+	/**
+	 * The state before any dream cycle has ever run.
+	 */
+	public static DreamState initial() {
+		return new DreamState(null, 0, null, null);
+	}
+
+	/**
+	 * Loads the dream state from {@code <memoriesDir>/.dream-state.json}, or returns
+	 * {@link #initial()} if the file does not exist yet.
+	 */
+	public static DreamState load(Path memoriesDir) {
+		Path stateFile = memoriesDir.resolve(STATE_FILE_NAME);
+		if (!Files.exists(stateFile)) {
+			return initial();
+		}
+		try {
+			String json = Files.readString(stateFile, StandardCharsets.UTF_8);
+			DreamState state = JSON.fromJson(json, DreamState.class);
+			return state != null ? state : initial();
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Failed to read dream state at " + stateFile, e);
+		}
+	}
+
+	/**
+	 * Persists this state to {@code <memoriesDir>/.dream-state.json}.
+	 */
+	public void save(Path memoriesDir) {
+		Path stateFile = memoriesDir.resolve(STATE_FILE_NAME);
+		try {
+			Files.writeString(stateFile, JSON.toJson(this), StandardCharsets.UTF_8);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException("Failed to write dream state at " + stateFile, e);
+		}
+	}
+
+	/**
+	 * Parses {@link #lastDreamAt()}, or returns {@code null} if a dream cycle has never
+	 * run.
+	 */
+	public Instant lastDreamInstant() {
+		return this.lastDreamAt != null ? Instant.parse(this.lastDreamAt) : null;
+	}
+
+	/**
+	 * Returns a copy with {@link #sessionsSinceLastDream()} incremented by one. Called by
+	 * {@code AutoDreamAdvisor} once per conversation turn it processes.
+	 */
+	public DreamState withSessionIncrement() {
+		return new DreamState(this.lastDreamAt, this.sessionsSinceLastDream + 1, this.lastDreamStatus,
+				this.lastDreamSummary);
+	}
+
+	/**
+	 * Returns a copy reflecting a just-completed dream cycle: the session counter resets
+	 * to zero and {@link #lastDreamAt()} is set to {@code dreamedAt}.
+	 */
+	public DreamState withDreamCompleted(Instant dreamedAt, String status, String summary) {
+		return new DreamState(dreamedAt.toString(), 0, status, summary);
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamTrigger.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamTrigger.java
@@ -1,0 +1,39 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.time.Instant;
+
+/**
+ * Decides whether {@code AutoDreamAdvisor} should kick off a background dream cycle,
+ * evaluated against the persisted {@link DreamState} rather than in-memory counters, so
+ * the decision survives process restarts.
+ *
+ * @author Christian Tzolov
+ * @see DreamTriggers
+ */
+@FunctionalInterface
+public interface DreamTrigger {
+
+	/**
+	 * @param state the dream state as of the current conversation turn (already
+	 * reflecting this turn's session increment)
+	 * @param now wall-clock time of the current turn
+	 * @return {@code true} if a dream cycle should be started now
+	 */
+	boolean shouldDream(DreamState state, Instant now);
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamTriggers.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/dream/DreamTriggers.java
@@ -1,0 +1,65 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.springframework.util.Assert;
+
+/**
+ * Common {@link DreamTrigger} factories.
+ *
+ * @author Christian Tzolov
+ */
+public final class DreamTriggers {
+
+	private DreamTriggers() {
+	}
+
+	/**
+	 * Fires only once <strong>both</strong> conditions hold since the last dream cycle:
+	 * at least {@code hours} have elapsed, and at least {@code sessions} conversation
+	 * turns have been processed. Mirrors Claude Code's Auto Dream dual-condition
+	 * heuristic. A memory store that has never been dreamed on satisfies the time
+	 * condition immediately, so only the session-count condition gates the first cycle.
+	 * @param hours minimum hours since the last dream cycle; must be positive
+	 * @param sessions minimum conversation turns since the last dream cycle; must be
+	 * positive
+	 */
+	public static DreamTrigger hoursAndSessions(long hours, int sessions) {
+		Assert.isTrue(hours > 0, "hours must be greater than 0");
+		Assert.isTrue(sessions > 0, "sessions must be greater than 0");
+
+		Duration minElapsed = Duration.ofHours(hours);
+		return (state, now) -> {
+			Instant lastDreamAt = state.lastDreamInstant();
+			boolean timeConditionMet = lastDreamAt == null
+					|| Duration.between(lastDreamAt, now).compareTo(minElapsed) >= 0;
+			boolean sessionConditionMet = state.sessionsSinceLastDream() >= sessions;
+			return timeConditionMet && sessionConditionMet;
+		};
+	}
+
+	/**
+	 * Never fires automatically — dream cycles only run when
+	 * {@code AutoDreamService.runDreamCycle(...)} is invoked explicitly.
+	 */
+	public static DreamTrigger manualOnly() {
+		return (state, now) -> false;
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/resources/prompt/AUTO_DREAM_SYSTEM_PROMPT.md
+++ b/spring-ai-agent-utils/src/main/resources/prompt/AUTO_DREAM_SYSTEM_PROMPT.md
@@ -1,0 +1,68 @@
+# Auto Dream
+
+You are "the Dreamer" — a dedicated background maintenance agent for a persistent,
+file-based memory store. You do not talk to the end user and nothing you do is visible
+mid-conversation; you run **out-of-band**, between conversations, with one job: leave the
+memory store cleaner and more useful than you found it.
+
+You have access to the same six memory tools the live agent uses — `MemoryView`,
+`MemoryCreate`, `MemoryStrReplace`, `MemoryInsert`, `MemoryDelete`, `MemoryRename` —
+scoped to a memories root directory. You have no access to source code, shell, or any
+other files — memory maintenance is your entire scope.
+
+If a `cross_session_search` tool is also available this cycle, you additionally have
+read-only access to that one user's full conversation history across every past session
+— use it to gather real signal, not just the memory tools. Otherwise, work only from what
+is already in the memory files.
+
+Because you run unsupervised, with no user present to catch a mistake mid-turn, always
+**bias toward merge-and-flag over delete** when you are not confident. A memory that is
+merely awkwardly worded is not a reason to delete it; only remove or overwrite entries you
+can clearly justify as stale, contradicted, or duplicated.
+
+## The four-phase dream cycle
+
+Work through these phases in order, every cycle:
+
+1. **Orient.** Call `MemoryView` on `/` and on `MEMORY.md` to see the current shape of the
+   memory store — how many files, what types, how big `MEMORY.md` has grown.
+
+2. **Gather signal.** Read through the memory files themselves (not just the index)
+   looking for:
+   - Duplicate or overlapping memories that cover the same fact or preference
+   - Contradictory memories (two entries that disagree with each other)
+   - Stale entries — relative dates that were never normalized, or facts that are clearly
+     time-bound and have expired
+   - `MEMORY.md` entries pointing to files that no longer exist, or memory files with no
+     corresponding `MEMORY.md` entry
+
+   If `cross_session_search` is available, also run a handful of *targeted* queries
+   against it — don't read the full history exhaustively. Good categories to search for:
+   corrections ("no,", "don't", "actually", "instead"), explicit save requests
+   ("remember that", "keep in mind"), and decisions ("we decided", "let's go with").
+   Scope queries with `since` as instructed in your kickoff message so you only see
+   history from after the last dream cycle.
+
+3. **Consolidate.**
+   - Merge duplicate/overlapping memories into a single, clearer entry.
+   - Delete memories you can confidently confirm are stale, superseded, or contradicted —
+     but prefer folding the surviving truth into the newer entry over deleting the old one
+     outright, so context isn't lost.
+   - Normalize any remaining relative dates ("last Thursday") to absolute ones.
+   - Tighten wording; keep the frontmatter `name`, `description`, and `type` fields in
+     sync with the body after any edit.
+
+4. **Prune and reindex.**
+   - Fix any dangling `MEMORY.md` links (removed files still indexed, or files missing
+     from the index).
+   - Keep `MEMORY.md` under 200 lines — if it has grown past that, tighten entries rather
+     than removing memories outright.
+   - Organize by topic, not chronologically.
+
+## When you're done
+
+Finish with a short plain-text summary (a few sentences) of what you changed — or state
+clearly that no changes were needed. This summary is recorded as the dream cycle's result
+and is not shown to the end user directly, so be factual and specific (e.g. "merged two
+overlapping feedback entries about testing conventions; removed one memory referencing a
+deleted file") rather than vague ("cleaned up memory").

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/AutoDreamAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/AutoDreamAdvisorTest.java
@@ -1,0 +1,186 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springaicommunity.agent.tools.task.repository.DefaultTaskRepository;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link AutoDreamAdvisor}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("AutoDreamAdvisor Tests")
+@ExtendWith(MockitoExtension.class)
+class AutoDreamAdvisorTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Mock
+	AdvisorChain advisorChain;
+
+	@Mock
+	AutoDreamService dreamService;
+
+	private AutoDreamAdvisor.Builder advisorBuilder() {
+		return AutoDreamAdvisor.builder()
+			.memoriesRootDirectory(this.tempDir.toString())
+			.dreamService(this.dreamService);
+	}
+
+	@Nested
+	@DisplayName("Builder")
+	class BuilderTests {
+
+		@Test
+		@DisplayName("Default order is HIGHEST_PRECEDENCE + 150")
+		void defaultOrder() {
+			AutoDreamAdvisor advisor = advisorBuilder().build();
+			assertThat(advisor.getOrder()).isEqualTo(BaseAdvisor.HIGHEST_PRECEDENCE + 150);
+		}
+
+		@Test
+		@DisplayName("Custom order is respected")
+		void customOrder() {
+			AutoDreamAdvisor advisor = advisorBuilder().order(42).build();
+			assertThat(advisor.getOrder()).isEqualTo(42);
+		}
+
+		@Test
+		@DisplayName("Empty memoriesRootDirectory throws")
+		void emptyDirectoryThrows() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> AutoDreamAdvisor.builder().dreamService(dreamService).build());
+		}
+
+		@Test
+		@DisplayName("Missing dreamService throws")
+		void missingDreamServiceThrows() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> AutoDreamAdvisor.builder().memoriesRootDirectory(tempDir.toString()).build());
+		}
+
+		@Test
+		@DisplayName("Null dreamTrigger throws immediately")
+		void nullDreamTriggerThrows() {
+			assertThatIllegalArgumentException().isThrownBy(() -> AutoDreamAdvisor.builder().dreamTrigger(null));
+		}
+
+	}
+
+	@Test
+	@DisplayName("before() passes the request through unchanged")
+	void beforePassesThrough() {
+		AutoDreamAdvisor advisor = advisorBuilder().build();
+		ChatClientRequest request = ChatClientRequest.builder().prompt(new Prompt(new UserMessage("hi"))).build();
+
+		assertThat(advisor.before(request, this.advisorChain)).isSameAs(request);
+	}
+
+	@Test
+	@DisplayName("after() always increments and persists the session counter")
+	void afterIncrementsSessionCounter() {
+		AutoDreamAdvisor advisor = advisorBuilder().dreamTrigger(DreamTriggers.manualOnly()).build();
+		ChatClientResponse response = ChatClientResponse.builder().context(Map.of()).build();
+
+		advisor.after(response, this.advisorChain);
+		advisor.after(response, this.advisorChain);
+
+		DreamState state = DreamState.load(this.tempDir);
+		assertThat(state.sessionsSinceLastDream()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("after() returns the response unchanged")
+	void afterReturnsResponseUnchanged() {
+		AutoDreamAdvisor advisor = advisorBuilder().dreamTrigger(DreamTriggers.manualOnly()).build();
+		ChatClientResponse response = ChatClientResponse.builder().context(Map.of()).build();
+
+		assertThat(advisor.after(response, this.advisorChain)).isSameAs(response);
+	}
+
+	@Test
+	@DisplayName("Trigger returning false never invokes the dream service")
+	void triggerFalseNeverInvokesDreamService() {
+		AutoDreamAdvisor advisor = advisorBuilder().dreamTrigger(DreamTriggers.manualOnly()).build();
+		ChatClientResponse response = ChatClientResponse.builder().context(Map.of()).build();
+
+		advisor.after(response, this.advisorChain);
+
+		verifyNoInteractions(this.dreamService);
+	}
+
+	@Test
+	@DisplayName("Trigger returning true submits a background task that runs the dream cycle")
+	void triggerTrueSubmitsBackgroundTask() {
+		when(this.dreamService.runDreamCycle(this.tempDir.toString(), null))
+			.thenReturn(DreamResult.completed("all clean"));
+
+		AutoDreamAdvisor advisor = advisorBuilder().dreamTrigger((state, now) -> true)
+			.taskRepository(new DefaultTaskRepository())
+			.build();
+		ChatClientResponse response = ChatClientResponse.builder().context(Map.of()).build();
+
+		advisor.after(response, this.advisorChain);
+
+		// The dream cycle runs on a background thread — wait for it rather than assert
+		// immediately.
+		verify(this.dreamService, timeout(2000)).runDreamCycle(this.tempDir.toString(), null);
+	}
+
+	@Test
+	@DisplayName("Configured userId is passed through to the session-aware overload")
+	void configuredUserIdIsPassedThrough() {
+		when(this.dreamService.runDreamCycle(this.tempDir.toString(), "alice"))
+			.thenReturn(DreamResult.completed("merged cross-session signal"));
+
+		AutoDreamAdvisor advisor = advisorBuilder().dreamTrigger((state, now) -> true)
+			.taskRepository(new DefaultTaskRepository())
+			.userId("alice")
+			.build();
+		ChatClientResponse response = ChatClientResponse.builder().context(Map.of()).build();
+
+		advisor.after(response, this.advisorChain);
+
+		verify(this.dreamService, timeout(2000)).runDreamCycle(this.tempDir.toString(), "alice");
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/AutoDreamServiceTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/AutoDreamServiceTest.java
@@ -1,0 +1,327 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.model.tool.DefaultToolCallingChatOptions;
+import org.springframework.ai.model.tool.ToolCallingChatOptions;
+import org.springframework.ai.session.DefaultSessionService;
+import org.springframework.ai.session.InMemorySessionRepository;
+import org.springframework.ai.session.SessionService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link AutoDreamService}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("AutoDreamService Tests")
+@ExtendWith(MockitoExtension.class)
+class AutoDreamServiceTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Mock
+	ChatModel chatModel;
+
+	@BeforeEach
+	void stubDefaultModelOptions() {
+		// ChatClient merges the model's own default options into the request; a bare
+		// Mockito mock returns null here, which NPEs deep inside the tool-calling
+		// pipeline before a test's own stubbing is ever reached.
+		lenient().when(this.chatModel.getOptions()).thenReturn(DefaultToolCallingChatOptions.builder().build());
+	}
+
+	private void stubModelReply(String text) {
+		lenient().when(this.chatModel.call(any(Prompt.class)))
+			.thenReturn(new ChatResponse(List.of(new Generation(new AssistantMessage(text)))));
+	}
+
+	private AutoDreamService.Builder serviceBuilder() {
+		this.stubModelReply("Merged two duplicate entries.");
+		return AutoDreamService.builder(ChatClient.builder(this.chatModel));
+	}
+
+	@Nested
+	@DisplayName("runDreamCycle() — AUTO_APPLY (default)")
+	class AutoApplyTests {
+
+		@Test
+		@DisplayName("Completes and persists dream state")
+		void completesAndPersistsState() {
+			AutoDreamService service = serviceBuilder().build();
+
+			DreamResult result = service.runDreamCycle(tempDir.toString());
+
+			assertThat(result.status()).isEqualTo("completed");
+			assertThat(result.summary()).isEqualTo("Merged two duplicate entries.");
+
+			DreamState state = DreamState.load(tempDir);
+			assertThat(state.lastDreamAt()).isNotNull();
+			assertThat(state.sessionsSinceLastDream()).isZero();
+			assertThat(state.lastDreamStatus()).isEqualTo("completed");
+			assertThat(state.lastDreamSummary()).isEqualTo("Merged two duplicate entries.");
+		}
+
+		@Test
+		@DisplayName("Creates the memories directory if it does not exist")
+		void createsMemoriesDirectory() {
+			Path nested = tempDir.resolve("nested/memories");
+			AutoDreamService service = serviceBuilder().build();
+
+			service.runDreamCycle(nested.toString());
+
+			assertThat(nested).exists().isDirectory();
+		}
+
+		@Test
+		@DisplayName("Releases the lock after completion")
+		void releasesLockAfterCompletion() {
+			AutoDreamService service = serviceBuilder().build();
+
+			service.runDreamCycle(tempDir.toString());
+
+			assertThat(tempDir.resolve(".dream.lock")).doesNotExist();
+		}
+
+		@Test
+		@DisplayName("Skips the cycle when the lock is already held")
+		void skipsWhenLockHeld() {
+			DreamLock heldLock = DreamLock.tryAcquire(tempDir, Duration.ofMinutes(15)).orElseThrow();
+			AutoDreamService service = AutoDreamService.builder(ChatClient.builder(chatModel)).build();
+
+			DreamResult result = service.runDreamCycle(tempDir.toString());
+
+			assertThat(result.status()).isEqualTo("skipped");
+			heldLock.close();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("runDreamCycle() — PROPOSE")
+	class ProposeModeTests {
+
+		@Test
+		@DisplayName("Copies existing memory files into a timestamped proposal directory")
+		void copiesIntoProposalDirectory() throws Exception {
+			Files.writeString(tempDir.resolve("MEMORY.md"), "- [Existing](existing.md) — hook");
+			Files.writeString(tempDir.resolve("existing.md"), "---\nname: existing\n---\ncontent");
+
+			AutoDreamService service = serviceBuilder().dreamMode(DreamMode.PROPOSE).build();
+
+			service.runDreamCycle(tempDir.toString());
+
+			Path proposalsDir = tempDir.resolve(".dream-proposals");
+			assertThat(proposalsDir).exists().isDirectory();
+
+			try (var children = Files.list(proposalsDir)) {
+				Path proposal = children.findFirst().orElseThrow();
+				assertThat(proposal.resolve("MEMORY.md")).exists();
+				assertThat(proposal.resolve("existing.md")).exists();
+			}
+		}
+
+		@Test
+		@DisplayName("Leaves the live memory files untouched")
+		void leavesLiveFilesUntouched() throws Exception {
+			Path liveMemory = tempDir.resolve("MEMORY.md");
+			Files.writeString(liveMemory, "- [Existing](existing.md) — hook");
+
+			AutoDreamService service = serviceBuilder().dreamMode(DreamMode.PROPOSE).build();
+			service.runDreamCycle(tempDir.toString());
+
+			assertThat(Files.readString(liveMemory)).isEqualTo("- [Existing](existing.md) — hook");
+		}
+
+		@Test
+		@DisplayName("Does not include dream bookkeeping files in the proposal copy")
+		void excludesDreamInternalFiles() throws Exception {
+			Files.writeString(tempDir.resolve("MEMORY.md"), "index");
+			DreamState.initial().withDreamCompleted(Instant.now(), "completed", "prior run").save(tempDir);
+
+			AutoDreamService service = serviceBuilder().dreamMode(DreamMode.PROPOSE).build();
+			service.runDreamCycle(tempDir.toString());
+
+			Path proposalsDir = tempDir.resolve(".dream-proposals");
+			try (var children = Files.list(proposalsDir)) {
+				Path proposal = children.findFirst().orElseThrow();
+				assertThat(proposal.resolve(".dream-state.json")).doesNotExist();
+				assertThat(proposal.resolve(".dream-proposals")).doesNotExist();
+			}
+		}
+
+	}
+
+	@Nested
+	@DisplayName("runDreamCycle(dir, userId) — cross-session recall")
+	class CrossSessionRecallTests {
+
+		private SessionService sessionService() {
+			return DefaultSessionService.builder().sessionRepository(InMemorySessionRepository.builder().build()).build();
+		}
+
+		@Test
+		@DisplayName("Adds cross_session_search when sessionService is configured and userId is given")
+		void addsCrossSessionSearchWhenConfigured() {
+			ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+
+			AutoDreamService service = serviceBuilder().sessionService(sessionService()).build();
+			service.runDreamCycle(tempDir.toString(), "alice");
+
+			verify(chatModel).call(promptCaptor.capture());
+			ToolCallingChatOptions options = (ToolCallingChatOptions) promptCaptor.getValue().getOptions();
+			List<String> toolNames = options.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
+
+			assertThat(toolNames).contains("cross_session_search");
+		}
+
+		@Test
+		@DisplayName("Omits cross_session_search when sessionService is not configured")
+		void omitsCrossSessionSearchWithoutSessionService() {
+			ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+
+			AutoDreamService service = serviceBuilder().build();
+			service.runDreamCycle(tempDir.toString(), "alice");
+
+			verify(chatModel).call(promptCaptor.capture());
+			ToolCallingChatOptions options = (ToolCallingChatOptions) promptCaptor.getValue().getOptions();
+			List<String> toolNames = options.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
+
+			assertThat(toolNames).doesNotContain("cross_session_search");
+		}
+
+		@Test
+		@DisplayName("Omits cross_session_search when userId is blank, even with sessionService configured")
+		void omitsCrossSessionSearchWithoutUserId() {
+			ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+
+			AutoDreamService service = serviceBuilder().sessionService(sessionService()).build();
+			service.runDreamCycle(tempDir.toString());
+
+			verify(chatModel).call(promptCaptor.capture());
+			ToolCallingChatOptions options = (ToolCallingChatOptions) promptCaptor.getValue().getOptions();
+			List<String> toolNames = options.getToolCallbacks().stream().map(tc -> tc.getToolDefinition().name()).toList();
+
+			assertThat(toolNames).doesNotContain("cross_session_search");
+		}
+
+		@Test
+		@DisplayName("Kickoff prompt mentions cross_session_search when it's available")
+		void kickoffPromptMentionsToolWhenAvailable() {
+			ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+
+			AutoDreamService service = serviceBuilder().sessionService(sessionService()).build();
+			service.runDreamCycle(tempDir.toString(), "alice");
+
+			verify(chatModel).call(promptCaptor.capture());
+			String userText = ((UserMessage) promptCaptor.getValue().getUserMessage()).getText();
+
+			assertThat(userText).contains("cross_session_search");
+		}
+
+		@Test
+		@DisplayName("Kickoff prompt does not mention cross_session_search when unavailable")
+		void kickoffPromptOmitsToolWhenUnavailable() {
+			ArgumentCaptor<Prompt> promptCaptor = ArgumentCaptor.forClass(Prompt.class);
+
+			AutoDreamService service = serviceBuilder().build();
+			service.runDreamCycle(tempDir.toString());
+
+			verify(chatModel).call(promptCaptor.capture());
+			String userText = ((UserMessage) promptCaptor.getValue().getUserMessage()).getText();
+
+			assertThat(userText).doesNotContain("cross_session_search");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Error handling")
+	class ErrorHandlingTests {
+
+		@Test
+		@DisplayName("A model failure is captured as a failed result rather than propagated")
+		void modelFailureIsCaptured() {
+			lenient().when(chatModel.call(any(Prompt.class))).thenThrow(new RuntimeException("model unavailable"));
+			AutoDreamService service = AutoDreamService.builder(ChatClient.builder(chatModel)).build();
+
+			DreamResult result = service.runDreamCycle(tempDir.toString());
+
+			assertThat(result.status()).isEqualTo("failed");
+			assertThat(result.summary()).contains("model unavailable");
+
+			DreamState state = DreamState.load(tempDir);
+			assertThat(state.lastDreamStatus()).isEqualTo("failed");
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Builder")
+	class BuilderTests {
+
+		@Test
+		@DisplayName("Null chatClientBuilder throws immediately")
+		void nullChatClientBuilderThrows() {
+			assertThatIllegalArgumentException().isThrownBy(() -> AutoDreamService.builder(null));
+		}
+
+		@Test
+		@DisplayName("Null dreamMode throws immediately")
+		void nullDreamModeThrows() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> AutoDreamService.builder(ChatClient.builder(chatModel)).dreamMode(null));
+		}
+
+		@Test
+		@DisplayName("Null staleLockAfter throws immediately")
+		void nullStaleLockAfterThrows() {
+			assertThatIllegalArgumentException()
+				.isThrownBy(() -> AutoDreamService.builder(ChatClient.builder(chatModel)).staleLockAfter(null));
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/DreamLockTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/DreamLockTest.java
@@ -1,0 +1,119 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DreamLock}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("DreamLock Tests")
+class DreamLockTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	@DisplayName("First acquisition succeeds")
+	void firstAcquisitionSucceeds() {
+		Optional<DreamLock> lock = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+
+		assertThat(lock).isPresent();
+		assertThat(this.tempDir.resolve(".dream.lock")).exists();
+	}
+
+	@Test
+	@DisplayName("Second acquisition fails while the first is held")
+	void secondAcquisitionFailsWhileHeld() {
+		Optional<DreamLock> first = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+		assertThat(first).isPresent();
+
+		Optional<DreamLock> second = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+
+		assertThat(second).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Acquisition succeeds again after close() releases the lock")
+	void reacquisitionSucceedsAfterClose() {
+		Optional<DreamLock> first = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+		assertThat(first).isPresent();
+		first.get().close();
+
+		Optional<DreamLock> second = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+
+		assertThat(second).isPresent();
+		assertThat(this.tempDir.resolve(".dream.lock")).exists();
+	}
+
+	@Test
+	@DisplayName("close() deletes the lock file")
+	void closeDeletesLockFile() {
+		DreamLock lock = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15)).orElseThrow();
+
+		lock.close();
+
+		assertThat(this.tempDir.resolve(".dream.lock")).doesNotExist();
+	}
+
+	@Test
+	@DisplayName("A lock older than staleAfter is reclaimed automatically")
+	void staleLockIsReclaimed() throws Exception {
+		Path lockFile = this.tempDir.resolve(".dream.lock");
+		long ancientTimestamp = Instant.now().minus(Duration.ofHours(1)).toEpochMilli();
+		Files.writeString(lockFile, Long.toString(ancientTimestamp), StandardOpenOption.CREATE_NEW);
+
+		Optional<DreamLock> reclaimed = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+
+		assertThat(reclaimed).isPresent();
+	}
+
+	@Test
+	@DisplayName("A lock younger than staleAfter is not reclaimed")
+	void freshLockIsNotReclaimed() throws Exception {
+		Path lockFile = this.tempDir.resolve(".dream.lock");
+		Files.writeString(lockFile, Long.toString(Instant.now().toEpochMilli()), StandardOpenOption.CREATE_NEW);
+
+		Optional<DreamLock> attempt = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+
+		assertThat(attempt).isEmpty();
+	}
+
+	@Test
+	@DisplayName("An unreadable lock file is treated as stale and reclaimed")
+	void unreadableLockFileIsReclaimed() throws Exception {
+		Path lockFile = this.tempDir.resolve(".dream.lock");
+		Files.writeString(lockFile, "not-a-timestamp", StandardOpenOption.CREATE_NEW);
+
+		Optional<DreamLock> reclaimed = DreamLock.tryAcquire(this.tempDir, Duration.ofMinutes(15));
+
+		assertThat(reclaimed).isPresent();
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/DreamStateTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/DreamStateTest.java
@@ -1,0 +1,92 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DreamState}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("DreamState Tests")
+class DreamStateTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	@DisplayName("Loading from an empty directory returns the initial state")
+	void loadWhenMissingReturnsInitial() {
+		DreamState state = DreamState.load(this.tempDir);
+
+		assertThat(state.lastDreamAt()).isNull();
+		assertThat(state.sessionsSinceLastDream()).isZero();
+		assertThat(state.lastDreamStatus()).isNull();
+		assertThat(state.lastDreamSummary()).isNull();
+		assertThat(state.lastDreamInstant()).isNull();
+	}
+
+	@Test
+	@DisplayName("save() followed by load() round-trips all fields")
+	void saveThenLoadRoundTrips() {
+		DreamState state = DreamState.initial().withSessionIncrement().withDreamCompleted(
+				Instant.parse("2026-07-20T09:00:00Z"), "completed", "Merged two duplicate entries.");
+
+		state.save(this.tempDir);
+		DreamState loaded = DreamState.load(this.tempDir);
+
+		assertThat(loaded).isEqualTo(state);
+		assertThat(loaded.lastDreamInstant()).isEqualTo(Instant.parse("2026-07-20T09:00:00Z"));
+		assertThat(loaded.lastDreamStatus()).isEqualTo("completed");
+		assertThat(loaded.lastDreamSummary()).isEqualTo("Merged two duplicate entries.");
+	}
+
+	@Test
+	@DisplayName("withSessionIncrement() increments the counter and preserves other fields")
+	void withSessionIncrement() {
+		DreamState state = new DreamState("2026-07-01T00:00:00Z", 3, "completed", "summary");
+
+		DreamState incremented = state.withSessionIncrement();
+
+		assertThat(incremented.sessionsSinceLastDream()).isEqualTo(4);
+		assertThat(incremented.lastDreamAt()).isEqualTo(state.lastDreamAt());
+		assertThat(incremented.lastDreamStatus()).isEqualTo(state.lastDreamStatus());
+		assertThat(incremented.lastDreamSummary()).isEqualTo(state.lastDreamSummary());
+	}
+
+	@Test
+	@DisplayName("withDreamCompleted() resets the session counter and updates status/summary")
+	void withDreamCompletedResetsCounter() {
+		DreamState state = new DreamState("2026-07-01T00:00:00Z", 7, "failed", "old summary");
+		Instant dreamedAt = Instant.parse("2026-07-21T12:00:00Z");
+
+		DreamState completed = state.withDreamCompleted(dreamedAt, "completed", "new summary");
+
+		assertThat(completed.sessionsSinceLastDream()).isZero();
+		assertThat(completed.lastDreamAt()).isEqualTo(dreamedAt.toString());
+		assertThat(completed.lastDreamStatus()).isEqualTo("completed");
+		assertThat(completed.lastDreamSummary()).isEqualTo("new summary");
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/DreamTriggersTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/dream/DreamTriggersTest.java
@@ -1,0 +1,89 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.dream;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link DreamTriggers}.
+ *
+ * @author Christian Tzolov
+ */
+@DisplayName("DreamTriggers Tests")
+class DreamTriggersTest {
+
+	private static final Instant NOW = Instant.parse("2026-07-22T00:00:00Z");
+
+	@Test
+	@DisplayName("hoursAndSessions rejects non-positive hours")
+	void rejectsNonPositiveHours() {
+		assertThatIllegalArgumentException().isThrownBy(() -> DreamTriggers.hoursAndSessions(0, 5));
+	}
+
+	@Test
+	@DisplayName("hoursAndSessions rejects non-positive sessions")
+	void rejectsNonPositiveSessions() {
+		assertThatIllegalArgumentException().isThrownBy(() -> DreamTriggers.hoursAndSessions(24, 0));
+	}
+
+	@Test
+	@DisplayName("Never dreamed before: time condition is satisfied immediately, session count still gates")
+	void neverDreamedBeforeGatesOnSessionsOnly() {
+		DreamTrigger trigger = DreamTriggers.hoursAndSessions(24, 5);
+
+		DreamState notEnoughSessions = new DreamState(null, 4, null, null);
+		DreamState enoughSessions = new DreamState(null, 5, null, null);
+
+		assertThat(trigger.shouldDream(notEnoughSessions, NOW)).isFalse();
+		assertThat(trigger.shouldDream(enoughSessions, NOW)).isTrue();
+	}
+
+	@Test
+	@DisplayName("Both conditions must hold")
+	void bothConditionsMustHold() {
+		DreamTrigger trigger = DreamTriggers.hoursAndSessions(24, 5);
+		String recentDream = NOW.minusSeconds(3600).toString(); // 1 hour ago — time not met
+		String oldDream = NOW.minusSeconds(48 * 3600).toString(); // 48 hours ago — time met
+
+		assertThat(trigger.shouldDream(new DreamState(recentDream, 10, null, null), NOW)).isFalse();
+		assertThat(trigger.shouldDream(new DreamState(oldDream, 2, null, null), NOW)).isFalse();
+		assertThat(trigger.shouldDream(new DreamState(oldDream, 10, null, null), NOW)).isTrue();
+	}
+
+	@Test
+	@DisplayName("Exact boundary values satisfy their condition")
+	void exactBoundaryIsSatisfied() {
+		DreamTrigger trigger = DreamTriggers.hoursAndSessions(24, 5);
+		String exactlyTwentyFourHoursAgo = NOW.minusSeconds(24 * 3600).toString();
+
+		assertThat(trigger.shouldDream(new DreamState(exactlyTwentyFourHoursAgo, 5, null, null), NOW)).isTrue();
+	}
+
+	@Test
+	@DisplayName("manualOnly never fires")
+	void manualOnlyNeverFires() {
+		DreamTrigger trigger = DreamTriggers.manualOnly();
+
+		assertThat(trigger.shouldDream(new DreamState(null, 1_000_000, null, null), NOW)).isFalse();
+	}
+
+}


### PR DESCRIPTION
- Out-of-band background "dream" cycles for AutoMemoryTools: AutoDreamAdvisor schedules periodic AutoDreamService runs (DreamTrigger/DreamState/DreamLock, AUTO_APPLY/PROPOSE modes) that deduplicate, prune, and reorganize an agent's memory store without blocking the live conversation.
- Optionally wires spring-ai-session's CrossSessionRecallTools so the Dreamer can also search a user's full session history, not just the memory store, via AutoDreamService.sessionService() / AutoDreamAdvisor.userId().
- Adds a provided+optional dependency on spring-ai-session.
- Add memory-tools-dream-demo example and reference docs.