### PR TITLE
feat: register one ToolCallback per skill in SkillsTool

### DIFF
--- a/docs/tools/DockerCliExecBackend.md
+++ b/docs/tools/DockerCliExecBackend.md
@@ -32,7 +32,7 @@ try (DockerCliExecBackend backend = DockerCliExecBackend.builder()
     GlobTool glob = GlobTool.builder().workspace(workspace).build();
 
     // Skill base directories and environment prompts show container paths
-    ToolCallback skills = SkillsTool.builder()
+    ToolCallbackProvider skills = SkillsTool.builder()
         .addSkillsDirectory(hostWorkspace.resolve("skills").toString())
         .workspace(workspace)
         .build();

--- a/docs/tools/SkillsTool.md
+++ b/docs/tools/SkillsTool.md
@@ -4,6 +4,7 @@ Extend AI agent capabilities with reusable, composable knowledge modules defined
 
 **Features:**
 - Define skills as Markdown files with YAML frontmatter
+- Every skill is registered as its own tool, named after the skill
 - Automatic skill invocation through semantic matching
 - Support for reference files and helper scripts
 - Progressive disclosure of detailed information
@@ -16,9 +17,9 @@ Extend AI agent capabilities with reusable, composable knowledge modules defined
 Skills are markdown files that teach the AI agent how to perform specific tasks. Unlike traditional tools that execute code, skills provide **knowledge and instructions** to the AI, enabling it to handle specialized domains effectively.
 
 **How Skills Work:**
-1. **Discovery**: At startup, SkillsTool loads skill names and descriptions
-2. **Semantic Matching**: When a user request matches a skill's description, the AI invokes it
-3. **Execution**: The full skill content is loaded and the AI follows its instructions
+1. **Discovery**: At startup, SkillsTool loads every `SKILL.md` and registers **one tool per skill**, named after the skill and described by the skill's front-matter
+2. **Semantic Matching**: When a user request matches a skill's description, the AI calls that skill's tool (no arguments)
+3. **Execution**: The full skill content is returned and the AI follows its instructions
 
 Extend agent capabilities with reusable, composable knowledge modules defined in Markdown with YAML front-matter:
 
@@ -193,7 +194,7 @@ Skills can come from multiple sources — filesystem directories, classpath reso
 ### Loading from Directories
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsDirectory(".claude/skills")           // Project skills
     .addSkillsDirectory(System.getenv("HOME") + "/.claude/skills")  // Personal skills
     .build();
@@ -202,7 +203,7 @@ SkillsTool skillsTool = SkillsTool.builder()
 Alternative using `addSkillsDirectories`:
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsDirectories(List.of(
         ".claude/skills",
         System.getenv("HOME") + "/.claude/skills"
@@ -226,7 +227,7 @@ public class SkillsConfig {
     private ResourceLoader resourceLoader;
 
     @Bean
-    public SkillsTool skillsTool() {
+    public ToolCallbackProvider skillsTool() {
         Resource skillsResource = resourceLoader.getResource("classpath:.claude/skills");
 
         return SkillsTool.builder()
@@ -240,7 +241,7 @@ Loading multiple resources:
 
 ```java
 @Bean
-public SkillsTool skillsTool() {
+public ToolCallbackProvider skillsTool() {
     List<Resource> skillResources = List.of(
         resourceLoader.getResource("classpath:.claude/skills"),
         resourceLoader.getResource("file:${user.home}/.claude/skills")
@@ -279,7 +280,7 @@ Add the JAR as a dependency, then point `SkillsTool` at the classpath prefix:
 ```
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsResource(new ClassPathResource("META-INF/resources/skills/anthropics/skills"))
     .build();
 ```
@@ -287,7 +288,7 @@ SkillsTool skillsTool = SkillsTool.builder()
 You can mix sources freely — filesystem directories, classpath JARs, and explicit JAR URLs:
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsDirectory(".claude/skills")                                         // Local filesystem
     .addSkillsResource(new ClassPathResource("META-INF/skills/my-org/my-skills")) // From a dependency JAR
     .addSkillsResource(new UrlResource("jar:file:/opt/skills.jar!/skills"))       // Explicit JAR URL
@@ -347,13 +348,17 @@ Skills loaded from JAR/classpath resources keep their synthetic base path unchan
 
 ### Custom Tool Description Template
 
+The template is applied **per skill**. It must contain a single `%s` placeholder, which is
+replaced by that skill's rendered front-matter (its `description`, followed by any remaining
+fields such as `allowed-tools` and `model`).
+
 ```java
 String customTemplate = """
-    Execute a custom skill...
+    Execute this skill within the main conversation.
 
-    <available_skills>
     %s
-    </available_skills>
+
+    The response starts with the skill base directory, followed by the skill instructions.
     """;
 
 SkillsTool.builder()
@@ -378,7 +383,7 @@ SkillsTool.builder()
 import org.springframework.core.io.Resource;
 
 @Bean
-public SkillsTool skillsTool(ResourceLoader resourceLoader) {
+public ToolCallbackProvider skillsTool(ResourceLoader resourceLoader) {
     Resource projectSkills = resourceLoader.getResource("classpath:.claude/skills");
     Resource userSkills = resourceLoader.getResource("file:${user.home}/.claude/skills");
 
@@ -396,7 +401,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.UrlResource;
 
 @Bean
-public SkillsTool skillsTool() {
+public ToolCallbackProvider skillsTool() {
     return SkillsTool.builder()
         .addSkillsDirectory(".claude/skills")                                         // Local filesystem
         .addSkillsResource(new ClassPathResource("META-INF/skills/my-org/my-skills")) // From a dependency JAR
@@ -527,18 +532,21 @@ ChatClient chatClient = chatClientBuilder
 
 1. **Discovery** (at startup):
    - SkillsTool scans `.claude/skills/` directories
-   - Loads `name` and `description` from each `SKILL.md`
-   - Creates lightweight skill registry
+   - Loads each `SKILL.md` and registers one `ToolCallback` per skill, named after the skill's
+     `name` front-matter and described by its `description`
+   - Each skill tool takes **no arguments**
 
 2. **Activation** (on user request):
    - User: "Help me extract data from this PDF"
-   - AI matches request to skill descriptions
-   - AI invokes skill: `Skill(command="pdf-processor")`
+   - AI matches the request against the skill tool descriptions
+   - AI calls the skill's own tool: `pdf-processor()`
 
 3. **Execution**:
-   - SkillsTool loads full `SKILL.md` content
-   - Returns content + base directory to AI
+   - The skill's `SKILL.md` content is returned, prefixed with the skill base directory
    - AI follows skill instructions
+
+Because each skill is a first-class tool, per-skill allow/deny lists work out of the box — e.g. a
+Claude subagent definition can list `pdf` in its `tools` or `disallowedTools`.
 
 ### Invocation Example
 
@@ -547,7 +555,7 @@ ChatClient chatClient = chatClientBuilder
 "I need to process a PDF file and extract tables"
 
 // AI recognizes "pdf" skill matches
-// AI calls: Skill(command="pdf")
+// AI calls: pdf()
 
 // SkillsTool returns:
 "Base directory for this skill: /project/.claude/skills/pdf
@@ -727,12 +735,30 @@ python scripts/visualize.py data.csv --type bar --output chart.png
 
 ### Namespace Collision Handling
 
-If multiple skills have the same name:
+If multiple skills have the same name, scope them with a fully qualified name:
 
-```java
-// Use fully qualified names: directory:skill-name
-Skill(command="project-a:pdf")
-Skill(command="project-b:pdf")
+```yaml
+# .claude/skills/project-a/pdf/SKILL.md
+name: project-a:pdf
+```
+
+```yaml
+# .claude/skills/project-b/pdf/SKILL.md
+name: project-b:pdf
+```
+
+The model providers do not accept `:` in a **tool** name, so `SkillsTool` derives the tool name
+from the skill name by replacing every character outside `[a-zA-Z0-9_-]` with `_` — the two skills
+above are registered as the tools `project-a_pdf` and `project-b_pdf`. The skill name itself stays
+as written, so `SKILL.md` files and subagent `skills:` lists keep using `project-a:pdf`.
+
+Names still have to be unique **after** that derivation, and at most 64 characters. Both are
+enforced at `build()` time:
+
+```text
+Duplicate skill tool name 'project-a_pdf' derived from skill 'project-a:pdf' in
+'/project-a/.claude/skills/pdf' and skill 'project-a_pdf' in '/other/.claude/skills/pdf'.
+Skill names must be unique.
 ```
 
 ## Spring Boot Integration
@@ -758,7 +784,7 @@ public class SkillsConfiguration {
     private String userSkillsDir;
 
     @Bean
-    public SkillsTool skillsTool() {
+    public ToolCallbackProvider skillsTool() {
         return SkillsTool.builder()
             .addSkillsDirectory(projectSkillsDir)
             .addSkillsDirectory(userSkillsDir)
@@ -768,7 +794,7 @@ public class SkillsConfiguration {
     @Bean
     public ChatClient chatClient(
             ChatClient.Builder chatClientBuilder,
-            SkillsTool skillsTool) {
+            ToolCallbackProvider skillsTool) {
 
         return chatClientBuilder
             .defaultToolCallbacks(skillsTool)
@@ -839,7 +865,10 @@ new ClassPathResource("META-INF/skills/my-org/my-skills")
 
 ### Multiple Skills with Same Name
 
-**Problem:** Naming collision between skills
+**Problem:** `build()` fails with `Duplicate skill tool name '…' derived from skill '…'`
+
+**Cause:** Each skill is registered as its own tool, so the derived tool names must be unique
+across all configured sources.
 
 **Solution:** Use fully qualified names
 ```markdown
@@ -847,11 +876,14 @@ new ClassPathResource("META-INF/skills/my-org/my-skills")
 name: project-name:skill-name
 ---
 ```
+The `:` is replaced by `_` when deriving the tool name, so the two skills no longer collide.
 
 ## Limitations
 
 - Skill descriptions limited to 1024 characters
-- Skill names limited to 64 characters
+- Skill names limited to 64 characters — the derived tool name must fit the provider limit
+- Characters outside `[a-zA-Z0-9_-]` are replaced by `_` in the derived tool name (e.g. `project-a:pdf` → `project-a_pdf`)
+- Derived tool names must be unique across all configured skill sources
 - Only `SKILL.md` files are recognized (exact name)
 - YAML frontmatter must be valid
 - Semantic matching depends on AI's understanding
@@ -869,6 +901,43 @@ name: project-name:skill-name
 9. **Document well**: Clear instructions for AI to follow
 10. **Maintain skills**: Update as requirements change
 11. **Share via JARs**: Package reusable skills as Maven/Gradle dependencies (SkillsJars) for cross-project sharing
+
+## Migration to 0.12.0
+
+`SkillsTool` used to register a **single** tool named `Skill`, whose description carried an
+`<available_skills>` catalog and which was invoked with the skill name as an argument
+(`Skill(command="pdf")`). Each skill is now its own tool.
+
+| Before (≤ 0.11) | After (0.12) |
+|---|---|
+| `ToolCallback build()` | `ToolCallbackProvider build()` |
+| One tool, `Skill` | One tool per skill, named after the skill |
+| `Skill(command="pdf")` | `pdf()` — no arguments |
+| `SkillsTool.SkillsInput`, `SkillsTool.SkillsFunction` | `SkillsTool.SkillFunction` |
+| `toolDescriptionTemplate` `%s` = the whole skill catalog | `%s` = a single skill's front-matter |
+| Duplicate skill names silently shadowed each other | `build()` fails with a duplicate-name error |
+| Skill name used as-is | Scoped names still supported; the tool name replaces illegal characters (`project-a:pdf` → `project-a_pdf`) |
+
+Registration is unchanged — `ChatClient.Builder.defaultTools(...)` and `defaultToolCallbacks(...)`
+both accept a `ToolCallbackProvider`:
+
+```java
+ChatClient chatClient = chatClientBuilder
+    .defaultToolCallbacks(SkillsTool.builder()
+        .addSkillsDirectory(".claude/skills")
+        .build())
+    .build();
+```
+
+Only code that stored the result in a `ToolCallback` variable needs updating:
+
+```java
+// Before
+ToolCallback skillsTool = SkillsTool.builder().addSkillsDirectory(".claude/skills").build();
+
+// After
+ToolCallbackProvider skillsTool = SkillsTool.builder().addSkillsDirectory(".claude/skills").build();
+```
 
 ## See Also
 

--- a/docs/tools/migration-0.12.md
+++ b/docs/tools/migration-0.12.md
@@ -1,6 +1,6 @@
 # Migration Guide: 0.11.0 to 0.12.0
 
-This release introduces the sandboxing foundation: the `ExecBackend` and `Workspace` SPIs, directory confinement for the search tools, and the `spring-ai-agent-utils-docker-cli` module. It also adds two agent-loop utilities: `InterruptAdvisor` (cooperative cancellation of in-flight turns) and `ToolCallListener` (tool invocation observability). **There are no breaking API changes** — all existing code compiles and runs unchanged. There is **one behavioral change** to review (background shells) and a few output-level changes worth knowing about.
+This release introduces the sandboxing foundation: the `ExecBackend` and `Workspace` SPIs, directory confinement for the search tools, and the `spring-ai-agent-utils-docker-cli` module. It also adds two agent-loop utilities: `InterruptAdvisor` (cooperative cancellation of in-flight turns) and `ToolCallListener` (tool invocation observability). It also changes `SkillsTool` to register **one tool per skill** — the only breaking API change. There is **one behavioral change** to review (background shells) and a few output-level changes worth knowing about.
 
 ## Dependency Version
 
@@ -13,6 +13,22 @@ This release introduces the sandboxing foundation: the `ExecBackend` and `Worksp
 ```
 
 The Spring AI dependency is unchanged (2.0.1).
+
+## Breaking change: one tool per skill
+
+`SkillsTool.builder().build()` now returns a `ToolCallbackProvider` with one `ToolCallback` per skill, named after the skill, instead of a single `Skill` tool whose description embedded an `<available_skills>` catalog:
+
+```java
+// Before
+ToolCallback skillsTool = SkillsTool.builder().addSkillsDirectory(".claude/skills").build();
+// model called: Skill(command="pdf")
+
+// After
+ToolCallbackProvider skillsTool = SkillsTool.builder().addSkillsDirectory(".claude/skills").build();
+// model calls: pdf() — no arguments
+```
+
+`ChatClient.Builder.defaultTools(...)` and `defaultToolCallbacks(...)` both accept a `ToolCallbackProvider`, so only code that stored the result in a `ToolCallback` variable needs updating. `SkillsTool.SkillsInput` and `SkillsTool.SkillsFunction` are replaced by `SkillsTool.SkillFunction`, `toolDescriptionTemplate`'s `%s` is now a single skill's front-matter, and duplicate skill names now fail at `build()` instead of silently shadowing each other. See [SkillsTool](SkillsTool.md) for the full details.
 
 ## Behavioral change: background shells are per-instance
 

--- a/spring-ai-agent-utils/docs/DockerCliExecBackend.md
+++ b/spring-ai-agent-utils/docs/DockerCliExecBackend.md
@@ -32,7 +32,7 @@ try (DockerCliExecBackend backend = DockerCliExecBackend.builder()
     GlobTool glob = GlobTool.builder().workspace(workspace).build();
 
     // Skill base directories and environment prompts show container paths
-    ToolCallback skills = SkillsTool.builder()
+    ToolCallbackProvider skills = SkillsTool.builder()
         .addSkillsDirectory(hostWorkspace.resolve("skills").toString())
         .workspace(workspace)
         .build();

--- a/spring-ai-agent-utils/docs/SkillsTool.md
+++ b/spring-ai-agent-utils/docs/SkillsTool.md
@@ -4,6 +4,7 @@ Extend AI agent capabilities with reusable, composable knowledge modules defined
 
 **Features:**
 - Define skills as Markdown files with YAML frontmatter
+- Every skill is registered as its own tool, named after the skill
 - Automatic skill invocation through semantic matching
 - Support for reference files and helper scripts
 - Progressive disclosure of detailed information
@@ -16,9 +17,9 @@ Extend AI agent capabilities with reusable, composable knowledge modules defined
 Skills are markdown files that teach the AI agent how to perform specific tasks. Unlike traditional tools that execute code, skills provide **knowledge and instructions** to the AI, enabling it to handle specialized domains effectively.
 
 **How Skills Work:**
-1. **Discovery**: At startup, SkillsTool loads skill names and descriptions
-2. **Semantic Matching**: When a user request matches a skill's description, the AI invokes it
-3. **Execution**: The full skill content is loaded and the AI follows its instructions
+1. **Discovery**: At startup, SkillsTool loads every `SKILL.md` and registers **one tool per skill**, named after the skill and described by the skill's front-matter
+2. **Semantic Matching**: When a user request matches a skill's description, the AI calls that skill's tool (no arguments)
+3. **Execution**: The full skill content is returned and the AI follows its instructions
 
 Extend agent capabilities with reusable, composable knowledge modules defined in Markdown with YAML front-matter:
 
@@ -193,7 +194,7 @@ Skills can come from multiple sources — filesystem directories, classpath reso
 ### Loading from Directories
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsDirectory(".claude/skills")           // Project skills
     .addSkillsDirectory(System.getenv("HOME") + "/.claude/skills")  // Personal skills
     .build();
@@ -202,7 +203,7 @@ SkillsTool skillsTool = SkillsTool.builder()
 Alternative using `addSkillsDirectories`:
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsDirectories(List.of(
         ".claude/skills",
         System.getenv("HOME") + "/.claude/skills"
@@ -226,7 +227,7 @@ public class SkillsConfig {
     private ResourceLoader resourceLoader;
 
     @Bean
-    public SkillsTool skillsTool() {
+    public ToolCallbackProvider skillsTool() {
         Resource skillsResource = resourceLoader.getResource("classpath:.claude/skills");
 
         return SkillsTool.builder()
@@ -240,7 +241,7 @@ Loading multiple resources:
 
 ```java
 @Bean
-public SkillsTool skillsTool() {
+public ToolCallbackProvider skillsTool() {
     List<Resource> skillResources = List.of(
         resourceLoader.getResource("classpath:.claude/skills"),
         resourceLoader.getResource("file:${user.home}/.claude/skills")
@@ -279,7 +280,7 @@ Add the JAR as a dependency, then point `SkillsTool` at the classpath prefix:
 ```
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsResource(new ClassPathResource("META-INF/resources/skills/anthropics/skills"))
     .build();
 ```
@@ -287,7 +288,7 @@ SkillsTool skillsTool = SkillsTool.builder()
 You can mix sources freely — filesystem directories, classpath JARs, and explicit JAR URLs:
 
 ```java
-SkillsTool skillsTool = SkillsTool.builder()
+ToolCallbackProvider skillsTool = SkillsTool.builder()
     .addSkillsDirectory(".claude/skills")                                         // Local filesystem
     .addSkillsResource(new ClassPathResource("META-INF/skills/my-org/my-skills")) // From a dependency JAR
     .addSkillsResource(new UrlResource("jar:file:/opt/skills.jar!/skills"))       // Explicit JAR URL
@@ -347,13 +348,17 @@ Skills loaded from JAR/classpath resources keep their synthetic base path unchan
 
 ### Custom Tool Description Template
 
+The template is applied **per skill**. It must contain a single `%s` placeholder, which is
+replaced by that skill's rendered front-matter (its `description`, followed by any remaining
+fields such as `allowed-tools` and `model`).
+
 ```java
 String customTemplate = """
-    Execute a custom skill...
+    Execute this skill within the main conversation.
 
-    <available_skills>
     %s
-    </available_skills>
+
+    The response starts with the skill base directory, followed by the skill instructions.
     """;
 
 SkillsTool.builder()
@@ -378,7 +383,7 @@ SkillsTool.builder()
 import org.springframework.core.io.Resource;
 
 @Bean
-public SkillsTool skillsTool(ResourceLoader resourceLoader) {
+public ToolCallbackProvider skillsTool(ResourceLoader resourceLoader) {
     Resource projectSkills = resourceLoader.getResource("classpath:.claude/skills");
     Resource userSkills = resourceLoader.getResource("file:${user.home}/.claude/skills");
 
@@ -396,7 +401,7 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.UrlResource;
 
 @Bean
-public SkillsTool skillsTool() {
+public ToolCallbackProvider skillsTool() {
     return SkillsTool.builder()
         .addSkillsDirectory(".claude/skills")                                         // Local filesystem
         .addSkillsResource(new ClassPathResource("META-INF/skills/my-org/my-skills")) // From a dependency JAR
@@ -527,18 +532,21 @@ ChatClient chatClient = chatClientBuilder
 
 1. **Discovery** (at startup):
    - SkillsTool scans `.claude/skills/` directories
-   - Loads `name` and `description` from each `SKILL.md`
-   - Creates lightweight skill registry
+   - Loads each `SKILL.md` and registers one `ToolCallback` per skill, named after the skill's
+     `name` front-matter and described by its `description`
+   - Each skill tool takes **no arguments**
 
 2. **Activation** (on user request):
    - User: "Help me extract data from this PDF"
-   - AI matches request to skill descriptions
-   - AI invokes skill: `Skill(command="pdf-processor")`
+   - AI matches the request against the skill tool descriptions
+   - AI calls the skill's own tool: `pdf-processor()`
 
 3. **Execution**:
-   - SkillsTool loads full `SKILL.md` content
-   - Returns content + base directory to AI
+   - The skill's `SKILL.md` content is returned, prefixed with the skill base directory
    - AI follows skill instructions
+
+Because each skill is a first-class tool, per-skill allow/deny lists work out of the box — e.g. a
+Claude subagent definition can list `pdf` in its `tools` or `disallowedTools`.
 
 ### Invocation Example
 
@@ -547,7 +555,7 @@ ChatClient chatClient = chatClientBuilder
 "I need to process a PDF file and extract tables"
 
 // AI recognizes "pdf" skill matches
-// AI calls: Skill(command="pdf")
+// AI calls: pdf()
 
 // SkillsTool returns:
 "Base directory for this skill: /project/.claude/skills/pdf
@@ -727,12 +735,30 @@ python scripts/visualize.py data.csv --type bar --output chart.png
 
 ### Namespace Collision Handling
 
-If multiple skills have the same name:
+If multiple skills have the same name, scope them with a fully qualified name:
 
-```java
-// Use fully qualified names: directory:skill-name
-Skill(command="project-a:pdf")
-Skill(command="project-b:pdf")
+```yaml
+# .claude/skills/project-a/pdf/SKILL.md
+name: project-a:pdf
+```
+
+```yaml
+# .claude/skills/project-b/pdf/SKILL.md
+name: project-b:pdf
+```
+
+The model providers do not accept `:` in a **tool** name, so `SkillsTool` derives the tool name
+from the skill name by replacing every character outside `[a-zA-Z0-9_-]` with `_` — the two skills
+above are registered as the tools `project-a_pdf` and `project-b_pdf`. The skill name itself stays
+as written, so `SKILL.md` files and subagent `skills:` lists keep using `project-a:pdf`.
+
+Names still have to be unique **after** that derivation, and at most 64 characters. Both are
+enforced at `build()` time:
+
+```text
+Duplicate skill tool name 'project-a_pdf' derived from skill 'project-a:pdf' in
+'/project-a/.claude/skills/pdf' and skill 'project-a_pdf' in '/other/.claude/skills/pdf'.
+Skill names must be unique.
 ```
 
 ## Spring Boot Integration
@@ -758,7 +784,7 @@ public class SkillsConfiguration {
     private String userSkillsDir;
 
     @Bean
-    public SkillsTool skillsTool() {
+    public ToolCallbackProvider skillsTool() {
         return SkillsTool.builder()
             .addSkillsDirectory(projectSkillsDir)
             .addSkillsDirectory(userSkillsDir)
@@ -768,7 +794,7 @@ public class SkillsConfiguration {
     @Bean
     public ChatClient chatClient(
             ChatClient.Builder chatClientBuilder,
-            SkillsTool skillsTool) {
+            ToolCallbackProvider skillsTool) {
 
         return chatClientBuilder
             .defaultToolCallbacks(skillsTool)
@@ -839,7 +865,10 @@ new ClassPathResource("META-INF/skills/my-org/my-skills")
 
 ### Multiple Skills with Same Name
 
-**Problem:** Naming collision between skills
+**Problem:** `build()` fails with `Duplicate skill tool name '…' derived from skill '…'`
+
+**Cause:** Each skill is registered as its own tool, so the derived tool names must be unique
+across all configured sources.
 
 **Solution:** Use fully qualified names
 ```markdown
@@ -847,11 +876,14 @@ new ClassPathResource("META-INF/skills/my-org/my-skills")
 name: project-name:skill-name
 ---
 ```
+The `:` is replaced by `_` when deriving the tool name, so the two skills no longer collide.
 
 ## Limitations
 
 - Skill descriptions limited to 1024 characters
-- Skill names limited to 64 characters
+- Skill names limited to 64 characters — the derived tool name must fit the provider limit
+- Characters outside `[a-zA-Z0-9_-]` are replaced by `_` in the derived tool name (e.g. `project-a:pdf` → `project-a_pdf`)
+- Derived tool names must be unique across all configured skill sources
 - Only `SKILL.md` files are recognized (exact name)
 - YAML frontmatter must be valid
 - Semantic matching depends on AI's understanding
@@ -869,6 +901,43 @@ name: project-name:skill-name
 9. **Document well**: Clear instructions for AI to follow
 10. **Maintain skills**: Update as requirements change
 11. **Share via JARs**: Package reusable skills as Maven/Gradle dependencies (SkillsJars) for cross-project sharing
+
+## Migration to 0.12.0
+
+`SkillsTool` used to register a **single** tool named `Skill`, whose description carried an
+`<available_skills>` catalog and which was invoked with the skill name as an argument
+(`Skill(command="pdf")`). Each skill is now its own tool.
+
+| Before (≤ 0.11) | After (0.12) |
+|---|---|
+| `ToolCallback build()` | `ToolCallbackProvider build()` |
+| One tool, `Skill` | One tool per skill, named after the skill |
+| `Skill(command="pdf")` | `pdf()` — no arguments |
+| `SkillsTool.SkillsInput`, `SkillsTool.SkillsFunction` | `SkillsTool.SkillFunction` |
+| `toolDescriptionTemplate` `%s` = the whole skill catalog | `%s` = a single skill's front-matter |
+| Duplicate skill names silently shadowed each other | `build()` fails with a duplicate-name error |
+| Skill name used as-is | Scoped names still supported; the tool name replaces illegal characters (`project-a:pdf` → `project-a_pdf`) |
+
+Registration is unchanged — `ChatClient.Builder.defaultTools(...)` and `defaultToolCallbacks(...)`
+both accept a `ToolCallbackProvider`:
+
+```java
+ChatClient chatClient = chatClientBuilder
+    .defaultToolCallbacks(SkillsTool.builder()
+        .addSkillsDirectory(".claude/skills")
+        .build())
+    .build();
+```
+
+Only code that stored the result in a `ToolCallback` variable needs updating:
+
+```java
+// Before
+ToolCallback skillsTool = SkillsTool.builder().addSkillsDirectory(".claude/skills").build();
+
+// After
+ToolCallbackProvider skillsTool = SkillsTool.builder().addSkillsDirectory(".claude/skills").build();
+```
 
 ## See Also
 

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/aot/AgentUtilsRuntimeHints.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/aot/AgentUtilsRuntimeHints.java
@@ -24,6 +24,7 @@ import org.springframework.aot.hint.RuntimeHintsRegistrar;
  * {@link RuntimeHintsRegistrar} for GraalVM native image support.
  *
  * @author Christian Tzolov
+ * @author kezhenxu94
  */
 public class AgentUtilsRuntimeHints implements RuntimeHintsRegistrar {
 
@@ -38,8 +39,7 @@ public class AgentUtilsRuntimeHints implements RuntimeHintsRegistrar {
 		hints.resources().registerPattern("META-INF/skills/**/*.md");
 
 		// Reflection for SkillsTool inner types used via tool invocation
-		hints.reflection().registerType(SkillsTool.SkillsInput.class, MemberCategory.values());
-		hints.reflection().registerType(SkillsTool.SkillsFunction.class, MemberCategory.values());
+		hints.reflection().registerType(SkillsTool.SkillFunction.class, MemberCategory.values());
 	}
 
 }

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/SkillsTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/SkillsTool.java
@@ -16,80 +16,74 @@
 package org.springaicommunity.agent.tools;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.springaicommunity.agent.common.workspace.Workspace;
 import org.springaicommunity.agent.utils.Skills;
 
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
 /**
+ * Registers every loaded skill as its own {@link ToolCallback}, named after the skill.
+ * Skill selection is therefore plain tool selection: the model calls the skill's tool
+ * (without arguments) instead of picking a name out of a catalog embedded in a single
+ * tool description.
+ *
  * @author Christian Tzolov
+ * @author kezhenxu94
  */
 public class SkillsTool {
 
+	/**
+	 * Characters that the model providers do not accept in a tool name. Scoped skill
+	 * names (e.g. {@code project-a:pdf}) remain valid skill names - the illegal
+	 * characters are replaced when deriving the tool name.
+	 */
+	private static final Pattern ILLEGAL_TOOL_NAME_CHARS = Pattern.compile("[^a-zA-Z0-9_-]");
+
+	/**
+	 * Maximum tool name length accepted by the model providers.
+	 */
+	private static final int MAX_TOOL_NAME_LENGTH = 64;
+
 	private static final String TOOL_DESCRIPTION_TEMPLATE = """
-			Execute a skill within the main conversation
-
-			<skills_instructions>
-			When users ask you to perform tasks, check if any of the available skills below can help complete the task more effectively. Skills provide specialized capabilities and domain knowledge.
-
-			How to use skills:
-			- Invoke skills using this tool with the skill name only (no arguments)
-			- When you invoke a skill, you will see <command-message>The "{name}" skill is loading</command-message>
-			- The skill's prompt will expand and provide detailed instructions on how to complete the task
-
-			NOTE: Response always starts start with the base directory of the skill execution environment. You can use this to retrieve additional files of call shell commands.
-			Skill description follows after the base directory line.
-
-			Important:
-			- Only use skills listed in <available_skills> below
-			- Do not invoke a skill that is already running
-			</skills_instructions>
-
-			<available_skills>
 			%s
-			</available_skills>
+
+			Returns the instructions to follow for this skill, preceded by a "Base directory for this skill: <path>" line - use that path to read the skill's other files or run its scripts.
 			""";
 
-	public static record SkillsInput(
-			@ToolParam(description = "The skill name (no arguments). E.g., \"pdf\" or \"xlsx\"") String command) {
-	}
+	/**
+	 * Returns the instructions of a single skill. Takes no input.
+	 */
+	public static class SkillFunction implements Supplier<String> {
 
-	public static class SkillsFunction implements Function<SkillsInput, String> {
+		private final Skill skill;
 
-		private Map<String, Skill> skillsMap;
+		private final Workspace workspace;
 
-		private Workspace workspace;
-
-		public SkillsFunction(Map<String, Skill> skillsMap) {
-			this(skillsMap, null);
+		public SkillFunction(Skill skill) {
+			this(skill, null);
 		}
 
-		public SkillsFunction(Map<String, Skill> skillsMap, Workspace workspace) {
-			this.skillsMap = skillsMap;
+		public SkillFunction(Skill skill, Workspace workspace) {
+			this.skill = skill;
 			this.workspace = workspace;
 		}
 
 		@Override
-		public String apply(SkillsInput input) {
-			Skill skill = this.skillsMap.get(input.command());
-
-			if (skill != null) {
-				String basePath = (this.workspace != null) ? this.workspace.display(skill.basePath())
-						: skill.basePath();
-				return "Base directory for this skill: %s\n\n%s".formatted(basePath, skill.content());
-			}
-
-			return "Skill not found: " + input.command();
+		public String get() {
+			String basePath = (this.workspace != null) ? this.workspace.display(this.skill.basePath())
+					: this.skill.basePath();
+			return "Base directory for this skill: %s\n\n%s".formatted(basePath, this.skill.content());
 		}
 
 	}
@@ -110,6 +104,10 @@ public class SkillsTool {
 
 		}
 
+		/**
+		 * @param template description template applied to every skill tool. Must contain
+		 * a single {@code %s} placeholder, replaced by the skill's rendered front-matter.
+		 */
 		public Builder toolDescriptionTemplate(String template) {
 			this.toolDescriptionTemplate = template;
 			return this;
@@ -150,14 +148,36 @@ public class SkillsTool {
 			return this;
 		}
 
-		public ToolCallback build() {
+		/**
+		 * @return one {@link ToolCallback} per configured skill, named after the skill.
+		 */
+		public ToolCallbackProvider build() {
 			Assert.notEmpty(this.skills, "At least one skill must be configured");
 
-			String skillsXml = this.skills.stream().map(s -> s.toXml()).collect(Collectors.joining("\n"));
+			Map<String, Skill> skillsByToolName = new LinkedHashMap<>();
 
-			return FunctionToolCallback.builder("Skill", new SkillsFunction(toSkillsMap(this.skills), this.workspace))
-				.description(this.toolDescriptionTemplate.formatted(skillsXml))
-				.inputType(SkillsInput.class)
+			for (Skill skill : this.skills) {
+				String toolName = skill.toolName();
+
+				Skill previous = skillsByToolName.put(toolName, skill);
+
+				if (previous != null) {
+					throw new IllegalArgumentException(
+							"Duplicate skill tool name '%s' derived from skill '%s' in '%s' and skill '%s' in '%s'. Skill names must be unique."
+								.formatted(toolName, previous.name(), previous.basePath(), skill.name(),
+										skill.basePath()));
+				}
+			}
+
+			return ToolCallbackProvider.from(skillsByToolName.entrySet()
+				.stream()
+				.map(e -> this.toToolCallback(e.getKey(), e.getValue()))
+				.toList());
+		}
+
+		private ToolCallback toToolCallback(String toolName, Skill skill) {
+			return FunctionToolCallback.builder(toolName, new SkillFunction(skill, this.workspace))
+				.description(this.toolDescriptionTemplate.formatted(skill.toDescription()))
 				.build();
 		}
 
@@ -169,7 +189,44 @@ public class SkillsTool {
 	public static record Skill(String basePath, Map<String, Object> frontMatter, String content) {
 
 		public String name() {
-			return this.frontMatter().get("name").toString();
+			Object name = this.frontMatter().get("name");
+			Assert.notNull(name, "Missing required 'name' front-matter field in skill: " + this.basePath());
+			return name.toString();
+		}
+
+		/**
+		 * The name of the tool registered for this skill. Scoped skill names (e.g.
+		 * {@code project-a:pdf}) are supported: characters that the model providers do
+		 * not allow in a tool name are replaced by {@code _} (e.g.
+		 * {@code project-a_pdf}).
+		 */
+		public String toolName() {
+			String name = this.name();
+			String toolName = ILLEGAL_TOOL_NAME_CHARS.matcher(name).replaceAll("_");
+
+			Assert.isTrue(toolName.length() <= MAX_TOOL_NAME_LENGTH,
+					"Skill name '%s' in '%s' is too long: a skill name is used as the tool name and must be at most %d characters."
+						.formatted(name, this.basePath(), MAX_TOOL_NAME_LENGTH));
+
+			return toolName;
+		}
+
+		/**
+		 * Renders the skill front-matter as the plain-text description of the skill tool:
+		 * the {@code description} field followed by any remaining fields (e.g.
+		 * {@code allowed-tools}, {@code model}) as {@code key: value} lines.
+		 */
+		public String toDescription() {
+			String description = String.valueOf(this.frontMatter().getOrDefault("description", ""));
+
+			String remainingFrontMatter = this.frontMatter()
+				.entrySet()
+				.stream()
+				.filter(e -> !"name".equals(e.getKey()) && !"description".equals(e.getKey()))
+				.map(e -> "%s: %s".formatted(e.getKey(), e.getValue()))
+				.collect(Collectors.joining("\n"));
+
+			return remainingFrontMatter.isEmpty() ? description : description + "\n\n" + remainingFrontMatter;
 		}
 
 		public String toXml() {
@@ -182,17 +239,6 @@ public class SkillsTool {
 			return "<skill>\n%s\n</skill>".formatted(frontMatterXml);
 		}
 
-	}
-
-	private static Map<String, Skill> toSkillsMap(List<Skill> skills) {
-
-		Map<String, Skill> skillsMap = new HashMap<>();
-
-		for (Skill skill : skills) {
-			skillsMap.put(skill.name(), skill);
-		}
-
-		return skillsMap;
 	}
 
 }

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/aot/AgentUtilsRuntimeHintsTests.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/aot/AgentUtilsRuntimeHintsTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link AgentUtilsRuntimeHints}.
  *
  * @author Christian Tzolov
+ * @author kezhenxu94
  */
 class AgentUtilsRuntimeHintsTests {
 
@@ -67,17 +68,9 @@ class AgentUtilsRuntimeHintsTests {
 	}
 
 	@Test
-	void skillsInputReflectionIsRegistered() {
+	void skillFunctionReflectionIsRegistered() {
 		assertThat(RuntimeHintsPredicates.reflection()
-			.onType(SkillsTool.SkillsInput.class)
-			.withMemberCategories(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS))
-			.accepts(this.hints);
-	}
-
-	@Test
-	void skillsFunctionReflectionIsRegistered() {
-		assertThat(RuntimeHintsPredicates.reflection()
-			.onType(SkillsTool.SkillsFunction.class)
+			.onType(SkillsTool.SkillFunction.class)
 			.withMemberCategories(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS))
 			.accepts(this.hints);
 	}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SkillsToolTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SkillsToolTest.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.UrlResource;
@@ -41,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for {@link SkillsTool}.
  *
  * @author Claude Code
+ * @author kezhenxu94
  */
 @DisplayName("SkillsTool Tests")
 class SkillsToolTest {
@@ -63,6 +67,24 @@ class SkillsToolTest {
 			This is another skill content.
 			""";
 
+	private static List<String> toolNames(ToolCallbackProvider provider) {
+		return Arrays.stream(provider.getToolCallbacks()).map(tc -> tc.getToolDefinition().name()).toList();
+	}
+
+	private static ToolCallback toolNamed(ToolCallbackProvider provider, String name) {
+		return Arrays.stream(provider.getToolCallbacks())
+			.filter(tc -> name.equals(tc.getToolDefinition().name()))
+			.findFirst()
+			.orElseThrow(() -> new AssertionError("No tool callback named: " + name));
+	}
+
+	private static Path writeSkill(Path parentDir, String directoryName, String skillMd) throws IOException {
+		Path skillDir = parentDir.resolve(directoryName);
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), skillMd, StandardCharsets.UTF_8);
+		return skillDir;
+	}
+
 	@Nested
 	@DisplayName("Filesystem Skills")
 	class FilesystemSkillsTests {
@@ -70,59 +92,92 @@ class SkillsToolTest {
 		@Test
 		@DisplayName("should load skills from directory via addSkillsDirectory")
 		void shouldLoadSkillsFromDirectory(@TempDir Path tempDir) throws IOException {
-			Path skillDir = tempDir.resolve("my-skill");
-			Files.createDirectories(skillDir);
-			Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD_CONTENT, StandardCharsets.UTF_8);
+			writeSkill(tempDir, "my-skill", SKILL_MD_CONTENT);
 
-			ToolCallback callback = SkillsTool.builder()
-				.addSkillsDirectory(tempDir.toString())
-				.build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build();
 
-			assertThat(callback).isNotNull();
-			assertThat(callback.getToolDefinition().description()).contains("test-skill");
+			assertThat(toolNames(provider)).containsExactly("test-skill");
+			assertThat(toolNamed(provider, "test-skill").getToolDefinition().description()).contains("A test skill");
 		}
 
 		@Test
 		@DisplayName("should load skills from FileSystemResource via addSkillsResource")
 		void shouldLoadSkillsFromFileSystemResource(@TempDir Path tempDir) throws IOException {
-			Path skillDir = tempDir.resolve("my-skill");
-			Files.createDirectories(skillDir);
-			Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD_CONTENT, StandardCharsets.UTF_8);
+			writeSkill(tempDir, "my-skill", SKILL_MD_CONTENT);
 
-			ToolCallback callback = SkillsTool.builder()
+			ToolCallbackProvider provider = SkillsTool.builder()
 				.addSkillsResource(new FileSystemResource(tempDir.toFile()))
 				.build();
 
-			assertThat(callback).isNotNull();
-			assertThat(callback.getToolDefinition().description()).contains("test-skill");
+			assertThat(toolNames(provider)).containsExactly("test-skill");
 		}
 
 		@Test
-		@DisplayName("should load multiple skills from nested directories")
-		void shouldLoadMultipleSkillsFromNestedDirectories(@TempDir Path tempDir) throws IOException {
-			Path skillDir1 = tempDir.resolve("skill-one");
-			Files.createDirectories(skillDir1);
-			Files.writeString(skillDir1.resolve("SKILL.md"), SKILL_MD_CONTENT, StandardCharsets.UTF_8);
+		@DisplayName("should create one tool callback per skill")
+		void shouldCreateOneToolCallbackPerSkill(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "skill-one", SKILL_MD_CONTENT);
+			writeSkill(tempDir, "skill-two", SKILL_MD_CONTENT_2);
 
-			Path skillDir2 = tempDir.resolve("skill-two");
-			Files.createDirectories(skillDir2);
-			Files.writeString(skillDir2.resolve("SKILL.md"), SKILL_MD_CONTENT_2, StandardCharsets.UTF_8);
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build();
 
-			ToolCallback callback = SkillsTool.builder()
+			assertThat(toolNames(provider)).containsExactlyInAnyOrder("test-skill", "another-skill");
+			assertThat(toolNamed(provider, "test-skill").getToolDefinition().description()).contains("A test skill")
+				.doesNotContain("Another test skill");
+			assertThat(toolNamed(provider, "another-skill").getToolDefinition().description())
+				.contains("Another test skill")
+				.doesNotContain("A test skill");
+		}
+
+		@Test
+		@DisplayName("should expose extra front-matter fields in the tool description")
+		void shouldExposeExtraFrontMatterFields(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "my-skill", """
+					---
+					name: rich-skill
+					description: A rich skill
+					allowed-tools: Read, Grep
+					model: claude-sonnet-4-5-20250929
+					---
+
+					Content.
+					""");
+
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build();
+
+			assertThat(toolNamed(provider, "rich-skill").getToolDefinition().description()).contains("A rich skill")
+				.contains("allowed-tools: Read, Grep")
+				.contains("model: claude-sonnet-4-5-20250929");
+		}
+
+		@Test
+		@DisplayName("should declare a no-argument input schema")
+		void shouldDeclareNoArgumentInputSchema(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "my-skill", SKILL_MD_CONTENT);
+
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build();
+
+			assertThat(toolNamed(provider, "test-skill").getToolDefinition().inputSchema())
+				.contains("\"properties\" : { }");
+		}
+
+		@Test
+		@DisplayName("should apply a custom tool description template per skill")
+		void shouldApplyCustomToolDescriptionTemplate(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "my-skill", SKILL_MD_CONTENT);
+
+			ToolCallbackProvider provider = SkillsTool.builder()
 				.addSkillsDirectory(tempDir.toString())
+				.toolDescriptionTemplate("Custom prefix: %s")
 				.build();
 
-			assertThat(callback).isNotNull();
-			String description = callback.getToolDefinition().description();
-			assertThat(description).contains("test-skill");
-			assertThat(description).contains("another-skill");
+			assertThat(toolNamed(provider, "test-skill").getToolDefinition().description())
+				.isEqualTo("Custom prefix: A test skill");
 		}
 
 		@Test
 		@DisplayName("should throw when directory does not exist")
 		void shouldThrowWhenDirectoryDoesNotExist() {
-			assertThatThrownBy(
-					() -> SkillsTool.builder().addSkillsDirectory("/nonexistent/directory").build())
+			assertThatThrownBy(() -> SkillsTool.builder().addSkillsDirectory("/nonexistent/directory").build())
 				.isInstanceOf(RuntimeException.class)
 				.hasMessageContaining("Root directory does not exist: /nonexistent/directory");
 		}
@@ -133,6 +188,102 @@ class SkillsToolTest {
 			assertThatThrownBy(() -> SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build())
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("At least one skill must be configured");
+		}
+
+		@Test
+		@DisplayName("should throw on duplicate skill names")
+		void shouldThrowOnDuplicateSkillNames(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "first", SKILL_MD_CONTENT);
+			writeSkill(tempDir, "second", SKILL_MD_CONTENT);
+
+			assertThatThrownBy(() -> SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build())
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Duplicate skill tool name 'test-skill'");
+		}
+
+		@Test
+		@DisplayName("should support scoped skill names")
+		void shouldSupportScopedSkillNames(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "project-a", """
+					---
+					name: project-a:pdf
+					description: The project-a PDF skill
+					---
+
+					Project A content.
+					""");
+			writeSkill(tempDir, "project-b", """
+					---
+					name: project-b:pdf
+					description: The project-b PDF skill
+					---
+
+					Project B content.
+					""");
+
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build();
+
+			assertThat(toolNames(provider)).containsExactlyInAnyOrder("project-a_pdf", "project-b_pdf");
+			assertThat(toolNamed(provider, "project-a_pdf").call("{}")).contains("Project A content.");
+			assertThat(toolNamed(provider, "project-b_pdf").call("{}")).contains("Project B content.");
+		}
+
+		@Test
+		@DisplayName("should throw when scoped skill names collide after tool name derivation")
+		void shouldThrowWhenDerivedToolNamesCollide(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "scoped", """
+					---
+					name: project-a:pdf
+					description: A scoped skill
+					---
+
+					Content.
+					""");
+			writeSkill(tempDir, "flat", """
+					---
+					name: project-a_pdf
+					description: A flat skill
+					---
+
+					Content.
+					""");
+
+			assertThatThrownBy(() -> SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build())
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Duplicate skill tool name 'project-a_pdf'");
+		}
+
+		@Test
+		@DisplayName("should throw on a skill name that is too long for a tool name")
+		void shouldThrowOnTooLongSkillName(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "my-skill", """
+					---
+					name: %s
+					description: A skill with a very long name
+					---
+
+					Content.
+					""".formatted("x".repeat(65)));
+
+			assertThatThrownBy(() -> SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build())
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("is too long");
+		}
+
+		@Test
+		@DisplayName("should throw when the name front-matter field is missing")
+		void shouldThrowWhenNameIsMissing(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "my-skill", """
+					---
+					description: A skill without a name
+					---
+
+					Content.
+					""");
+
+			assertThatThrownBy(() -> SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build())
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining("Missing required 'name' front-matter field in skill:");
 		}
 
 	}
@@ -176,25 +327,19 @@ class SkillsToolTest {
 		void shouldLoadSkillsFromJarResource() throws Exception {
 			UrlResource jarResource = new UrlResource("jar:" + jarPath.toUri() + "!/skills");
 
-			ToolCallback callback = SkillsTool.builder().addSkillsResource(jarResource).build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsResource(jarResource).build();
 
-			assertThat(callback).isNotNull();
-			String description = callback.getToolDefinition().description();
-			assertThat(description).contains("test-skill");
-			assertThat(description).contains("another-skill");
+			assertThat(toolNames(provider)).containsExactlyInAnyOrder("test-skill", "another-skill");
 		}
 
 		@Test
 		@DisplayName("should load single skill from nested JAR path")
 		void shouldLoadSingleSkillFromNestedJarPath() throws Exception {
-			UrlResource jarResource = new UrlResource(
-					"jar:" + jarPath.toUri() + "!/skills/my-skill");
+			UrlResource jarResource = new UrlResource("jar:" + jarPath.toUri() + "!/skills/my-skill");
 
-			ToolCallback callback = SkillsTool.builder().addSkillsResource(jarResource).build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsResource(jarResource).build();
 
-			assertThat(callback).isNotNull();
-			String description = callback.getToolDefinition().description();
-			assertThat(description).contains("test-skill");
+			assertThat(toolNames(provider)).containsExactly("test-skill");
 		}
 
 	}
@@ -206,15 +351,13 @@ class SkillsToolTest {
 		@Test
 		@DisplayName("should load pdf skill from anthropics__skills__pdf JAR on classpath")
 		void shouldLoadPdfSkillFromClasspathJar() {
-			ClassPathResource resource = new ClassPathResource(
-					"META-INF/resources/skills/anthropics/skills");
+			ClassPathResource resource = new ClassPathResource("META-INF/resources/skills/anthropics/skills");
 
-			ToolCallback callback = SkillsTool.builder().addSkillsResource(resource).build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsResource(resource).build();
 
-			assertThat(callback).isNotNull();
-			assertThat(callback.getToolDefinition().description()).contains("pdf");
+			assertThat(toolNames(provider)).contains("pdf");
 
-			String result = callback.call("{\"command\":\"pdf\"}");
+			String result = toolNamed(provider, "pdf").call("{}");
 			assertThat(result).contains("Base directory for this skill:");
 			assertThat(result).contains("PDF");
 		}
@@ -224,15 +367,13 @@ class SkillsToolTest {
 		void shouldLoadSpringBootSkillFromClasspathJar() {
 			// sivalabs JAR uses META-INF/skills/ (not META-INF/resources/skills/)
 			// and includes explicit directory entries, exercising a different code path
-			ClassPathResource resource = new ClassPathResource(
-					"META-INF/skills/sivaprasadreddy/sivalabs-agent-skills");
+			ClassPathResource resource = new ClassPathResource("META-INF/skills/sivaprasadreddy/sivalabs-agent-skills");
 
-			ToolCallback callback = SkillsTool.builder().addSkillsResource(resource).build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsResource(resource).build();
 
-			assertThat(callback).isNotNull();
-			assertThat(callback.getToolDefinition().description()).contains("spring-boot-skill");
+			assertThat(toolNames(provider)).contains("spring-boot-skill");
 
-			String result = callback.call("{\"command\":\"spring-boot-skill\"}");
+			String result = toolNamed(provider, "spring-boot-skill").call("{}");
 			assertThat(result).contains("Base directory for this skill:");
 			assertThat(result).contains("Spring Boot");
 		}
@@ -240,21 +381,17 @@ class SkillsToolTest {
 	}
 
 	@Nested
-	@DisplayName("SkillsFunction")
-	class SkillsFunctionTests {
+	@DisplayName("SkillFunction")
+	class SkillFunctionTests {
 
 		@Test
 		@DisplayName("should return content with base directory for filesystem skill")
 		void shouldReturnContentWithBaseDirectory(@TempDir Path tempDir) throws IOException {
-			Path skillDir = tempDir.resolve("my-skill");
-			Files.createDirectories(skillDir);
-			Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD_CONTENT, StandardCharsets.UTF_8);
+			Path skillDir = writeSkill(tempDir, "my-skill", SKILL_MD_CONTENT);
 
-			ToolCallback callback = SkillsTool.builder()
-				.addSkillsDirectory(tempDir.toString())
-				.build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build();
 
-			String result = callback.call("{\"command\":\"test-skill\"}");
+			String result = toolNamed(provider, "test-skill").call("{}");
 
 			assertThat(result).contains("Base directory for this skill:");
 			assertThat(result).contains(skillDir.toString());
@@ -262,19 +399,13 @@ class SkillsToolTest {
 		}
 
 		@Test
-		@DisplayName("should return not found message for unknown skill")
-		void shouldReturnNotFoundForUnknownSkill(@TempDir Path tempDir) throws IOException {
-			Path skillDir = tempDir.resolve("my-skill");
-			Files.createDirectories(skillDir);
-			Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD_CONTENT, StandardCharsets.UTF_8);
+		@DisplayName("should not register a tool for an unknown skill")
+		void shouldNotRegisterToolForUnknownSkill(@TempDir Path tempDir) throws IOException {
+			writeSkill(tempDir, "my-skill", SKILL_MD_CONTENT);
 
-			ToolCallback callback = SkillsTool.builder()
-				.addSkillsDirectory(tempDir.toString())
-				.build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsDirectory(tempDir.toString()).build();
 
-			String result = callback.call("{\"command\":\"nonexistent\"}");
-
-			assertThat(result).contains("Skill not found: nonexistent");
+			assertThat(toolNames(provider)).doesNotContain("nonexistent");
 		}
 
 		@Test
@@ -295,9 +426,9 @@ class SkillsToolTest {
 
 			UrlResource jarResource = new UrlResource("jar:" + jarPath.toUri() + "!/skills");
 
-			ToolCallback callback = SkillsTool.builder().addSkillsResource(jarResource).build();
+			ToolCallbackProvider provider = SkillsTool.builder().addSkillsResource(jarResource).build();
 
-			String result = callback.call("{\"command\":\"jar-skill\"}");
+			String result = toolNamed(provider, "jar-skill").call("{}");
 
 			assertThat(result).contains("Base directory for this skill: skills/jar-skill");
 			assertThat(result).contains("JAR skill content.");

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/WorkspaceAdoptionTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/WorkspaceAdoptionTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springaicommunity.agent.common.workspace.Workspace;
 
-import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -131,12 +131,12 @@ class WorkspaceAdoptionTest {
 
 		};
 
-		ToolCallback callback = SkillsTool.builder()
+		ToolCallbackProvider provider = SkillsTool.builder()
 			.addSkillsDirectory(this.workspaceDir.resolve("skills").toString())
 			.workspace(sandboxView)
 			.build();
 
-		String result = callback.call("{\"command\":\"test-skill\"}");
+		String result = provider.getToolCallbacks()[0].call("{}");
 
 		assertThat(result).contains("Base directory for this skill: /workspace/skills/test-skill");
 		assertThat(result).doesNotContain(this.workspaceDir.toString());
@@ -148,11 +148,11 @@ class WorkspaceAdoptionTest {
 		Files.createDirectories(skillDir);
 		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
 
-		ToolCallback callback = SkillsTool.builder()
+		ToolCallbackProvider provider = SkillsTool.builder()
 			.addSkillsDirectory(this.workspaceDir.resolve("skills").toString())
 			.build();
 
-		assertThat(callback.call("{\"command\":\"test-skill\"}"))
+		assertThat(provider.getToolCallbacks()[0].call("{}"))
 			.contains("Base directory for this skill: " + skillDir);
 	}
 


### PR DESCRIPTION
## Problem

`SkillsTool.build()` returned a **single** `Skill` tool whose description embedded an `<available_skills>` catalog of every loaded skill, invoked indirectly as `Skill(command="pdf")` and resolved through a `HashMap`.

The motivating case: **~100 skills with the tool search tool enabled.** Because the catalog of all 100 descriptions lives inside one tool description, that tool can never be deferred or indexed per skill — every tool search has to load all 100 skill descriptions just to select one. That is wasted tokens and wasted time on every call.

Secondary problems in the same code path:

- A mistyped or hallucinated `command` failed silently at runtime with `Skill not found: ...` instead of being prevented by the tool schema.
- Duplicate skill names were silently swallowed by `HashMap.put` — both appeared in the catalog, only the last was reachable.
- Front-matter values were injected raw into pseudo-XML, so a `<` or `</skill>` in a description corrupted the prompt structure.

## Change

Each skill is now its own `ToolCallback`, named after the skill, described by that skill's own front-matter, taking no arguments. Skill selection becomes ordinary tool selection — so skills are individually searchable and `defer_loading`-able.

- `build()` returns `ToolCallbackProvider`; one callback per skill.
- `SkillsInput` + `SkillsFunction` (the `command` string and map lookup) are replaced by `SkillFunction implements Supplier<String>`, one instance per skill. Zero-argument tools are first-class in Spring AI: `FunctionToolCallback.builder(name, Supplier)` sets `inputType(Void.class)`, and `JsonSchemaGenerator` has an explicit `Void` branch emitting an empty `properties` object.
- `build()` fails fast on duplicate names (naming both skills and base paths) and on names too long for a tool name.
- The per-skill description keeps only what the schema cannot convey — that the response's first line is the skill base directory, used to read sibling files or run its scripts.
- Per-skill allow/deny filtering in subagent `tools` / `disallowedTools` now works, since those match on `ToolDefinition.name()`.

### Scoped skill names still work

The skill `name` stays exactly as written; the **tool** name is derived from it, replacing characters the model providers reject (tool names must match `^[a-zA-Z0-9_-]{1,64}$`, so `:` is not allowed):

```
project-a:pdf  ->  tool "project-a_pdf"
project-b:pdf  ->  tool "project-b_pdf"
```

`SKILL.md` files and subagent `skills:` lists keep using `project-a:pdf`. Uniqueness is enforced on the derived name, so `project-a:pdf` and `project-a_pdf` in different directories are still caught.

## Breaking changes

A migration section was added to `docs/SkillsTool.md`.

| Before | After |
|---|---|
| `ToolCallback build()` | `ToolCallbackProvider build()` |
| One tool, `Skill` | One tool per skill, named after the skill |
| `Skill(command="pdf")` | `pdf()` — no arguments |
| `SkillsInput`, `SkillsFunction` | `SkillFunction` |
| `toolDescriptionTemplate` `%s` = whole catalog | `%s` = a single skill's front-matter |
| Duplicate names silently shadowed | `build()` fails with a duplicate-name error |

Registration is unchanged — `ChatClient.Builder.defaultTools(...)` and `defaultToolCallbacks(...)` both accept a `ToolCallbackProvider` — so **no example application needed any edit**. Only code that stored the result in a `ToolCallback` variable is affected.

`Skill.toXml()` is retained: `ClaudeSubagentExecutor` still uses it to preload skills into a subagent's system prompt, and that path is untouched by this change.

## Verification

- `SkillsToolTest` rewritten and extended — per-skill callbacks and descriptions, scoped names, post-derivation collisions, over-length names, missing `name` front-matter, empty input schema, custom per-skill template. Passes.
- `AgentUtilsRuntimeHintsTests` updated for the renamed inner class. Passes.
- All four example apps compile unchanged (`./mvnw -f examples package`).
- Full `spring-ai-agent-utils` module: the only failure is `SmartWebFetchToolTest$ConcurrencyTests.shouldHandleConcurrentCacheAccessSafely`, confirmed to fail identically on a clean `main` — pre-existing and unrelated.