### PR TITLE
Introduce ExecBackend SPI and route ShellTools through it

### DIFF
--- a/docs/tools/ShellTools.md
+++ b/docs/tools/ShellTools.md
@@ -28,7 +28,7 @@ The primary tool for executing shell commands either synchronously or in the bac
 **Basic Usage:**
 
 ```java
-ShellTools shellTools = new ShellTools();
+ShellTools shellTools = ShellTools.builder().build();
 
 // Synchronous execution
 String result = shellTools.bash(
@@ -159,7 +159,7 @@ String result = shellTools.killShell(
 **Example Workflow:**
 
 ```java
-ShellTools shellTools = new ShellTools();
+ShellTools shellTools = ShellTools.builder().build();
 
 // 1. Start a long-running background task
 String start = shellTools.bash(
@@ -225,3 +225,43 @@ String killResult = shellTools.killShell("shell_1234567890");
    ```java
    shellTools.killShell(bashId);
    ```
+
+## Execution backend & working directory
+
+`ShellTools` executes commands through a pluggable `ExecBackend` (SPI in
+`spring-ai-agent-utils-common`, package `org.springaicommunity.agent.common.exec`).
+The default `LocalExecBackend` runs processes on the host JVM; alternative
+implementations can execute inside a container or on a remote worker without any
+tool changes.
+
+```java
+// Confine local execution to a workspace directory (per session/agent)
+ShellTools tools = ShellTools.builder()
+    .workingDirectory(Path.of("/workspace/session-42"))
+    .build();
+
+// Or supply a fully configured backend
+ShellTools tools = ShellTools.builder()
+    .execBackend(LocalExecBackend.builder()
+        .workingDirectory(workDir)
+        .cleanEnvironment(true)                 // child processes do NOT inherit the JVM env
+        .environment(Map.of("LANG", "C"))
+        .build())
+    .build();
+```
+
+Security notes:
+
+- **Working directory** — without one, commands run in the JVM's current directory.
+  Always set a per-session working directory when commands are model-authored.
+- **Environment** — by default child processes inherit the full JVM environment
+  (historical behavior). Enable `cleanEnvironment(true)` so secrets in host
+  environment variables are not visible to model-authored commands.
+- **Shell namespaces** — background shells (`BashOutput`/`KillShell`) are tracked
+  per `ShellTools` instance, not globally. Agents holding *different* instances have
+  separate shell namespaces; agents that *share* an instance (for example Claude
+  subagents, which reuse the single `ShellTools` created by `ClaudeSubagentType`)
+  share a namespace and can see each other's shells. Migration note: the registry
+  was previously JVM-global — if you relied on reading or killing a shell from a
+  different `ShellTools` instance, share one instance between those agents
+  explicitly.

--- a/docs/tools/SkillsTool.md
+++ b/docs/tools/SkillsTool.md
@@ -482,7 +482,7 @@ ChatClient chatClient = chatClientBuilder
     .defaultTools(FileSystemTools.builder().build())
 
     // Required for skills to execute scripts
-    .defaultTools(new ShellTools())
+    .defaultTools(ShellTools.builder().build())
 
     .build();
 ```
@@ -619,7 +619,7 @@ public class SkillsConfig {
                 .addSkillsDirectory("examples/.claude/skills")
                 .build())
             .defaultTools(FileSystemTools.builder().build())
-            .defaultTools(new ShellTools())
+            .defaultTools(ShellTools.builder().build())
             .defaultTools(GrepTool.builder().build())
             .build();
     }
@@ -742,7 +742,7 @@ public class SkillsConfiguration {
         return chatClientBuilder
             .defaultToolCallbacks(skillsTool)
             .defaultTools(FileSystemTools.builder().build())
-            .defaultTools(new ShellTools())
+            .defaultTools(ShellTools.builder().build())
             .build();
     }
 }
@@ -785,7 +785,7 @@ ChatClient chatClient = chatClientBuilder
 ```java
 ChatClient chatClient = chatClientBuilder
     .defaultToolCallbacks(skillsTool)
-    .defaultTools(new ShellTools())  // Add this
+    .defaultTools(ShellTools.builder().build())  // Add this
     .build();
 ```
 

--- a/spring-ai-agent-utils-common/pom.xml
+++ b/spring-ai-agent-utils-common/pom.xml
@@ -70,6 +70,13 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.2</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- <dependency>
 			<groupId>com.vladsch.flexmark</groupId>
 			<artifactId>flexmark-html2md-converter</artifactId>

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecBackend.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecBackend.java
@@ -1,0 +1,42 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.common.exec;
+
+/**
+ * Where model-authored shell commands run. Tools describe <em>what</em> to execute (an
+ * {@link ExecSpec}); the backend decides <em>where and how</em> — which shell, which
+ * working directory, which environment variables. The default implementation runs
+ * processes on the host JVM; alternative implementations can execute inside a container
+ * or on a remote worker without any tool changes.
+ *
+ * @author Christian Tzolov
+ */
+public interface ExecBackend {
+
+	/**
+	 * Executes the command synchronously, honoring the spec's timeout. Failures are
+	 * reported via {@link ExecResult.Status}, never thrown.
+	 */
+	ExecResult run(ExecSpec spec);
+
+	/**
+	 * Starts the command in the background and returns a handle to poll or kill it.
+	 * Throws {@link IllegalStateException} with the (unprefixed) failure reason when the
+	 * command cannot be launched. Handle ids must be unique within the backend.
+	 */
+	ExecHandle start(ExecSpec spec);
+
+}

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecHandle.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecHandle.java
@@ -1,0 +1,46 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.common.exec;
+
+/**
+ * A handle to a background command started via {@link ExecBackend#start}. Handles are
+ * owned by the caller (not a process-global registry), so separate tool instances have
+ * separate shell namespaces.
+ *
+ * @author Christian Tzolov
+ */
+public interface ExecHandle {
+
+	/** Stable identifier for this background command. */
+	String id();
+
+	/** Whether the underlying process is still running. */
+	boolean isAlive();
+
+	/**
+	 * Returns output produced since the previous call (cursor semantics). When
+	 * {@code filterRegex} is non-null, only lines matching it are returned; filtered-out
+	 * lines are consumed and not returned by later calls.
+	 */
+	String newOutput(String filterRegex);
+
+	/** The process exit code; only valid once {@link #isAlive()} is false. */
+	int exitCode();
+
+	/** Terminates the process (graceful first, forcibly after a short grace period). */
+	void kill();
+
+}

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecResult.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecResult.java
@@ -1,0 +1,74 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.common.exec;
+
+/**
+ * The outcome of a synchronous command execution. The {@link Status} discriminates the
+ * four possible outcomes explicitly — no sentinel exit codes: {@code exitCode} is only
+ * meaningful when the status is {@link Status#COMPLETED}. Backends report failures as
+ * results rather than throwing, and messages carry no user-facing prefixes (the tool
+ * layer owns presentation).
+ *
+ * @param status how the execution ended
+ * @param exitCode the process exit code; meaningful only for {@link Status#COMPLETED}
+ * @param stdout captured standard output (possibly partial for non-completed statuses)
+ * @param stderr captured standard error, or the failure reason for
+ * {@link Status#LAUNCH_FAILED} / {@link Status#INTERRUPTED}
+ * @author Christian Tzolov
+ */
+public record ExecResult(Status status, int exitCode, String stdout, String stderr) {
+
+	/** How a synchronous execution ended. */
+	public enum Status {
+
+		/** The process ran to completion; {@code exitCode} is its exit code. */
+		COMPLETED,
+
+		/** The process was killed after exceeding the spec's timeout. */
+		TIMED_OUT,
+
+		/**
+		 * The command could not be launched at all; {@code stderr} carries the reason.
+		 */
+		LAUNCH_FAILED,
+
+		/** The executing thread was interrupted; {@code stderr} carries the reason. */
+		INTERRUPTED
+
+	}
+
+	public ExecResult {
+		stdout = (stdout != null) ? stdout : "";
+		stderr = (stderr != null) ? stderr : "";
+	}
+
+	public static ExecResult completed(int exitCode, String stdout, String stderr) {
+		return new ExecResult(Status.COMPLETED, exitCode, stdout, stderr);
+	}
+
+	public static ExecResult timedOut(String stdout, String stderr) {
+		return new ExecResult(Status.TIMED_OUT, -1, stdout, stderr);
+	}
+
+	public static ExecResult launchFailed(String reason) {
+		return new ExecResult(Status.LAUNCH_FAILED, -1, "", reason);
+	}
+
+	public static ExecResult interrupted(String stdout, String reason) {
+		return new ExecResult(Status.INTERRUPTED, -1, stdout, reason);
+	}
+
+}

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecSpec.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/ExecSpec.java
@@ -1,0 +1,61 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.common.exec;
+
+import java.util.Map;
+
+/**
+ * A shell command to execute: the command line as the model authored it, a wall-clock
+ * timeout in milliseconds (applied to synchronous runs), and extra environment variables
+ * to set for this invocation. Shell selection and working directory are backend concerns,
+ * not part of the spec.
+ *
+ * <p>
+ * Timeout policy is owned here so every backend behaves the same: non-positive values are
+ * replaced by {@link #DEFAULT_TIMEOUT_MILLIS} and values above
+ * {@link #MAX_TIMEOUT_MILLIS} are clamped to it. Read {@link #timeoutMillis()} for the
+ * effective value.
+ *
+ * @param command the shell command line to execute
+ * @param timeoutMillis effective wall-clock timeout for synchronous execution
+ * @param env extra environment variables for this invocation (never null)
+ * @author Christian Tzolov
+ */
+public record ExecSpec(String command, long timeoutMillis, Map<String, String> env) {
+
+	/** Default timeout for synchronous commands: 2 minutes. */
+	public static final long DEFAULT_TIMEOUT_MILLIS = 120_000;
+
+	/** Upper bound for synchronous command timeouts: 10 minutes. */
+	public static final long MAX_TIMEOUT_MILLIS = 600_000;
+
+	public ExecSpec {
+		if (command == null || command.isBlank()) {
+			throw new IllegalArgumentException("command must not be blank");
+		}
+		if (timeoutMillis <= 0) {
+			timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+		}
+		timeoutMillis = Math.min(timeoutMillis, MAX_TIMEOUT_MILLIS);
+		env = (env != null) ? Map.copyOf(env) : Map.of();
+	}
+
+	/** Creates a spec with the default timeout and no extra environment. */
+	public static ExecSpec of(String command) {
+		return new ExecSpec(command, DEFAULT_TIMEOUT_MILLIS, Map.of());
+	}
+
+}

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/package-info.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/exec/package-info.java
@@ -1,0 +1,26 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+ * Execution backend SPI: where model-authored shell commands run. Tools submit an
+ * {@link org.springaicommunity.agent.common.exec.ExecSpec} and consume an
+ * {@link org.springaicommunity.agent.common.exec.ExecResult} or
+ * {@link org.springaicommunity.agent.common.exec.ExecHandle}; the
+ * {@link org.springaicommunity.agent.common.exec.ExecBackend} implementation decides the
+ * shell, working directory, and environment — host JVM by default, container or remote
+ * worker in sandboxed deployments.
+ */
+package org.springaicommunity.agent.common.exec;

--- a/spring-ai-agent-utils-common/src/test/java/org/springaicommunity/agent/common/exec/ExecSpecTest.java
+++ b/spring-ai-agent-utils-common/src/test/java/org/springaicommunity/agent/common/exec/ExecSpecTest.java
@@ -1,0 +1,60 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.common.exec;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Timeout policy is owned by the spec so every backend behaves identically.
+ *
+ * @author Christian Tzolov
+ */
+class ExecSpecTest {
+
+	@Test
+	void nonPositiveTimeoutBecomesDefault() {
+		assertEquals(ExecSpec.DEFAULT_TIMEOUT_MILLIS, new ExecSpec("echo hi", 0, Map.of()).timeoutMillis());
+		assertEquals(ExecSpec.DEFAULT_TIMEOUT_MILLIS, new ExecSpec("echo hi", -5, Map.of()).timeoutMillis());
+	}
+
+	@Test
+	void oversizedTimeoutIsClampedToMax() {
+		assertEquals(ExecSpec.MAX_TIMEOUT_MILLIS,
+				new ExecSpec("echo hi", ExecSpec.MAX_TIMEOUT_MILLIS + 1, Map.of()).timeoutMillis());
+	}
+
+	@Test
+	void positiveTimeoutIsKept() {
+		assertEquals(1, new ExecSpec("echo hi", 1, Map.of()).timeoutMillis());
+	}
+
+	@Test
+	void blankCommandIsRejected() {
+		assertThrows(IllegalArgumentException.class, () -> new ExecSpec("  ", 1000, Map.of()));
+	}
+
+	@Test
+	void nullEnvBecomesEmpty() {
+		assertTrue(new ExecSpec("echo hi", 1000, null).env().isEmpty());
+	}
+
+}

--- a/spring-ai-agent-utils/docs/ShellTools.md
+++ b/spring-ai-agent-utils/docs/ShellTools.md
@@ -28,7 +28,7 @@ The primary tool for executing shell commands either synchronously or in the bac
 **Basic Usage:**
 
 ```java
-ShellTools shellTools = new ShellTools();
+ShellTools shellTools = ShellTools.builder().build();
 
 // Synchronous execution
 String result = shellTools.bash(
@@ -159,7 +159,7 @@ String result = shellTools.killShell(
 **Example Workflow:**
 
 ```java
-ShellTools shellTools = new ShellTools();
+ShellTools shellTools = ShellTools.builder().build();
 
 // 1. Start a long-running background task
 String start = shellTools.bash(
@@ -225,3 +225,43 @@ String killResult = shellTools.killShell("shell_1234567890");
    ```java
    shellTools.killShell(bashId);
    ```
+
+## Execution backend & working directory
+
+`ShellTools` executes commands through a pluggable `ExecBackend` (SPI in
+`spring-ai-agent-utils-common`, package `org.springaicommunity.agent.common.exec`).
+The default `LocalExecBackend` runs processes on the host JVM; alternative
+implementations can execute inside a container or on a remote worker without any
+tool changes.
+
+```java
+// Confine local execution to a workspace directory (per session/agent)
+ShellTools tools = ShellTools.builder()
+    .workingDirectory(Path.of("/workspace/session-42"))
+    .build();
+
+// Or supply a fully configured backend
+ShellTools tools = ShellTools.builder()
+    .execBackend(LocalExecBackend.builder()
+        .workingDirectory(workDir)
+        .cleanEnvironment(true)                 // child processes do NOT inherit the JVM env
+        .environment(Map.of("LANG", "C"))
+        .build())
+    .build();
+```
+
+Security notes:
+
+- **Working directory** — without one, commands run in the JVM's current directory.
+  Always set a per-session working directory when commands are model-authored.
+- **Environment** — by default child processes inherit the full JVM environment
+  (historical behavior). Enable `cleanEnvironment(true)` so secrets in host
+  environment variables are not visible to model-authored commands.
+- **Shell namespaces** — background shells (`BashOutput`/`KillShell`) are tracked
+  per `ShellTools` instance, not globally. Agents holding *different* instances have
+  separate shell namespaces; agents that *share* an instance (for example Claude
+  subagents, which reuse the single `ShellTools` created by `ClaudeSubagentType`)
+  share a namespace and can see each other's shells. Migration note: the registry
+  was previously JVM-global — if you relied on reading or killing a shell from a
+  different `ShellTools` instance, share one instance between those agents
+  explicitly.

--- a/spring-ai-agent-utils/docs/SkillsTool.md
+++ b/spring-ai-agent-utils/docs/SkillsTool.md
@@ -482,7 +482,7 @@ ChatClient chatClient = chatClientBuilder
     .defaultTools(FileSystemTools.builder().build())
 
     // Required for skills to execute scripts
-    .defaultTools(new ShellTools())
+    .defaultTools(ShellTools.builder().build())
 
     .build();
 ```
@@ -619,7 +619,7 @@ public class SkillsConfig {
                 .addSkillsDirectory("examples/.claude/skills")
                 .build())
             .defaultTools(FileSystemTools.builder().build())
-            .defaultTools(new ShellTools())
+            .defaultTools(ShellTools.builder().build())
             .defaultTools(GrepTool.builder().build())
             .build();
     }
@@ -742,7 +742,7 @@ public class SkillsConfiguration {
         return chatClientBuilder
             .defaultToolCallbacks(skillsTool)
             .defaultTools(FileSystemTools.builder().build())
-            .defaultTools(new ShellTools())
+            .defaultTools(ShellTools.builder().build())
             .build();
     }
 }
@@ -785,7 +785,7 @@ ChatClient chatClient = chatClientBuilder
 ```java
 ChatClient chatClient = chatClientBuilder
     .defaultToolCallbacks(skillsTool)
-    .defaultTools(new ShellTools())  // Add this
+    .defaultTools(ShellTools.builder().build())  // Add this
     .build();
 ```
 

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/exec/LocalExecBackend.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/exec/LocalExecBackend.java
@@ -1,0 +1,315 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.exec;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+
+import org.springaicommunity.agent.common.exec.ExecBackend;
+import org.springaicommunity.agent.common.exec.ExecHandle;
+import org.springaicommunity.agent.common.exec.ExecResult;
+import org.springaicommunity.agent.common.exec.ExecSpec;
+
+/**
+ * {@link ExecBackend} that runs commands on the host JVM via {@link ProcessBuilder}.
+ * Compared to the historical inline execution in {@code ShellTools}, this implementation
+ * supports a working directory, a clean-environment mode (child processes no longer
+ * inherit the full JVM environment, including its secrets, unless you opt in), and
+ * per-instance background handles instead of a process-global registry.
+ *
+ * @author Christian Tzolov
+ */
+public final class LocalExecBackend implements ExecBackend {
+
+	private static final AtomicLong HANDLE_SEQUENCE = new AtomicLong(System.currentTimeMillis());
+
+	private final Path workingDirectory;
+
+	private final boolean cleanEnvironment;
+
+	private final Map<String, String> environment;
+
+	private final List<String> shellCommand;
+
+	private LocalExecBackend(Path workingDirectory, boolean cleanEnvironment, Map<String, String> environment,
+			List<String> shellCommand) {
+		this.workingDirectory = workingDirectory;
+		this.cleanEnvironment = cleanEnvironment;
+		this.environment = environment;
+		this.shellCommand = shellCommand;
+	}
+
+	@Override
+	public ExecResult run(ExecSpec spec) {
+		Process process;
+		try {
+			process = launch(spec);
+		}
+		catch (IOException e) {
+			return ExecResult.launchFailed(e.getMessage());
+		}
+
+		StringBuilder stdout = new StringBuilder();
+		StringBuilder stderr = new StringBuilder();
+		Thread stdoutReader = drain(process.getInputStream(), stdout);
+		Thread stderrReader = drain(process.getErrorStream(), stderr);
+
+		try {
+			boolean completed = process.waitFor(spec.timeoutMillis(), TimeUnit.MILLISECONDS);
+			if (!completed) {
+				destroy(process);
+				return ExecResult.timedOut(snapshot(stdout), snapshot(stderr));
+			}
+			stdoutReader.join(1000);
+			stderrReader.join(1000);
+			return ExecResult.completed(process.exitValue(), snapshot(stdout), snapshot(stderr));
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			destroy(process);
+			return ExecResult.interrupted(snapshot(stdout), e.getMessage());
+		}
+	}
+
+	@Override
+	public ExecHandle start(ExecSpec spec) {
+		String id = "shell_" + HANDLE_SEQUENCE.incrementAndGet();
+		try {
+			return new LocalExecHandle(id, launch(spec));
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e.getMessage(), e);
+		}
+	}
+
+	/** Reads a drain buffer under the same lock its reader thread appends with. */
+	private static String snapshot(StringBuilder buffer) {
+		synchronized (buffer) {
+			return buffer.toString();
+		}
+	}
+
+	private Process launch(ExecSpec spec) throws IOException {
+		List<String> command = new ArrayList<>(this.shellCommand);
+		command.add(spec.command());
+		ProcessBuilder processBuilder = new ProcessBuilder(command);
+		processBuilder.redirectErrorStream(false);
+		if (this.workingDirectory != null) {
+			processBuilder.directory(this.workingDirectory.toFile());
+		}
+		if (this.cleanEnvironment) {
+			processBuilder.environment().clear();
+		}
+		processBuilder.environment().putAll(this.environment);
+		processBuilder.environment().putAll(spec.env());
+		return processBuilder.start();
+	}
+
+	private static Thread drain(java.io.InputStream stream, StringBuilder target) {
+		Thread reader = new Thread(() -> {
+			try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream))) {
+				String line;
+				while ((line = bufferedReader.readLine()) != null) {
+					synchronized (target) {
+						target.append(line).append("\n");
+					}
+				}
+			}
+			catch (IOException e) {
+				// Process terminated or stream closed
+			}
+		});
+		reader.setDaemon(true);
+		reader.start();
+		return reader;
+	}
+
+	private static void destroy(Process process) {
+		process.destroy();
+		try {
+			if (!process.waitFor(5, TimeUnit.SECONDS)) {
+				process.destroyForcibly();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			process.destroyForcibly();
+		}
+	}
+
+	/** Background handle over a host process, with cursor-based incremental output. */
+	private static final class LocalExecHandle implements ExecHandle {
+
+		private final String id;
+
+		private final Process process;
+
+		private final StringBuilder stdout = new StringBuilder();
+
+		private final StringBuilder stderr = new StringBuilder();
+
+		private int lastStdoutPosition = 0;
+
+		private int lastStderrPosition = 0;
+
+		LocalExecHandle(String id, Process process) {
+			this.id = id;
+			this.process = process;
+			drain(process.getInputStream(), this.stdout);
+			drain(process.getErrorStream(), this.stderr);
+		}
+
+		@Override
+		public String id() {
+			return this.id;
+		}
+
+		@Override
+		public boolean isAlive() {
+			return this.process.isAlive();
+		}
+
+		@Override
+		public String newOutput(String filterRegex) {
+			StringBuilder result = new StringBuilder();
+			synchronized (this.stdout) {
+				String newStdout = this.stdout.substring(this.lastStdoutPosition);
+				newStdout = filter(newStdout, filterRegex);
+				if (!newStdout.isEmpty()) {
+					result.append("STDOUT:\n").append(newStdout);
+				}
+				this.lastStdoutPosition = this.stdout.length();
+			}
+			synchronized (this.stderr) {
+				String newStderr = this.stderr.substring(this.lastStderrPosition);
+				newStderr = filter(newStderr, filterRegex);
+				if (!newStderr.isEmpty()) {
+					if (result.length() > 0) {
+						result.append("\n");
+					}
+					result.append("STDERR:\n").append(newStderr);
+				}
+				this.lastStderrPosition = this.stderr.length();
+			}
+			return result.toString();
+		}
+
+		@Override
+		public int exitCode() {
+			return this.process.exitValue();
+		}
+
+		@Override
+		public void kill() {
+			destroy(this.process);
+		}
+
+		private static String filter(String output, String filterRegex) {
+			if (filterRegex == null || filterRegex.isEmpty() || output.isEmpty()) {
+				return output;
+			}
+			Pattern pattern = Pattern.compile(filterRegex);
+			StringBuilder filtered = new StringBuilder();
+			for (String line : output.split("\n")) {
+				if (pattern.matcher(line).find()) {
+					filtered.append(line).append("\n");
+				}
+			}
+			return filtered.toString();
+		}
+
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private Path workingDirectory;
+
+		private boolean cleanEnvironment = false;
+
+		private final Map<String, String> environment = new HashMap<>();
+
+		private List<String> shellCommand;
+
+		private Builder() {
+		}
+
+		/**
+		 * Working directory for launched processes. Default: the JVM's current directory.
+		 */
+		public Builder workingDirectory(Path workingDirectory) {
+			this.workingDirectory = workingDirectory;
+			return this;
+		}
+
+		public Builder workingDirectory(String workingDirectory) {
+			return workingDirectory(workingDirectory != null ? Paths.get(workingDirectory) : null);
+		}
+
+		/**
+		 * When true, child processes start from an empty environment instead of
+		 * inheriting the JVM's (recommended when commands are model-authored — the JVM
+		 * environment often carries secrets). Default: false, preserving historical
+		 * behavior.
+		 */
+		public Builder cleanEnvironment(boolean cleanEnvironment) {
+			this.cleanEnvironment = cleanEnvironment;
+			return this;
+		}
+
+		/** Environment variables to set for every launched process. */
+		public Builder environment(Map<String, String> environment) {
+			if (environment != null) {
+				this.environment.putAll(environment);
+			}
+			return this;
+		}
+
+		/**
+		 * Overrides shell selection. Default: {@code cmd.exe /c} on Windows,
+		 * {@code /bin/bash -c} elsewhere.
+		 */
+		public Builder shellCommand(String... shellCommand) {
+			this.shellCommand = List.of(shellCommand);
+			return this;
+		}
+
+		public LocalExecBackend build() {
+			List<String> shell = this.shellCommand;
+			if (shell == null) {
+				String os = System.getProperty("os.name").toLowerCase();
+				shell = os.contains("win") ? List.of("cmd.exe", "/c") : List.of("/bin/bash", "-c");
+			}
+			return new LocalExecBackend(this.workingDirectory, this.cleanEnvironment, Map.copyOf(this.environment),
+					shell);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/exec/package-info.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/exec/package-info.java
@@ -1,0 +1,24 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+ * Host-JVM implementation of the execution backend SPI
+ * ({@link org.springaicommunity.agent.common.exec.ExecBackend}). Serves as the reference
+ * implementation, mirroring how the {@code task/claude} package implements the subagent
+ * SPI; container and remote implementations follow the same contract in their own
+ * modules.
+ */
+package org.springaicommunity.agent.exec;

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ShellTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ShellTools.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2025 - 2025 the original author or authors.
+* Copyright 2025 - 2026 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -15,150 +15,61 @@
 */
 package org.springaicommunity.agent.tools;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 
+import org.springaicommunity.agent.common.exec.ExecBackend;
+import org.springaicommunity.agent.common.exec.ExecHandle;
+import org.springaicommunity.agent.common.exec.ExecResult;
+import org.springaicommunity.agent.common.exec.ExecSpec;
+import org.springaicommunity.agent.exec.LocalExecBackend;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.util.Assert;
 
 /**
+ * Shell tools (Bash, BashOutput, KillShell) executing through a pluggable
+ * {@link ExecBackend}. By default commands run on the host JVM
+ * ({@link LocalExecBackend}); configure a different backend to execute inside a
+ * sandbox/container, or use the {@code workingDirectory} builder option to confine local
+ * execution to a workspace directory. Background shells are tracked per
+ * {@code ShellTools} instance, so separate agents/sessions have separate shell
+ * namespaces.
+ *
  * @author Christian Tzolov
  */
 public class ShellTools {
 
-	// Storage for background processes
-	private static final Map<String, BackgroundProcess> backgroundProcesses = new ConcurrentHashMap<>();
+	private static final int MAX_OUTPUT_LENGTH = 30_000;
 
-	// Inner class to manage background processes
-	private static class BackgroundProcess {
+	// Synchronous run ids live in their own "shell_run_" namespace so they can never
+	// collide with backend-minted background handle ids ("shell_<n>").
+	private static final java.util.concurrent.atomic.AtomicLong SYNC_RUN_SEQUENCE = new java.util.concurrent.atomic.AtomicLong(
+			System.currentTimeMillis());
 
-		final Process process;
+	private final ExecBackend execBackend;
 
-		final StringBuilder stdout;
+	// Background shells owned by this instance (not process-global).
+	private final Map<String, ExecHandle> backgroundShells = new ConcurrentHashMap<>();
 
-		final StringBuilder stderr;
+	protected ShellTools(ExecBackend execBackend) {
+		Assert.notNull(execBackend, "execBackend must not be null");
+		this.execBackend = execBackend;
+	}
 
-		final Thread stdoutReader;
-
-		final Thread stderrReader;
-
-		int lastStdoutPosition = 0;
-
-		int lastStderrPosition = 0;
-
-		BackgroundProcess(Process process) {
-			this.process = process;
-			this.stdout = new StringBuilder();
-			this.stderr = new StringBuilder();
-
-			// Start thread to read stdout
-			this.stdoutReader = new Thread(() -> {
-				try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-					String line;
-					while ((line = reader.readLine()) != null) {
-						synchronized (stdout) {
-							stdout.append(line).append("\n");
-						}
-					}
-				}
-				catch (IOException e) {
-					// Process terminated or stream closed
-				}
-			});
-			this.stdoutReader.setDaemon(true);
-			this.stdoutReader.start();
-
-			// Start thread to read stderr
-			this.stderrReader = new Thread(() -> {
-				try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-					String line;
-					while ((line = reader.readLine()) != null) {
-						synchronized (stderr) {
-							stderr.append(line).append("\n");
-						}
-					}
-				}
-				catch (IOException e) {
-					// Process terminated or stream closed
-				}
-			});
-			this.stderrReader.setDaemon(true);
-			this.stderrReader.start();
-		}
-
-		String getNewOutput(String filter) {
-			StringBuilder result = new StringBuilder();
-
-			synchronized (stdout) {
-				String newStdout = stdout.substring(lastStdoutPosition);
-				if (filter != null && !filter.isEmpty()) {
-					Pattern pattern = Pattern.compile(filter);
-					newStdout = filterOutput(newStdout, pattern);
-				}
-				if (!newStdout.isEmpty()) {
-					result.append("STDOUT:\n").append(newStdout);
-				}
-				lastStdoutPosition = stdout.length();
-			}
-
-			synchronized (stderr) {
-				String newStderr = stderr.substring(lastStderrPosition);
-				if (filter != null && !filter.isEmpty()) {
-					Pattern pattern = Pattern.compile(filter);
-					newStderr = filterOutput(newStderr, pattern);
-				}
-				if (!newStderr.isEmpty()) {
-					if (result.length() > 0)
-						result.append("\n");
-					result.append("STDERR:\n").append(newStderr);
-				}
-				lastStderrPosition = stderr.length();
-			}
-
-			return result.toString();
-		}
-
-		private String filterOutput(String output, Pattern pattern) {
-			String[] lines = output.split("\n");
-			StringBuilder filtered = new StringBuilder();
-			for (String line : lines) {
-				if (pattern.matcher(line).find()) {
-					filtered.append(line).append("\n");
-				}
-			}
-			return filtered.toString();
-		}
-
-		boolean isAlive() {
-			return process.isAlive();
-		}
-
-		void destroy() {
-			process.destroy();
-			try {
-				if (!process.waitFor(5, TimeUnit.SECONDS)) {
-					process.destroyForcibly();
-				}
-			}
-			catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-				process.destroyForcibly();
-			}
-		}
-
-		int getExitCode() {
-			return process.exitValue();
-		}
-
+	/**
+	 * @deprecated use {@link #builder()} — allows configuring the execution backend and
+	 * working directory.
+	 */
+	@Deprecated
+	public ShellTools() {
+		this(LocalExecBackend.builder().build());
 	}
 
 	//
-	// Shell comnmands
+	// Shell commands
 	//
 
 	// @formatter:off
@@ -240,129 +151,71 @@ public class ShellTools {
 		@ToolParam(description = "Clear, concise description of what this command does in 5-10 words, in active voice. Examples:\nInput: ls\nOutput: List files in current directory\n\nInput: git status\nOutput: Show working tree status\n\nInput: npm install\nOutput: Install package dependencies\n\nInput: mkdir foo\nOutput: Create directory 'foo'", required = false) String description,
 		@ToolParam(description = "Set to true to run this command in the background. Use BashOutput to read the output later.", required = false) Boolean runInBackground) { // @formatter:on
 
-		// Generate unique shell ID for all executions
-		String shellId = "shell_" + System.currentTimeMillis();
-
-		try {
-			// Determine the shell to use based on OS
-			String[] shellCommand;
-			String os = System.getProperty("os.name").toLowerCase();
-			if (os.contains("win")) {
-				shellCommand = new String[] { "cmd.exe", "/c", command };
-			}
-			else {
-				shellCommand = new String[] { "/bin/bash", "-c", command };
-			}
-
-			ProcessBuilder processBuilder = new ProcessBuilder(shellCommand);
-			processBuilder.redirectErrorStream(false);
-
-			// Set working directory if available in tool context
-			// processBuilder.directory(new File(workingDirectory));
-
-			Process process = processBuilder.start();
-
-			if (Boolean.TRUE.equals(runInBackground)) {
-				// Run in background
-				BackgroundProcess bgProcess = new BackgroundProcess(process);
-				backgroundProcesses.put(shellId, bgProcess);
-
-				return String.format(
-						"bash_id: %s\n\nBackground shell started with ID: %s\nUse BashOutput tool with bash_id='%s' to retrieve output.",
-						shellId, shellId, shellId);
-			}
-			else {
-				// Run synchronously with timeout
-				long timeoutMs = timeout != null ? Math.min(timeout, 600000) : 120000;
-
-				StringBuilder stdout = new StringBuilder();
-				StringBuilder stderr = new StringBuilder();
-
-				// Read stdout
-				Thread stdoutThread = new Thread(() -> {
-					try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-						String line;
-						while ((line = reader.readLine()) != null) {
-							stdout.append(line).append("\n");
-						}
-					}
-					catch (IOException e) {
-						// Ignore
-					}
-				});
-
-				// Read stderr
-				Thread stderrThread = new Thread(() -> {
-					try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()))) {
-						String line;
-						while ((line = reader.readLine()) != null) {
-							stderr.append(line).append("\n");
-						}
-					}
-					catch (IOException e) {
-						// Ignore
-					}
-				});
-
-				stdoutThread.start();
-				stderrThread.start();
-
-				boolean completed = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS);
-
-				if (!completed) {
-					process.destroy();
-					if (!process.waitFor(5, TimeUnit.SECONDS)) {
-						process.destroyForcibly();
-					}
-					return String.format("bash_id: %s\n\nCommand timed out after %dms", shellId, timeoutMs);
-				}
-
-				stdoutThread.join(1000);
-				stderrThread.join(1000);
-
-				int exitCode = process.exitValue();
-				StringBuilder result = new StringBuilder();
-
-				// Add bash_id at the beginning
-				result.append("bash_id: ").append(shellId).append("\n\n");
-
-				if (stdout.length() > 0) {
-					result.append(stdout.toString());
-				}
-
-				if (stderr.length() > 0) {
-					if (result.length() > result.indexOf("\n\n") + 2)
-						result.append("\n");
-					result.append("STDERR:\n").append(stderr.toString());
-				}
-
-				if (exitCode != 0) {
-					if (result.length() > result.indexOf("\n\n") + 2)
-						result.append("\n");
-					result.append("Exit code: ").append(exitCode);
-				}
-
-				// Truncate if too long
-				String output = result.toString();
-				if (output.length() > 30000) {
-					// Keep the bash_id header
-					String header = output.substring(0, output.indexOf("\n\n") + 2);
-					String content = output.substring(output.indexOf("\n\n") + 2);
-					output = header + content.substring(0, Math.min(content.length(), 30000 - header.length()))
-							+ "\n... (output truncated)";
-				}
-
-				return output;
-			}
-
+		if (command == null || command.isBlank()) {
+			return "Error: command must not be blank";
 		}
