### PR TITLE
fix: remove `coding` in `TodoWriteTool` prompt to make it more general

### DIFF
--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/TodoWriteTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/TodoWriteTool.java
@@ -57,7 +57,7 @@ public class TodoWriteTool {
 
 	// @formatter:off
 	@Tool(name = "TodoWrite", description = """
-		Use this tool to create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
+		Use this tool to create and manage a structured task list for your current session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
 		It also helps the user understand the progress of the task and overall progress of their requests.
 
 		## When to Use This Tool


### PR DESCRIPTION
For general AI agent, complex task is not managed by this TODO write tool, maybe because this tool is bound to `coding` session, I knew this tool is from Claude code cli so maybe removing the `coding` word makes it more general as this project is not specific for coding AI agents only; @tzolov let me know what do you think, thanks!