### PR TITLE
fix: correct well-known URL construction for agent base with paths

### DIFF
--- a/spring-ai-agent-utils-a2a/pom.xml
+++ b/spring-ai-agent-utils-a2a/pom.xml
@@ -76,5 +76,17 @@
 			<version>${a2a.sdk.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>6.1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.23.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/spring-ai-agent-utils-a2a/src/main/java/org/springaicommunity/agent/subagent/a2a/A2ASubagentResolver.java
+++ b/spring-ai-agent-utils-a2a/src/main/java/org/springaicommunity/agent/subagent/a2a/A2ASubagentResolver.java
@@ -15,8 +15,6 @@
 */
 package org.springaicommunity.agent.subagent.a2a;
 
-import java.net.URI;
-
 import io.a2a.A2A;
 import io.a2a.spec.AgentCard;
 import org.slf4j.Logger;
@@ -60,11 +58,11 @@ public class A2ASubagentResolver implements SubagentResolver {
 		if (subagentRef == null) {
 			throw new IllegalArgumentException("SubagentReference must not be null");
 		}
+
 		try {
-			String url = subagentRef.uri();
-			String path = new URI(url).getPath();
-			AgentCard card = A2A.getAgentCard(url, path + agentCardPath, null);
-			logger.debug("Discovered agent: {} at {}", card.name(), url);
+			String fullWellKnownUrl = buildWellKnownUrl(subagentRef.uri(), agentCardPath);
+			AgentCard card = A2A.getAgentCard(fullWellKnownUrl);
+			logger.debug("Discovered agent: {} at {}", card.name(), subagentRef.uri());
 			return new A2ASubagentDefinition(subagentRef, card);
 		}
 		catch (Exception e) {
@@ -72,4 +70,12 @@ public class A2ASubagentResolver implements SubagentResolver {
 		}
 	}
 
+	private String buildWellKnownUrl(String agentBaseUrl, String cardPath) {
+		// Ensure base URL ends with a single slash
+		String base = agentBaseUrl.endsWith("/") ? agentBaseUrl : agentBaseUrl + "/";
+		// Remove leading slash from card path to make it relative (avoids double slashes)
+		String relativeCardPath = cardPath.startsWith("/") ? cardPath.substring(1) : cardPath;
+
+		return base + relativeCardPath;
+	}
 }

--- a/spring-ai-agent-utils-a2a/src/test/java/org/springaicommunity/agent/subagent/a2a/A2ASubagentResolverTest.java
+++ b/spring-ai-agent-utils-a2a/src/test/java/org/springaicommunity/agent/subagent/a2a/A2ASubagentResolverTest.java
@@ -1,0 +1,47 @@
+package org.springaicommunity.agent.subagent.a2a;
+
+import io.a2a.A2A;
+import io.a2a.spec.AgentCard;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.MockedStatic;
+import org.springaicommunity.agent.common.task.subagent.SubagentReference;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Tests for {@link A2ASubagentResolver}.
+ *
+ * @author Caio Henrique Silva
+ */
+class A2ASubagentResolverTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "http://localhost:8080,              /.well-known/agent-card.json, http://localhost:8080/.well-known/agent-card.json",
+            "http://localhost:8080/dominio,      /.well-known/agent-card.json, http://localhost:8080/dominio/.well-known/agent-card.json",
+            "http://localhost:8080/dominio/,     /.well-known/agent-card.json, http://localhost:8080/dominio/.well-known/agent-card.json",
+            "https://api.example.com/v1,         /.well-known/agent-card.json, https://api.example.com/v1/.well-known/agent-card.json",
+            "http://localhost:8080,              /custom/agent-card.json,      http://localhost:8080/custom/agent-card.json",
+            "http://localhost:8080/dominio,      /custom/agent-card.json,      http://localhost:8080/dominio/custom/agent-card.json",
+            "http://localhost:8080,              custom/agent.json,            http://localhost:8080/custom/agent.json",
+            "http://localhost:8080/dominio,      custom/agent.json,            http://localhost:8080/dominio/custom/agent.json"
+    })
+    @DisplayName("Should build the correct well-known URL for various agent base URLs and card paths")
+    void resolve_shouldCallA2AWithCorrectFullUri(String baseUrl, String agentCardPath, String expectedFullUri) {
+        A2ASubagentResolver resolver = new A2ASubagentResolver(agentCardPath);
+        SubagentReference ref = new SubagentReference(baseUrl, A2ASubagentDefinition.KIND);
+
+        try (MockedStatic<A2A> a2aMock = mockStatic(A2A.class)) {
+            a2aMock.when(() -> A2A.getAgentCard(anyString()))
+                    .thenReturn(mock(AgentCard.class));
+
+            resolver.resolve(ref);
+
+            a2aMock.verify(() -> A2A.getAgentCard(expectedFullUri));
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR fixes a bug in `A2ASubagentResolver` where the well‑known agent card URL was being constructed with **duplicated path segments** when the agent base URI already contained a path.

### Problem

The previous implementation appended the base path twice, causing the agent’s sub‑path (e.g., `/dominio`) to appear duplicated in the final URL. This resulted in HTTP 404 errors for agents deployed with a context path.

### Solution

The URL construction logic has been changed to:
- Normalize the base URL to always end with a single slash (`/`).
- Remove the leading slash from the configured `agentCardPath` to treat it as a relative path.
- Concatenate both parts to produce the final URL.

This change eliminates the path duplication and handles the following cases:
- Base URLs with and without trailing slashes
- Base URLs with and without sub‑paths
- Custom `agentCardPath` values (with and without leading `/`)
- Both HTTP and HTTPS schemes

### Testing

Parameterized tests have been added covering multiple scenarios. All tests pass.

| Example | Before | After |
|---------|--------|-------|
| `http://localhost:8080/dominio` | `http://localhost:8080/dominio/dominio/.well-known/agent-card.json` | `http://localhost:8080/dominio/.well-known/agent-card.json` |
| `http://localhost:8080` | `http://localhost:8080/.well-known/agent-card.json` | `http://localhost:8080/.well-known/agent-card.json` (unchanged) |

### Checklist

- [x] Code compiles and tests pass
- [x] Unit tests added/updated
- [x] No breaking changes
- [x] Follows project conventions