### PR TITLE
fix: flatten `TodoWrite` tool parameter to a plain list of todo items

### DIFF
--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/TodoWriteTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/TodoWriteTool.java
@@ -31,6 +31,7 @@ import org.springframework.ai.tool.annotation.Tool;
  * time and that all task data is properly formatted.
  *
  * @author Christian Tzolov
+ * @author kezhenxu94
  */
 public class TodoWriteTool {
 
@@ -241,12 +242,14 @@ public class TodoWriteTool {
 
 		When in doubt, use this tool. Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully.
 		""")
-	public String todoWrite(Todos todos) { // @formatter:on
+	public String todoWrite(List<Todos.TodoItem> todos) { // @formatter:on
+
+		Todos todoList = new Todos(todos);
 
 		// Validate the todos
-		this.validateTodos(todos);
+		this.validateTodos(todoList);
 
-		this.todoListConsumer.handle(todos);
+		this.todoListConsumer.handle(todoList);
 
 		return "Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable";
 	}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/TodoWriteToolTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/TodoWriteToolTest.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for {@link TodoWriteTool}.
  *
  * @author Christian Tzolov
+ * @author kezhenxu94
  */
 @DisplayName("TodoWriteTool Tests")
 class TodoWriteToolTest {
@@ -81,24 +82,20 @@ class TodoWriteToolTest {
 		@DisplayName("Should accept valid todos with one pending task")
 		void shouldAcceptValidTodosWithOnePendingTask() {
 			List<TodoItem> items = List.of(new TodoItem("Fix bug", Status.pending, "Fixing bug"));
-			Todos todos = new Todos(items);
-
-			String result = TodoWriteToolTest.this.tool.todoWrite(todos);
+			String result = TodoWriteToolTest.this.tool.todoWrite(items);
 
 			assertThat(result).contains("Todos have been modified successfully");
-			assertThat(TodoWriteToolTest.this.capturedTodos.get()).isEqualTo(todos);
+			assertThat(TodoWriteToolTest.this.capturedTodos.get().todos()).isEqualTo(items);
 		}
 
 		@Test
 		@DisplayName("Should accept valid todos with one in_progress task")
 		void shouldAcceptValidTodosWithOneInProgressTask() {
 			List<TodoItem> items = List.of(new TodoItem("Implement feature", Status.in_progress, "Implementing feature"));
-			Todos todos = new Todos(items);
-
-			String result = TodoWriteToolTest.this.tool.todoWrite(todos);
+			String result = TodoWriteToolTest.this.tool.todoWrite(items);
 
 			assertThat(result).contains("Todos have been modified successfully");
-			assertThat(TodoWriteToolTest.this.capturedTodos.get()).isEqualTo(todos);
+			assertThat(TodoWriteToolTest.this.capturedTodos.get().todos()).isEqualTo(items);
 		}
 
 		@Test
@@ -107,12 +104,10 @@ class TodoWriteToolTest {
 			List<TodoItem> items = List.of(new TodoItem("Task 1", Status.completed, "Completing task 1"),
 					new TodoItem("Task 2", Status.in_progress, "Working on task 2"),
 					new TodoItem("Task 3", Status.pending, "Preparing task 3"));
-			Todos todos = new Todos(items);
-
-			String result = TodoWriteToolTest.this.tool.todoWrite(todos);
+			String result = TodoWriteToolTest.this.tool.todoWrite(items);
 
 			assertThat(result).contains("Todos have been modified successfully");
-			assertThat(TodoWriteToolTest.this.capturedTodos.get()).isEqualTo(todos);
+			assertThat(TodoWriteToolTest.this.capturedTodos.get().todos()).isEqualTo(items);
 			assertThat(TodoWriteToolTest.this.capturedTodos.get().todos()).hasSize(3);
 		}
 
@@ -121,23 +116,19 @@ class TodoWriteToolTest {
 		void shouldAcceptValidTodosWithAllCompletedTasks() {
 			List<TodoItem> items = List.of(new TodoItem("Task 1", Status.completed, "Completing task 1"),
 					new TodoItem("Task 2", Status.completed, "Completing task 2"));
-			Todos todos = new Todos(items);
-
-			String result = TodoWriteToolTest.this.tool.todoWrite(todos);
+			String result = TodoWriteToolTest.this.tool.todoWrite(items);
 
 			assertThat(result).contains("Todos have been modified successfully");
-			assertThat(TodoWriteToolTest.this.capturedTodos.get()).isEqualTo(todos);
+			assertThat(TodoWriteToolTest.this.capturedTodos.get().todos()).isEqualTo(items);
 		}
 
 		@Test
 		@DisplayName("Should accept empty todo list")
 		void shouldAcceptEmptyTodoList() {
-			Todos todos = new Todos(new ArrayList<>());
-
-			String result = TodoWriteToolTest.this.tool.todoWrite(todos);
+			String result = TodoWriteToolTest.this.tool.todoWrite(new ArrayList<>());
 
 			assertThat(result).contains("Todos have been modified successfully");
-			assertThat(TodoWriteToolTest.this.capturedTodos.get()).isEqualTo(todos);
+			assertThat(TodoWriteToolTest.this.capturedTodos.get().todos()).isEmpty();
 		}
 
 	}
@@ -151,9 +142,7 @@ class TodoWriteToolTest {
 		void shouldRejectTodosWithTwoInProgressTasks() {
 			List<TodoItem> items = List.of(new TodoItem("Task 1", Status.in_progress, "Working on task 1"),
 					new TodoItem("Task 2", Status.in_progress, "Working on task 2"));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("Only ONE task can be in_progress at a time")
 				.hasMessageContaining("Found 2 in_progress tasks");
@@ -165,9 +154,7 @@ class TodoWriteToolTest {
 			List<TodoItem> items = List.of(new TodoItem("Task 1", Status.in_progress, "Working on task 1"),
 					new TodoItem("Task 2", Status.in_progress, "Working on task 2"),
 					new TodoItem("Task 3", Status.in_progress, "Working on task 3"));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("Only ONE task can be in_progress at a time")
 				.hasMessageContaining("Found 3 in_progress tasks");
@@ -183,9 +170,7 @@ class TodoWriteToolTest {
 		@DisplayName("Should reject todo with null content")
 		void shouldRejectTodoWithNullContent() {
 			List<TodoItem> items = List.of(new TodoItem(null, Status.pending, "Doing something"));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("has empty or blank content");
 		}
@@ -194,9 +179,7 @@ class TodoWriteToolTest {
 		@DisplayName("Should reject todo with empty content")
 		void shouldRejectTodoWithEmptyContent() {
 			List<TodoItem> items = List.of(new TodoItem("", Status.pending, "Doing something"));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("has empty or blank content");
 		}
@@ -205,9 +188,7 @@ class TodoWriteToolTest {
 		@DisplayName("Should reject todo with blank content")
 		void shouldRejectTodoWithBlankContent() {
 			List<TodoItem> items = List.of(new TodoItem("   ", Status.pending, "Doing something"));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("has empty or blank content");
 		}
@@ -217,9 +198,7 @@ class TodoWriteToolTest {
 		void shouldRejectSecondTodoWithBlankContent() {
 			List<TodoItem> items = List.of(new TodoItem("Valid task", Status.pending, "Doing valid task"),
 					new TodoItem("   ", Status.pending, "Doing something"));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("Task at index 1")
 				.hasMessageContaining("has empty or blank content");
@@ -235,9 +214,7 @@ class TodoWriteToolTest {
 		@DisplayName("Should reject todo with null activeForm")
 		void shouldRejectTodoWithNullActiveForm() {
 			List<TodoItem> items = List.of(new TodoItem("Fix bug", Status.pending, null));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("has empty or blank activeForm");
 		}
@@ -246,9 +223,7 @@ class TodoWriteToolTest {
 		@DisplayName("Should reject todo with empty activeForm")
 		void shouldRejectTodoWithEmptyActiveForm() {
 			List<TodoItem> items = List.of(new TodoItem("Fix bug", Status.pending, ""));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("has empty or blank activeForm");
 		}
@@ -257,9 +232,7 @@ class TodoWriteToolTest {
 		@DisplayName("Should reject todo with blank activeForm")
 		void shouldRejectTodoWithBlankActiveForm() {
 			List<TodoItem> items = List.of(new TodoItem("Fix bug", Status.pending, "   "));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("has empty or blank activeForm");
 		}
@@ -274,9 +247,7 @@ class TodoWriteToolTest {
 		@DisplayName("Should reject todo with null status")
 		void shouldRejectTodoWithNullStatus() {
 			List<TodoItem> items = List.of(new TodoItem("Fix bug", null, "Fixing bug"));
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("has null status")
 				.hasMessageContaining("Status must be one of: pending, in_progress, completed");
@@ -297,23 +268,11 @@ class TodoWriteToolTest {
 		}
 
 		@Test
-		@DisplayName("Should reject null todo list")
-		void shouldRejectNullTodoList() {
-			Todos todos = new Todos(null);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("Todos cannot be null");
-		}
-
-		@Test
 		@DisplayName("Should reject null todo item")
 		void shouldRejectNullTodoItem() {
 			List<TodoItem> items = new ArrayList<>();
 			items.add(null);
-			Todos todos = new Todos(items);
-
-			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(todos))
+			assertThatThrownBy(() -> TodoWriteToolTest.this.tool.todoWrite(items))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessageContaining("Task at index 0 is null");
 		}
@@ -363,26 +322,22 @@ class TodoWriteToolTest {
 			// Initial state - all pending
 			List<TodoItem> items1 = List.of(new TodoItem("Task 1", Status.pending, "Doing task 1"),
 					new TodoItem("Task 2", Status.pending, "Doing task 2"));
-			Todos todos1 = new Todos(items1);
-			TodoWriteToolTest.this.tool.todoWrite(todos1);
+			TodoWriteToolTest.this.tool.todoWrite(items1);
 
 			// Start working on task 1
 			List<TodoItem> items2 = List.of(new TodoItem("Task 1", Status.in_progress, "Doing task 1"),
 					new TodoItem("Task 2", Status.pending, "Doing task 2"));
-			Todos todos2 = new Todos(items2);
-			TodoWriteToolTest.this.tool.todoWrite(todos2);
+			TodoWriteToolTest.this.tool.todoWrite(items2);
 
 			// Complete task 1, start task 2
 			List<TodoItem> items3 = List.of(new TodoItem("Task 1", Status.completed, "Doing task 1"),
 					new TodoItem("Task 2", Status.in_progress, "Doing task 2"));
-			Todos todos3 = new Todos(items3);
-			TodoWriteToolTest.this.tool.todoWrite(todos3);
+			TodoWriteToolTest.this.tool.todoWrite(items3);
 
 			// Complete all tasks
 			List<TodoItem> items4 = List.of(new TodoItem("Task 1", Status.completed, "Doing task 1"),
 					new TodoItem("Task 2", Status.completed, "Doing task 2"));
-			Todos todos4 = new Todos(items4);
-			String result = TodoWriteToolTest.this.tool.todoWrite(todos4);
+			String result = TodoWriteToolTest.this.tool.todoWrite(items4);
 
 			assertThat(result).contains("Todos have been modified successfully");
 		}


### PR DESCRIPTION
## Problem

`TodoWriteTool.todoWrite` took the `Todos` wrapper record, whose single component is *also* named `todos`:

```java
public record Todos(List<TodoItem> todos) { ... }

public String todoWrite(Todos todos) { ... }
```

Spring AI's `JsonSchemaGenerator.generateForMethodInput` builds the root schema from the **method parameters**, keyed by reflected parameter name, and inlines the schema of each parameter's type. With the parameter named `todos` and the record component named `todos`, that yields a doubly nested schema:

```json
{
  "type": "object",
  "properties": {
    "todos": {                    // the method parameter
      "type": "object",
      "properties": {
        "todos": {                // the Todos record component
          "type": "array",
          "items": { "content": …, "status": …, "activeForm": … }
        }
      },
      "required": ["todos"]
    }
  },
  "required": ["todos"]
}
```

So the only accepted payload was `{"todos": {"todos": [...]}}`. Models overwhelmingly emit `{"todos": [...]}`, which fails with `cannot deserialize Todos from Array value`. Nothing in the (very long) tool description names the fields, so there is no signal to recover from — and the natural second guess, `{"todos": {"items": [...]}}`, fails with the same message because the inner key is `todos`, not `items`.

Observed repeatedly in practice; a model burning turns on it looks like this:

> TodoWrite keeps failing — maybe the "todos" param must be an object containing "todos" array... I did pass `{"todos": [...]}`. Hmm, error says cannot deserialize Todos from Array value. Maybe the parameter itself should be the array directly? The schema shows todos: {items: {...}, type: array}. Passing `{"todos": [...]}` means the value of "todos" is an object with a "todos" key... wait no, I passed todos = `{"todos": [...]}` — that's an object where array expected? Actually error says "from Array value" meaning it received an Array where it expected an object Todos. So the todos property expects an object of type Todos (wrapper), which contains an array inside. So I should pass `{"todos": {"todos": [...]}}`.

## Fix

Take the list directly and wrap internally:

```java
public String todoWrite(List<Todos.TodoItem> todos) {
    Todos todoList = new Todos(todos);
    this.validateTodos(todoList);
    this.todoListConsumer.handle(todoList);
    ...
}
```

`Todos`, `Todos.TodoItem` and `TodoEventHandler` are unchanged, so event-handler consumers (e.g. `examples/todo-demo`) are unaffected. Generated schema, verified against the compiled class via `JsonSchemaGenerator.generateForMethodInput`:

```json
{
  "type": "object",
  "properties": {
    "todos": {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          "activeForm": { "type": "string" },
          "content": { "type": "string" },
          "status": { "type": "string", "enum": ["pending", "in_progress", "completed"] }
        },
        "required": ["activeForm", "content", "status"],
        "additionalProperties": false
      }
    }
  },
  "required": ["todos"],
  "additionalProperties": false
}
```

`{"todos": [...]}` now validates.

## Note on the tool contract

This changes the JSON shape the model must produce, and the Java signature. Prompts or transcripts pinned to `{"todos": {"todos": [...]}}` would need updating — in practice that shape is the thing models fail to produce, so this should only fix behaviour.

## Tests

`TodoWriteToolTest` updated to call `todoWrite(items)` and assert on `capturedTodos.get().todos()`. `shouldRejectNullTodoList` was removed: with the flat signature it became a literal duplicate of `shouldRejectNullTodos` (both `todoWrite(null)`), and `validateTodos` still rejects that via the existing `todos.todos() == null` guard.

```
./mvnw -pl spring-ai-agent-utils test -Dtest=TodoWriteToolTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