-		catch (IOException e) {
-			return "Error executing command: " + e.getMessage();
+		// Timeout policy (<=0 -> default, clamp to max) is owned by ExecSpec; read the
+		// effective value back so diagnostics never report a value we didn't honor.
+		ExecSpec spec = new ExecSpec(command, timeout != null ? timeout : ExecSpec.DEFAULT_TIMEOUT_MILLIS, Map.of());
+
+		if (Boolean.TRUE.equals(runInBackground)) {
+			ExecHandle handle;
+			try {
+				handle = this.execBackend.start(spec);
+			}
+			catch (RuntimeException e) {
+				// Backends throw with the raw reason; presentation prefix is added once
+				// here.
+				return "Error executing command: " + e.getMessage();
+			}
+			this.backgroundShells.put(handle.id(), handle);
+			return String.format(
+					"bash_id: %s\n\nBackground shell started with ID: %s\nUse BashOutput tool with bash_id='%s' to retrieve output.",
+					handle.id(), handle.id(), handle.id());
 		}
-		catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			return "Command execution interrupted: " + e.getMessage();
+
+		String shellId = "shell_run_" + SYNC_RUN_SEQUENCE.incrementAndGet();
+		ExecResult execResult = this.execBackend.run(spec);
+
+		switch (execResult.status()) {
+			case TIMED_OUT:
+				return String.format("bash_id: %s\n\nCommand timed out after %dms", shellId, spec.timeoutMillis());
+			case LAUNCH_FAILED:
+				return "Error executing command: " + execResult.stderr();
+			case INTERRUPTED:
+				return "Command execution interrupted: " + execResult.stderr();
+			case COMPLETED:
+				break;
 		}
+
+		StringBuilder result = new StringBuilder();
+		result.append("bash_id: ").append(shellId).append("\n\n");
+
+		if (!execResult.stdout().isEmpty()) {
+			result.append(execResult.stdout());
+		}
+		if (!execResult.stderr().isEmpty()) {
+			if (result.length() > result.indexOf("\n\n") + 2) {
+				result.append("\n");
+			}
+			result.append("STDERR:\n").append(execResult.stderr());
+		}
+		if (execResult.exitCode() != 0) {
+			if (result.length() > result.indexOf("\n\n") + 2) {
+				result.append("\n");
+			}
+			result.append("Exit code: ").append(execResult.exitCode());
+		}
+
+		// Truncate if too long, keeping the bash_id header
+		String output = result.toString();
+		if (output.length() > MAX_OUTPUT_LENGTH) {
+			String header = output.substring(0, output.indexOf("\n\n") + 2);
+			String content = output.substring(output.indexOf("\n\n") + 2);
+			output = header + content.substring(0, Math.min(content.length(), MAX_OUTPUT_LENGTH - header.length()))
+					+ "\n... (output truncated)";
+		}
+		return output;
 	}
 
 	// @formatter:off
@@ -379,21 +232,20 @@ public class ShellTools {
 		@ToolParam(description = "The ID of the background shell to retrieve output from") String bash_id,
 		@ToolParam(description = "Optional regular expression to filter the output lines. Only lines matching this regex will be included in the result. Any lines that do not match will no longer be available to read.", required = false) String filter) { // @formatter:on
 
-		BackgroundProcess bgProcess = backgroundProcesses.get(bash_id);
-
-		if (bgProcess == null) {
+		ExecHandle handle = this.backgroundShells.get(bash_id);
+		if (handle == null) {
 			return "Error: No background shell found with ID: " + bash_id;
 		}
 
-		String newOutput = bgProcess.getNewOutput(filter);
+		String newOutput = handle.newOutput(filter);
 
 		StringBuilder result = new StringBuilder();
 		result.append("Shell ID: ").append(bash_id).append("\n");
-		result.append("Status: ").append(bgProcess.isAlive() ? "Running" : "Completed").append("\n");
+		result.append("Status: ").append(handle.isAlive() ? "Running" : "Completed").append("\n");
 
-		if (!bgProcess.isAlive()) {
+		if (!handle.isAlive()) {
 			try {
-				result.append("Exit code: ").append(bgProcess.getExitCode()).append("\n");
+				result.append("Exit code: ").append(handle.exitCode()).append("\n");
 			}
 			catch (IllegalThreadStateException e) {
 				// Process not yet terminated
@@ -406,7 +258,6 @@ public class ShellTools {
 		else {
 			result.append("\nNo new output since last check.");
 		}
-
 		return result.toString();
 	}
 
@@ -421,18 +272,17 @@ public class ShellTools {
 	public String killShell(
 		@ToolParam(description = "The ID of the background shell to kill") String bash_id) { // @formatter:on
 
-		BackgroundProcess bgProcess = backgroundProcesses.get(bash_id);
-
-		if (bgProcess == null) {
+		ExecHandle handle = this.backgroundShells.get(bash_id);
+		if (handle == null) {
 			return "Error: No background shell found with ID: " + bash_id;
 		}
 
-		if (!bgProcess.isAlive()) {
-			backgroundProcesses.remove(bash_id);
+		if (!handle.isAlive()) {
+			this.backgroundShells.remove(bash_id);
 			return "Shell " + bash_id + " was already terminated. Removed from active shells.";
 		}
 
-		bgProcess.destroy();
+		handle.kill();
 
 		// Wait a bit to confirm termination
 		try {
@@ -442,19 +292,56 @@ public class ShellTools {
 			Thread.currentThread().interrupt();
 		}
 
-		backgroundProcesses.remove(bash_id);
-
+		this.backgroundShells.remove(bash_id);
 		return "Successfully killed shell: " + bash_id;
 	}
 
 	public static Builder builder() {
 		return new Builder();
 	}
-	
+
 	public static class Builder {
-		public ShellTools build() {
-			return new ShellTools();
+
+		private ExecBackend execBackend;
+
+		private Path workingDirectory;
+
+		private Builder() {
 		}
+
+		/**
+		 * Execution backend for all commands. Default: {@link LocalExecBackend} on the
+		 * host JVM.
+		 */
+		public Builder execBackend(ExecBackend execBackend) {
+			this.execBackend = execBackend;
+			return this;
+		}
+
+		/**
+		 * Convenience: run commands locally with this working directory. Mutually
+		 * exclusive with {@link #execBackend(ExecBackend)} — a custom backend owns its
+		 * own working directory.
+		 */
+		public Builder workingDirectory(Path workingDirectory) {
+			this.workingDirectory = workingDirectory;
+			return this;
+		}
+
+		public Builder workingDirectory(String workingDirectory) {
+			return workingDirectory(workingDirectory != null ? Paths.get(workingDirectory) : null);
+		}
+
+		public ShellTools build() {
+			Assert.state(this.execBackend == null || this.workingDirectory == null,
+					"Set either execBackend or workingDirectory, not both — a custom backend owns its working directory");
+			ExecBackend backend = this.execBackend;
+			if (backend == null) {
+				backend = LocalExecBackend.builder().workingDirectory(this.workingDirectory).build();
+			}
+			return new ShellTools(backend);
+		}
+
 	}
 
 }

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/exec/LocalExecBackendTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/exec/LocalExecBackendTest.java
@@ -1,0 +1,136 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.exec;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.springaicommunity.agent.common.exec.ExecBackend;
+import org.springaicommunity.agent.common.exec.ExecHandle;
+import org.springaicommunity.agent.common.exec.ExecResult;
+import org.springaicommunity.agent.common.exec.ExecSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+@DisabledOnOs(OS.WINDOWS)
+class LocalExecBackendTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void runsInConfiguredWorkingDirectory() throws Exception {
+		ExecBackend backend = LocalExecBackend.builder().workingDirectory(this.tempDir).build();
+		ExecResult result = backend.run(ExecSpec.of("pwd"));
+
+		assertThat(result.exitCode()).isZero();
+		// toRealPath(): on macOS the temp dir is reported via the /var symlink while pwd
+		// prints the physical /private/var path
+		assertThat(result.stdout().trim()).isEqualTo(this.tempDir.toRealPath().toString());
+	}
+
+	@Test
+	void defaultsToJvmWorkingDirectory() {
+		ExecBackend backend = LocalExecBackend.builder().build();
+		ExecResult result = backend.run(ExecSpec.of("pwd"));
+
+		assertThat(result.exitCode()).isZero();
+		assertThat(result.stdout().trim()).isEqualTo(System.getProperty("user.dir"));
+	}
+
+	@Test
+	void cleanEnvironmentHidesJvmVariables() {
+		ExecBackend backend = LocalExecBackend.builder()
+			.workingDirectory(this.tempDir)
+			.cleanEnvironment(true)
+			.environment(Map.of("SAFE_VAR", "visible"))
+			.build();
+		ExecResult result = backend.run(ExecSpec.of("echo HOME=[$HOME] SAFE_VAR=[$SAFE_VAR]"));
+
+		assertThat(result.stdout()).contains("HOME=[]").contains("SAFE_VAR=[visible]");
+	}
+
+	@Test
+	void inheritsJvmEnvironmentByDefault() {
+		ExecBackend backend = LocalExecBackend.builder().workingDirectory(this.tempDir).build();
+		ExecResult result = backend.run(ExecSpec.of("echo HOME=[$HOME]"));
+
+		assertThat(result.stdout()).doesNotContain("HOME=[]");
+	}
+
+	@Test
+	void perSpecEnvironmentIsApplied() {
+		ExecBackend backend = LocalExecBackend.builder().workingDirectory(this.tempDir).build();
+		ExecResult result = backend
+			.run(new ExecSpec("echo VALUE=[$SPEC_VAR]", 10_000, Map.of("SPEC_VAR", "from-spec")));
+
+		assertThat(result.stdout()).contains("VALUE=[from-spec]");
+	}
+
+	@Test
+	void timesOutAndReportsIt() {
+		ExecBackend backend = LocalExecBackend.builder().workingDirectory(this.tempDir).build();
+		ExecResult result = backend.run(new ExecSpec("sleep 5", 300, Map.of()));
+
+		assertThat(result.status()).isEqualTo(ExecResult.Status.TIMED_OUT);
+	}
+
+	@Test
+	void reportsLaunchFailureWithoutThrowing() {
+		ExecBackend backend = LocalExecBackend.builder()
+			.workingDirectory(this.tempDir)
+			.shellCommand("/no/such/shell", "-c")
+			.build();
+		ExecResult result = backend.run(ExecSpec.of("echo hi"));
+
+		assertThat(result.status()).isEqualTo(ExecResult.Status.LAUNCH_FAILED);
+		assertThat(result.stderr()).isNotBlank();
+	}
+
+	@Test
+	void backgroundHandleStreamsIncrementalOutputAndKills() throws Exception {
+		ExecBackend backend = LocalExecBackend.builder().workingDirectory(this.tempDir).build();
+		ExecHandle handle = backend.start(ExecSpec.of("echo first; sleep 3; echo second"));
+
+		assertThat(handle.id()).startsWith("shell_");
+		Thread.sleep(500);
+		assertThat(handle.newOutput(null)).contains("first");
+		// Cursor semantics: already-consumed output is not repeated
+		assertThat(handle.newOutput(null)).doesNotContain("first");
+
+		handle.kill();
+		Thread.sleep(200);
+		assertThat(handle.isAlive()).isFalse();
+	}
+
+	@Test
+	void handleIdsAreUniqueAcrossBackends() {
+		ExecBackend backend1 = LocalExecBackend.builder().workingDirectory(this.tempDir).build();
+		ExecBackend backend2 = LocalExecBackend.builder().workingDirectory(this.tempDir).build();
+		ExecHandle handle1 = backend1.start(ExecSpec.of("true"));
+		ExecHandle handle2 = backend2.start(ExecSpec.of("true"));
+
+		assertThat(handle1.id()).isNotEqualTo(handle2.id());
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/ShellToolsExecBackendTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/ShellToolsExecBackendTest.java
@@ -1,0 +1,133 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ExecBackend integration behavior of {@link ShellTools}: working-directory confinement
+ * and per-instance background shell namespaces (regression tests for the historical
+ * JVM-cwd execution and the process-global static shell registry).
+ *
+ * @author Christian Tzolov
+ */
+@DisabledOnOs(OS.WINDOWS)
+class ShellToolsExecBackendTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void commandsRunInConfiguredWorkingDirectory() throws Exception {
+		ShellTools shellTools = ShellTools.builder().workingDirectory(this.tempDir).build();
+
+		String result = shellTools.bash("pwd && touch created-here.txt", null, null, null);
+
+		// toRealPath(): macOS reports temp dirs via the /var symlink; pwd prints
+		// /private/var
+		assertThat(result).contains(this.tempDir.toRealPath().toString());
+		assertThat(Files.exists(this.tempDir.resolve("created-here.txt"))).isTrue();
+	}
+
+	@Test
+	void backgroundShellsAreScopedPerInstance() throws Exception {
+		ShellTools sessionA = ShellTools.builder().workingDirectory(this.tempDir).build();
+		ShellTools sessionB = ShellTools.builder().workingDirectory(this.tempDir).build();
+
+		String started = sessionA.bash("sleep 30", null, null, true);
+		String shellId = started.substring(started.indexOf("bash_id: ") + 9, started.indexOf("\n"));
+
+		// Session B cannot see (or kill) session A's shell — the registry is per instance
+		assertThat(sessionB.bashOutput(shellId, null)).contains("No background shell found");
+		assertThat(sessionB.killShell(shellId)).contains("No background shell found");
+
+		// Session A can
+		assertThat(sessionA.bashOutput(shellId, null)).contains("Status: Running");
+		assertThat(sessionA.killShell(shellId)).contains("Successfully killed shell");
+	}
+
+	@Test
+	void blankCommandReturnsErrorStringInsteadOfThrowing() {
+		ShellTools shellTools = ShellTools.builder().workingDirectory(this.tempDir).build();
+
+		assertThat(shellTools.bash("   ", null, null, null)).isEqualTo("Error: command must not be blank");
+		assertThat(shellTools.bash(null, null, null, null)).isEqualTo("Error: command must not be blank");
+	}
+
+	@Test
+	void nonPositiveTimeoutIsClampedAndCommandStillRuns() {
+		ShellTools shellTools = ShellTools.builder().workingDirectory(this.tempDir).build();
+
+		String result = shellTools.bash("echo clamped-ok", 0L, null, null);
+
+		assertThat(result).contains("clamped-ok").doesNotContain("timed out");
+	}
+
+	@Test
+	void timeoutDiagnosticReportsEffectiveTimeout() {
+		ShellTools shellTools = ShellTools.builder().workingDirectory(this.tempDir).build();
+
+		String result = shellTools.bash("sleep 5", 200L, null, null);
+
+		assertThat(result).contains("Command timed out after 200ms");
+	}
+
+	@Test
+	void backgroundLaunchFailureHasSingleErrorPrefix() {
+		ShellTools shellTools = ShellTools.builder()
+			.execBackend(org.springaicommunity.agent.exec.LocalExecBackend.builder()
+				.shellCommand("/no/such/shell", "-c")
+				.build())
+			.build();
+
+		String result = shellTools.bash("echo hi", null, null, true);
+
+		assertThat(result).startsWith("Error executing command: ");
+		assertThat(result.indexOf("Error executing command:"))
+			.isEqualTo(result.lastIndexOf("Error executing command:"));
+	}
+
+	@Test
+	void syncRunIdsUseTheirOwnNamespaceAndAreNeverResolvable() {
+		ShellTools shellTools = ShellTools.builder().workingDirectory(this.tempDir).build();
+
+		String result = shellTools.bash("echo hi", null, null, null);
+		String syncId = result.substring(result.indexOf("bash_id: ") + 9, result.indexOf("\n"));
+
+		// Distinct namespace from backend handle ids ("shell_<n>") — collisions
+		// impossible
+		assertThat(syncId).startsWith("shell_run_");
+		assertThat(shellTools.bashOutput(syncId, null)).contains("No background shell found");
+	}
+
+	@Test
+	void execBackendAndWorkingDirectoryAreMutuallyExclusive() {
+		assertThatThrownBy(() -> ShellTools.builder()
+			.execBackend(org.springaicommunity.agent.exec.LocalExecBackend.builder().build())
+			.workingDirectory(this.tempDir)
+			.build()).isInstanceOf(IllegalStateException.class);
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/ShellToolsTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/ShellToolsTest.java
@@ -487,7 +487,7 @@ class ShellToolsTest {
 			String result = shellTools.bash("echo 'Test'", null, null, null);
 
 			String shellId = extractShellId(result);
-			assertThat(shellId).matches("shell_\\d+");
+			assertThat(shellId).matches("shell_run_\\d+");
 		}
 
 	}
@@ -496,7 +496,7 @@ class ShellToolsTest {
 	 * Helper method to extract shell_id from command output
 	 */
 	private String extractShellId(String output) {
-		Pattern pattern = Pattern.compile("bash_id: (shell_\\d+)");
+		Pattern pattern = Pattern.compile("bash_id: (shell_(?:run_)?\\d+)");
 		Matcher matcher = pattern.matcher(output);
 		if (matcher.find()) {
 			return matcher.group(1);


### PR DESCRIPTION
Adds an execution-backend SPI (`ExecBackend`, `ExecSpec`, `ExecResult`, `ExecHandle`) to `spring-ai-agent-utils-common` — the seam that lets shell execution move into a sandbox/container without tool changes — plus `LocalExecBackend` as the host reference implementation, mirroring how the subagent SPI is organized.

Partially addresses #61 (the exec half; the filesystem/workspace half is planned as a follow-up together with #75's `allowedDirectories` for Grep/Glob/ListDirectory).

`ShellTools` now delegates to the backend, which also fixes three issues in the historical inline execution:

- commands can run in a configured working directory (the `.directory()` call was commented out; everything ran in the JVM cwd)
- child processes no longer have to inherit the full JVM environment (`cleanEnvironment` mode; secrets in host env vars stay invisible)
- background shells are tracked per `ShellTools` instance instead of a process-global static map

## Design notes

- `ExecResult` carries an explicit `Status` enum (`COMPLETED` / `TIMED_OUT` / `LAUNCH_FAILED` / `INTERRUPTED`) — no sentinel exit codes. Timeout policy (`<=0` → 2min default, clamp at 10min) is owned by `ExecSpec` so every backend behaves identically.
- **Relation to [agent-sandbox](https://github.com/markpollack/agent-sandbox):** `Sandbox.exec(ExecSpec) → ExecResult` there is shape-compatible with this SPI, so an `AgentSandboxExecBackend` adapter is trivial for the synchronous path. What this SPI adds is background execution (`ExecHandle` with incremental output and kill), which `BashOutput`/`KillShell` require and agent-sandbox does not currently model.

## Migration notes

- The background-shell registry was previously **JVM-global**: any `ShellTools` instance could read/kill any shell by `bash_id`. It is now **per-instance**. If you relied on cross-instance continuity (e.g. a parent agent reading a shell started by a subagent holding a different instance), share one `ShellTools` instance between those agents explicitly. Claude subagents already share the single instance created by `ClaudeSubagentType`, so their behavior is unchanged.
- Synchronous runs now report ids in a distinct `shell_run_<n>` namespace (they were never resolvable via `BashOutput`; now that is structurally evident and can no longer collide with background handle ids).
- `new ShellTools()` is deprecated in favor of `ShellTools.builder()` (docs updated).

## Test plan

- [x] All pre-existing `ShellToolsTest` cases pass (response formats preserved; id-pattern test updated for the deliberate `shell_run_` namespace)
- [x] New `LocalExecBackendTest`: working directory, env inherit/clean/per-spec, timeout, launch failure as result, background handle cursor semantics + kill, id uniqueness
- [x] New `ShellToolsExecBackendTest`: workdir confinement, per-instance shell namespaces, blank-command guard, timeout diagnostics, single error prefix, sync-id namespace
- [x] New `ExecSpecTest` in `-common` (test execution enabled there — junit-jupiter dependency was commented out)
