### PR TITLE
Add allowedDirectories confinement to Grep/Glob/ListDirectory tools

### DIFF
--- a/docs/tools/FileSystemTools.md
+++ b/docs/tools/FileSystemTools.md
@@ -335,3 +335,11 @@ String result = fileTools.edit(
 | "old_string not found" | Text doesn't exist in file | Verify exact string including whitespace |
 | "appears N times" | Multiple matches found | Add more context or use `replace_all=true` |
 | "must be different" | old_string equals new_string | Ensure you're actually changing the content |
+
+## Confining the search tools too
+
+Since the search tools share this check, configure them together so the confinement is consistent:
+`FileSystemTools`, `GrepTool`, `GlobTool` and `ListDirectoryTool` all accept
+`allowedDirectory(...)` / `allowedDirectories(...)` with identical semantics (one shared
+implementation) — without it on the search tools, an explicit `path` argument can read
+outside the workspace even when Read/Write/Edit are confined.

--- a/docs/tools/GlobTool.md
+++ b/docs/tools/GlobTool.md
@@ -815,3 +815,28 @@ String response = chatClient.prompt()
 - [GrepTool](GrepTool.md) - For searching file contents
 - [FileSystemTools](FileSystemTools.md) - For reading/writing files
 - [ShellTools](ShellTools.md) - For running system commands
+
+## Directory confinement (`allowedDirectory` / `allowedDirectories`)
+
+By itself, `workingDirectory(...)` is only the **default** used when the model omits the
+`path` argument — an explicit `path` is taken as-is. To confine searches to a workspace,
+also configure allowed directories (same semantics and shared implementation with
+`FileSystemTools`; empty = unrestricted):
+
+```java
+GlobTool.builder()
+    .workingDirectory(workspace)     // default when path is omitted
+    .allowedDirectory(workspace)     // jail: explicit paths must stay inside
+    .build();
+```
+
+The resolved search path — whether from the model or the `workingDirectory` fallback —
+is validated before any filesystem access (raw `..` components rejected, normalized
+prefix check, symlink resolution). In addition, when confinement is configured the
+directory traversal does **not** follow symbolic links, so a link inside the workspace
+cannot expose content outside it (unconfined tools keep following links, as before).
+A violation returns:
+
+```
+Error: Access denied. Path is outside the allowed directories: /etc
+```

--- a/docs/tools/GrepTool.md
+++ b/docs/tools/GrepTool.md
@@ -1110,3 +1110,28 @@ String deserializationRisks = grepTool.grep(
 - [FileSystemTools](FileSystemTools.md) - For reading files found by grep
 - [ShellTools](ShellTools.md) - For running system grep if needed
 - [SkillsTool](SkillsTool.md) - For creating code analysis skills
+
+## Directory confinement (`allowedDirectory` / `allowedDirectories`)
+
+By itself, `workingDirectory(...)` is only the **default** used when the model omits the
+`path` argument — an explicit `path` is taken as-is. To confine searches to a workspace,
+also configure allowed directories (same semantics and shared implementation with
+`FileSystemTools`; empty = unrestricted):
+
+```java
+GrepTool.builder()
+    .workingDirectory(workspace)     // default when path is omitted
+    .allowedDirectory(workspace)     // jail: explicit paths must stay inside
+    .build();
+```
+
+The resolved search path — whether from the model or the `workingDirectory` fallback —
+is validated before any filesystem access (raw `..` components rejected, normalized
+prefix check, symlink resolution). In addition, when confinement is configured the
+directory traversal does **not** follow symbolic links, so a link inside the workspace
+cannot expose content outside it (unconfined tools keep following links, as before).
+A violation returns:
+
+```
+Error: Access denied. Path is outside the allowed directories: /etc
+```

--- a/spring-ai-agent-utils/docs/FileSystemTools.md
+++ b/spring-ai-agent-utils/docs/FileSystemTools.md
@@ -335,3 +335,11 @@ String result = fileTools.edit(
 | "old_string not found" | Text doesn't exist in file | Verify exact string including whitespace |
 | "appears N times" | Multiple matches found | Add more context or use `replace_all=true` |
 | "must be different" | old_string equals new_string | Ensure you're actually changing the content |
+
+## Confining the search tools too
+
+Since the search tools share this check, configure them together so the confinement is consistent:
+`FileSystemTools`, `GrepTool`, `GlobTool` and `ListDirectoryTool` all accept
+`allowedDirectory(...)` / `allowedDirectories(...)` with identical semantics (one shared
+implementation) — without it on the search tools, an explicit `path` argument can read
+outside the workspace even when Read/Write/Edit are confined.

--- a/spring-ai-agent-utils/docs/GlobTool.md
+++ b/spring-ai-agent-utils/docs/GlobTool.md
@@ -815,3 +815,28 @@ String response = chatClient.prompt()
 - [GrepTool](GrepTool.md) - For searching file contents
 - [FileSystemTools](FileSystemTools.md) - For reading/writing files
 - [ShellTools](ShellTools.md) - For running system commands
+
+## Directory confinement (`allowedDirectory` / `allowedDirectories`)
+
+By itself, `workingDirectory(...)` is only the **default** used when the model omits the
+`path` argument — an explicit `path` is taken as-is. To confine searches to a workspace,
+also configure allowed directories (same semantics and shared implementation with
+`FileSystemTools`; empty = unrestricted):
+
+```java
+GlobTool.builder()
+    .workingDirectory(workspace)     // default when path is omitted
+    .allowedDirectory(workspace)     // jail: explicit paths must stay inside
+    .build();
+```
+
+The resolved search path — whether from the model or the `workingDirectory` fallback —
+is validated before any filesystem access (raw `..` components rejected, normalized
+prefix check, symlink resolution). In addition, when confinement is configured the
+directory traversal does **not** follow symbolic links, so a link inside the workspace
+cannot expose content outside it (unconfined tools keep following links, as before).
+A violation returns:
+
+```
+Error: Access denied. Path is outside the allowed directories: /etc
+```

--- a/spring-ai-agent-utils/docs/GrepTool.md
+++ b/spring-ai-agent-utils/docs/GrepTool.md
@@ -1110,3 +1110,28 @@ String deserializationRisks = grepTool.grep(
 - [FileSystemTools](FileSystemTools.md) - For reading files found by grep
 - [ShellTools](ShellTools.md) - For running system grep if needed
 - [SkillsTool](SkillsTool.md) - For creating code analysis skills
+
+## Directory confinement (`allowedDirectory` / `allowedDirectories`)
+
+By itself, `workingDirectory(...)` is only the **default** used when the model omits the
+`path` argument — an explicit `path` is taken as-is. To confine searches to a workspace,
+also configure allowed directories (same semantics and shared implementation with
+`FileSystemTools`; empty = unrestricted):
+
+```java
+GrepTool.builder()
+    .workingDirectory(workspace)     // default when path is omitted
+    .allowedDirectory(workspace)     // jail: explicit paths must stay inside
+    .build();
+```
+
+The resolved search path — whether from the model or the `workingDirectory` fallback —
+is validated before any filesystem access (raw `..` components rejected, normalized
+prefix check, symlink resolution). In addition, when confinement is configured the
+directory traversal does **not** follow symbolic links, so a link inside the workspace
+cannot expose content outside it (unconfined tools keep following links, as before).
+A violation returns:
+
+```
+Error: Access denied. Path is outside the allowed directories: /etc
+```

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/AllowedDirectories.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/AllowedDirectories.java
@@ -1,0 +1,163 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Shared directory-confinement check for tools that accept model-supplied paths
+ * (FileSystemTools, GrepTool, GlobTool, ListDirectoryTool). One implementation, one set
+ * of semantics: when no allowed directories are configured, all paths are allowed; when
+ * configured, a path must fall within at least one allowed directory.
+ *
+ * <p>
+ * Extracted from {@code FileSystemTools.validateAllowedAccess} so the search tools get
+ * the same containment as Read/Write/Edit instead of three copies of the check.
+ *
+ * @author Christian Tzolov
+ */
+final class AllowedDirectories {
+
+	private final List<Path> allowedDirectories;
+
+	AllowedDirectories(List<Path> allowedDirectories) {
+		this.allowedDirectories = List.copyOf(allowedDirectories);
+	}
+
+	/** Whether any confinement is configured (empty = unrestricted). */
+	boolean isRestricted() {
+		return !this.allowedDirectories.isEmpty();
+	}
+
+	/**
+	 * Validates that the given file path is within at least one configured allowed
+	 * directory. When no allowed directories are configured, all paths are allowed. Uses
+	 * three checks per directory candidate: (1) rejects raw {@code ..} path components to
+	 * prevent symlink+{@code ..} escapes, (2) normalized path containment check to block
+	 * remaining {@code ..} traversal, (3) real-path resolution walking up existing path
+	 * components to catch symlink escapes including dangling symlinks (skipped when the
+	 * candidate directory does not yet exist).
+	 * @param filePath the path to validate
+	 * @return an error string if access is denied, or {@code null} if access is allowed
+	 */
+	String validate(String filePath) {
+		if (this.allowedDirectories.isEmpty()) {
+			return null;
+		}
+		try {
+			Path targetAbs = Paths.get(filePath).toAbsolutePath();
+
+			// Check 1: reject '..' components in the raw absolute path.
+			// Normalizing before this check would hide symlink+'..' bypass attempts
+			// (e.g. /allowed/link/../outside normalizes to /allowed/outside but the OS
+			// resolves 'link' as a symlink first, landing outside the allowed directory).
+			for (Path component : targetAbs) {
+				if ("..".equals(component.toString())) {
+					return "Error: Access denied. Path is outside the allowed directories: " + filePath;
+				}
+			}
+
+			Path target = targetAbs.normalize();
+
+			for (Path allowedDir : this.allowedDirectories) {
+				Path allowed = allowedDir.toAbsolutePath().normalize();
+				Path realAllowed = Files.exists(allowed) ? allowed.toRealPath() : null;
+
+				// Check 2: normalized path must start with this candidate (blocks
+				// remaining traversal). A canonical path is also accepted when the
+				// configured directory has a symlinked prefix (e.g. /tmp -> /private/tmp
+				// on macOS), matching against the real form of the allowed directory.
+				if (!target.startsWith(allowed) && (realAllowed == null || !target.startsWith(realAllowed))) {
+					continue;
+				}
+
+				// Check 3: resolve symlinks in all existing path components to catch
+				// symlink escapes. Skipped when the candidate directory does not yet
+				// exist (checks 1+2 are sufficient then).
+				if (realAllowed != null) {
+					Path existing = target;
+					while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+						existing = existing.getParent();
+					}
+					if (existing != null) {
+						Path realExisting;
+						try {
+							realExisting = existing.toRealPath();
+						}
+						catch (IOException e) {
+							// toRealPath() throws on a dangling symlink (symlink exists
+							// but target does not). We cannot verify where it points, so
+							// deny access unconditionally.
+							return "Error: Access denied. Cannot resolve path (possible dangling symlink): " + filePath;
+						}
+						if (!realExisting.startsWith(realAllowed)) {
+							continue;
+						}
+					}
+				}
+
+				return null; // path is within this allowed directory
+			}
+
+			return "Error: Access denied. Path is outside the allowed directories: " + filePath;
+		}
+		catch (RuntimeException e) {
+			return "Error: Invalid path: " + e.getMessage();
+		}
+		catch (IOException e) {
+			return "Error validating path: " + e.getMessage();
+		}
+	}
+
+	/**
+	 * Builder-side collector shared by the tool builders (FileSystemTools, GrepTool,
+	 * GlobTool, ListDirectoryTool) so the configuration logic — null handling, string
+	 * conversion — lives in one place next to the validation it feeds.
+	 */
+	static final class Collector {
+
+		private final java.util.List<Path> directories = new java.util.ArrayList<>();
+
+		void add(Path directory) {
+			if (directory != null) {
+				this.directories.add(directory);
+			}
+		}
+
+		void add(String directory) {
+			if (directory != null) {
+				this.directories.add(Paths.get(directory));
+			}
+		}
+
+		void addAll(Path... directories) {
+			for (Path directory : directories) {
+				add(directory);
+			}
+		}
+
+		java.util.List<Path> toList() {
+			return java.util.List.copyOf(this.directories);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
@@ -17,13 +17,13 @@ package org.springaicommunity.agent.tools;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -37,85 +37,46 @@ import org.springframework.ai.tool.annotation.ToolParam;
  */
 public class FileSystemTools {
 
-	private final List<Path> allowedDirectories;
+	private final AllowedDirectories allowedDirectories;
 
 	protected FileSystemTools(List<Path> allowedDirectories) {
-		this.allowedDirectories = List.copyOf(allowedDirectories);
+		this.allowedDirectories = new AllowedDirectories(allowedDirectories);
 	}
 
 	/**
-	 * Validates that the given file path is within at least one configured allowed directory.
-	 * When no allowed directories are configured, all paths are allowed.
-	 * Uses three checks per directory candidate:
-	 * (1) rejects raw {@code ..} path components to prevent symlink+{@code ..} escapes,
-	 * (2) normalized path containment check to block remaining {@code ..} traversal,
-	 * (3) real-path resolution walking up existing path components to catch symlink escapes
-	 * including dangling symlinks (skipped when the candidate directory does not yet exist).
+	 * Validates that the given file path is within at least one configured allowed
+	 * directory. Shared semantics with GrepTool/GlobTool/ListDirectoryTool — see
+	 * {@link AllowedDirectories}.
 	 * @param filePath the path to validate
 	 * @return an error string if access is denied, or {@code null} if access is allowed
 	 */
 	private String validateAllowedAccess(String filePath) {
-		if (this.allowedDirectories.isEmpty()) {
-			return null;
-		}
-		try {
-			Path targetAbs = Paths.get(filePath).toAbsolutePath();
+		return this.allowedDirectories.validate(filePath);
+	}
 
-			// Check 1: reject '..' components in the raw absolute path.
-			// Normalizing before this check would hide symlink+'..' bypass attempts
-			// (e.g. /allowed/link/../outside normalizes to /allowed/outside but the OS
-			// resolves 'link' as a symlink first, landing outside the allowed directory).
-			for (Path component : targetAbs) {
-				if ("..".equals(component.toString())) {
-					return "Error: Access denied. Path is outside the allowed directories: " + filePath;
-				}
-			}
+	/**
+	 * UTF-8 reader with REPLACE error handling: malformed bytes become U+FFFD instead of
+	 * aborting the whole read (matching the tolerance of the legacy FileReader while
+	 * standardizing the charset).
+	 */
+	private static BufferedReader lenientUtf8Reader(Path file) throws IOException {
+		return new BufferedReader(new InputStreamReader(Files.newInputStream(file),
+				StandardCharsets.UTF_8.newDecoder()
+					.onMalformedInput(CodingErrorAction.REPLACE)
+					.onUnmappableCharacter(CodingErrorAction.REPLACE)));
+	}
 
-			Path target = targetAbs.normalize();
-
-			for (Path allowedDir : this.allowedDirectories) {
-				Path allowed = allowedDir.toAbsolutePath().normalize();
-
-				// Check 2: normalized path must start with this candidate (blocks remaining traversal)
-				if (!target.startsWith(allowed)) {
-					continue;
-				}
-
-				// Check 3: resolve symlinks in all existing path components to catch symlink escapes.
-				// Skipped when the candidate directory does not yet exist (checks 1+2 are sufficient then).
-				if (Files.exists(allowed)) {
-					Path realAllowed = allowed.toRealPath();
-					Path existing = target;
-					while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
-						existing = existing.getParent();
-					}
-					if (existing != null) {
-						Path realExisting;
-						try {
-							realExisting = existing.toRealPath();
-						}
-						catch (IOException e) {
-							// toRealPath() throws on a dangling symlink (symlink exists but target does not).
-							// We cannot verify where it points, so deny access unconditionally.
-							return "Error: Access denied. Cannot resolve path (possible dangling symlink): "
-									+ filePath;
-						}
-						if (!realExisting.startsWith(realAllowed)) {
-							continue;
-						}
-					}
-				}
-
-				return null; // path is within this allowed directory
-			}
-
-			return "Error: Access denied. Path is outside the allowed directories: " + filePath;
-		}
-		catch (RuntimeException e) {
-			return "Error: Invalid path: " + e.getMessage();
-		}
-		catch (IOException e) {
-			return "Error validating path: " + e.getMessage();
+	/**
+	 * Streaming UTF-8 write with REPLACE error handling: unpaired surrogates are
+	 * substituted instead of failing the write (matching the legacy FileWriter), and
+	 * content is streamed rather than materialized as one encoded byte array.
+	 */
+	private static void lenientUtf8Write(Path file, String content) throws IOException {
+		try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(file),
+				StandardCharsets.UTF_8.newEncoder()
+					.onMalformedInput(CodingErrorAction.REPLACE)
+					.onUnmappableCharacter(CodingErrorAction.REPLACE)))) {
+			writer.write(content);
 		}
 	}
 
@@ -143,19 +104,23 @@ public class FileSystemTools {
 		@ToolParam(description = "The line number to start reading from. Only provide if the file is too large to read at once", required = false) Integer offset,
 		@ToolParam(description = "The number of lines to read. Only provide if the file is too large to read at once.", required = false) Integer limit) { // @formatter:on
 
+		if (filePath == null || filePath.isBlank()) {
+			return "Error: file_path must not be empty";
+		}
+
 		String accessError = validateAllowedAccess(filePath);
 		if (accessError != null) {
 			return accessError;
 		}
 
 		try {
-			File file = new File(filePath);
+			Path file = Paths.get(filePath);
 
-			if (!file.exists()) {
+			if (!Files.exists(file)) {
 				return "Error: File does not exist: " + filePath;
 			}
 
-			if (file.isDirectory()) {
+			if (Files.isDirectory(file)) {
 				return "Error: Path is a directory, not a file: " + filePath;
 			}
 
@@ -171,7 +136,8 @@ public class FileSystemTools {
 			int currentLine = 0;
 			int linesRead = 0;
 
-			try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+			boolean limitHit = false;
+			try (BufferedReader reader = lenientUtf8Reader(file)) {
 				String line;
 				while ((line = reader.readLine()) != null) {
 					currentLine++;
@@ -181,8 +147,10 @@ public class FileSystemTools {
 						continue;
 					}
 
-					// Stop if we've read enough lines
+					// Stop if we've read enough lines. The line that triggered the stop
+					// was already counted, so the file has at least currentLine lines.
 					if (linesRead >= maxLines) {
+						limitHit = true;
 						break;
 					}
 
@@ -208,8 +176,11 @@ public class FileSystemTools {
 
 			StringBuilder result = new StringBuilder();
 			result.append(String.format("File: %s\n", filePath));
+			// When the limit stopped the read, currentLine is a lower bound, not the
+			// total — say so, or the model assumes the file was fully read.
 			result.append(
-					String.format("Showing lines %d-%d of %d\n\n", startLine, startLine + linesRead - 1, currentLine));
+					String.format(limitHit ? "Showing lines %d-%d of at least %d\n\n" : "Showing lines %d-%d of %d\n\n",
+							startLine, startLine + linesRead - 1, currentLine));
 
 			for (String line : lines) {
 				result.append(line).append("\n");
@@ -217,6 +188,9 @@ public class FileSystemTools {
 
 			return result.toString();
 
+		}
+		catch (InvalidPathException e) {
+			return "Error: Invalid path: " + e.getMessage();
 		}
 		catch (IOException e) {
 			return "Error reading file: " + e.getMessage();
@@ -238,6 +212,10 @@ public class FileSystemTools {
 		@ToolParam(description = "The absolute path to the file to write (must be absolute, not relative)") String filePath,
 		@ToolParam(description = "The content to write to the file") String content) { // @formatter:on
 
+		if (filePath == null || filePath.isBlank()) {
+			return "Error: file_path must not be empty";
+		}
+
 		String accessError = validateAllowedAccess(filePath);
 		if (accessError != null) {
 			return accessError;
@@ -247,23 +225,23 @@ public class FileSystemTools {
 			content = content != null ? content : "";
 
 			Path path = Paths.get(filePath);
-			File file = path.toFile();
 
 			// Create parent directories if they don't exist
-			File parentDir = file.getParentFile();
-			if (parentDir != null && !parentDir.exists()) {
-				if (!parentDir.mkdirs()) {
+			Path parentDir = path.getParent();
+			if (parentDir != null && !Files.exists(parentDir)) {
+				try {
+					Files.createDirectories(parentDir);
+				}
+				catch (IOException e) {
 					return "Error: Failed to create parent directories for: " + filePath;
 				}
 			}
 
 			// Check if file already exists
-			boolean fileExists = file.exists();
+			boolean fileExists = Files.exists(path);
 
 			// Write content to file
-			try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, false))) {
-				writer.write(content);
-			}
+			lenientUtf8Write(path, content);
 
 			if (fileExists) {
 				return String.format("Successfully overwrote file: %s (%d bytes)", filePath, content.length());
@@ -299,19 +277,23 @@ public class FileSystemTools {
 		@ToolParam(description = "The text to replace it with (must be different from old_string)") String new_string,
 		@ToolParam(description = "Replace all occurences of old_string (default false)", required = false) Boolean replace_all) { // @formatter:on
 
+		if (filePath == null || filePath.isBlank()) {
+			return "Error: file_path must not be empty";
+		}
+
 		String accessError = validateAllowedAccess(filePath);
 		if (accessError != null) {
 			return accessError;
 		}
 
 		try {
-			File file = new File(filePath);
+			Path file = Paths.get(filePath);
 
-			if (!file.exists()) {
+			if (!Files.exists(file)) {
 				return "Error: File does not exist: " + filePath;
 			}
 
-			if (file.isDirectory()) {
+			if (Files.isDirectory(file)) {
 				return "Error: Path is a directory, not a file: " + filePath;
 			}
 
@@ -323,7 +305,7 @@ public class FileSystemTools {
 			// Read the entire file content preserving exact line endings
 			String originalContent;
 			try {
-				originalContent = Files.readString(file.toPath(), StandardCharsets.UTF_8);
+				originalContent = Files.readString(file, StandardCharsets.UTF_8);
 			}
 			catch (IOException e) {
 				return "Error reading file content: " + e.getMessage();
@@ -356,9 +338,7 @@ public class FileSystemTools {
 			}
 
 			// Write the modified content back to the file
-			try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, false))) {
-				writer.write(newContent);
-			}
+			lenientUtf8Write(file, newContent);
 
 			// Generate a snippet showing the context around the edit
 			String snippet = generateEditSnippet(newContent, new_string);
@@ -368,6 +348,9 @@ public class FileSystemTools {
 					"The file %s has been updated. Here's the result of running `cat -n` on a snippet of the edited file:\n%s",
 					filePath, snippet);
 
+		}
+		catch (InvalidPathException e) {
+			return "Error: Invalid path: " + e.getMessage();
 		}
 		catch (IOException e) {
 			return "Error editing file: " + e.getMessage();
@@ -478,22 +461,20 @@ public class FileSystemTools {
 
 	public static class Builder {
 
-		private final List<Path> allowedDirectories = new ArrayList<>();
+		private final AllowedDirectories.Collector allowedDirectories = new AllowedDirectories.Collector();
 
 		private Builder() {
 		}
 
 		/**
-		 * Adds a directory to the list of allowed paths. All file operations are restricted
-		 * to the union of configured allowed directories. Symlinks are resolved to their
-		 * real path before the check.
+		 * Adds a directory to the list of allowed paths. All file operations are
+		 * restricted to the union of configured allowed directories. Symlinks are
+		 * resolved to their real path before the check.
 		 * @param allowedDirectory the directory to allow operations within
 		 * @return this builder
 		 */
 		public Builder allowedDirectory(Path allowedDirectory) {
-			if (allowedDirectory != null) {
-				this.allowedDirectories.add(allowedDirectory);
-			}
+			this.allowedDirectories.add(allowedDirectory);
 			return this;
 		}
 
@@ -503,9 +484,7 @@ public class FileSystemTools {
 		 * @return this builder
 		 */
 		public Builder allowedDirectory(String allowedDirectory) {
-			if (allowedDirectory != null) {
-				this.allowedDirectories.add(Paths.get(allowedDirectory));
-			}
+			this.allowedDirectories.add(allowedDirectory);
 			return this;
 		}
 
@@ -515,16 +494,12 @@ public class FileSystemTools {
 		 * @return this builder
 		 */
 		public Builder allowedDirectories(Path... allowedDirectories) {
-			for (Path dir : allowedDirectories) {
-				if (dir != null) {
-					this.allowedDirectories.add(dir);
-				}
-			}
+			this.allowedDirectories.addAll(allowedDirectories);
 			return this;
 		}
 
 		public FileSystemTools build() {
-			return new FileSystemTools(this.allowedDirectories);
+			return new FileSystemTools(this.allowedDirectories.toList());
 		}
 
 	}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GlobTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GlobTool.java
@@ -50,18 +50,27 @@ public class GlobTool {
 
 	private final Path workingDirectory;
 
+	private final AllowedDirectories allowedDirectories;
+
 	/**
 	 * Constructor with configurable parameters.
 	 * @param maxDepth Maximum directory traversal depth to prevent infinite recursion
 	 * (default: 100)
 	 * @param maxResults Maximum number of results to return (default: 1000)
-	 * @param workingDirectory The working directory to use when path is not specified.
-	 * If null, defaults to current JVM working directory.
+	 * @param workingDirectory The working directory to use when path is not specified. If
+	 * null, defaults to current JVM working directory.
 	 */
 	protected GlobTool(int maxDepth, int maxResults, Path workingDirectory) {
+		this(maxDepth, maxResults, workingDirectory, List.of());
+	}
+
+	protected GlobTool(int maxDepth, int maxResults, Path workingDirectory, List<Path> allowedDirectories) {
 		this.maxDepth = maxDepth;
 		this.maxResults = maxResults;
-		this.workingDirectory = workingDirectory;
+		// Operator-supplied config: normalize so the model-input '..' defense in the
+		// confinement check does not reject the tool's own working directory.
+		this.workingDirectory = (workingDirectory != null) ? workingDirectory.toAbsolutePath().normalize() : null;
+		this.allowedDirectories = new AllowedDirectories(allowedDirectories);
 	}
 
 	// @formatter:off
@@ -80,7 +89,8 @@ public class GlobTool {
 		Assert.hasText(pattern, "	The glob pattern must not be empty");
 
 		try {
-			// Determine search path - use configured workingDirectory if path not specified
+			// Determine search path - use configured workingDirectory if path not
+			// specified
 			Path searchPath;
 			if (StringUtils.hasText(path)) {
 				searchPath = Paths.get(path);
@@ -90,6 +100,12 @@ public class GlobTool {
 			}
 			else {
 				searchPath = Paths.get(".");
+			}
+
+			// Confinement check shared with FileSystemTools (see AllowedDirectories)
+			String accessError = this.allowedDirectories.validate(searchPath.toString());
+			if (accessError != null) {
+				return accessError;
 			}
 
 			if (!Files.exists(searchPath)) {
@@ -106,7 +122,11 @@ public class GlobTool {
 			// Find matching files
 			List<FileInfo> matchingFiles = new ArrayList<>();
 
-			try (Stream<Path> paths = Files.walk(searchPath, this.maxDepth, FileVisitOption.FOLLOW_LINKS)) {
+			// Under confinement, do not follow symbolic links during traversal — a link
+			// inside the workspace must not expose content outside the allowed
+			// directories.
+			try (Stream<Path> paths = this.allowedDirectories.isRestricted() ? Files.walk(searchPath, this.maxDepth)
+					: Files.walk(searchPath, this.maxDepth, FileVisitOption.FOLLOW_LINKS)) {
 				paths.filter(Files::isRegularFile)
 					.filter(p -> !this.isIgnoredPath(p))
 					.filter(p -> this.matchesPattern(p, searchPath, matcher))
@@ -201,6 +221,8 @@ public class GlobTool {
 
 		private Path workingDirectory = null;
 
+		private final AllowedDirectories.Collector allowedDirectories = new AllowedDirectories.Collector();
+
 		private Builder() {
 		}
 
@@ -215,8 +237,8 @@ public class GlobTool {
 		}
 
 		/**
-		 * Set the working directory to use when the agent doesn't specify a path.
-		 * This allows tools to operate within a sandbox/workspace context.
+		 * Set the working directory to use when the agent doesn't specify a path. This
+		 * allows tools to operate within a sandbox/workspace context.
 		 * @param workingDirectory the working directory path
 		 * @return this builder
 		 */
@@ -235,8 +257,41 @@ public class GlobTool {
 			return this;
 		}
 
+		/**
+		 * Adds a directory to the list of allowed paths. When configured, the resolved
+		 * search path (explicit {@code path} argument or the workingDirectory fallback)
+		 * must fall within the union of allowed directories — same semantics as
+		 * FileSystemTools. Empty (the default) means unrestricted.
+		 * @param allowedDirectory the directory to allow searches within
+		 * @return this builder
+		 */
+		public Builder allowedDirectory(Path allowedDirectory) {
+			this.allowedDirectories.add(allowedDirectory);
+			return this;
+		}
+
+		/**
+		 * Adds a directory to the list of allowed paths.
+		 * @param allowedDirectory the directory path as a string; ignored if {@code null}
+		 * @return this builder
+		 */
+		public Builder allowedDirectory(String allowedDirectory) {
+			this.allowedDirectories.add(allowedDirectory);
+			return this;
+		}
+
+		/**
+		 * Adds multiple directories to the list of allowed paths.
+		 * @param allowedDirectories the directories to allow searches within
+		 * @return this builder
+		 */
+		public Builder allowedDirectories(Path... allowedDirectories) {
+			this.allowedDirectories.addAll(allowedDirectories);
+			return this;
+		}
+
 		public GlobTool build() {
-			return new GlobTool(maxDepth, maxResults, workingDirectory);
+			return new GlobTool(maxDepth, maxResults, workingDirectory, this.allowedDirectories.toList());
 		}
 
 	}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GrepTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GrepTool.java
@@ -57,6 +57,8 @@ public class GrepTool {
 
 	private final Path workingDirectory;
 
+	private final AllowedDirectories allowedDirectories;
+
 	// File type mappings (common extensions)
 	private static final Map<String, String[]> FILE_TYPE_EXTENSIONS = new HashMap<>();
 	static {
@@ -85,7 +87,7 @@ public class GrepTool {
 	 */
 	@Deprecated
 	public GrepTool() {
-		this(100000, 100, 10000, null);
+		this(100000, 100, 10000, null, List.of());
 	}
 
 	/**
@@ -95,14 +97,18 @@ public class GrepTool {
 	 * (default: 100)
 	 * @param maxLineLength Maximum line length to process, longer lines are skipped
 	 * (default: 10000)
-	 * @param workingDirectory The working directory to use when path is not specified.
-	 * If null, defaults to current JVM working directory.
+	 * @param workingDirectory The working directory to use when path is not specified. If
+	 * null, defaults to current JVM working directory.
 	 */
-	private GrepTool(int maxOutputLength, int maxDepth, int maxLineLength, Path workingDirectory) {
+	private GrepTool(int maxOutputLength, int maxDepth, int maxLineLength, Path workingDirectory,
+			List<Path> allowedDirectories) {
 		this.maxOutputLength = maxOutputLength;
 		this.maxDepth = maxDepth;
 		this.maxLineLength = maxLineLength;
-		this.workingDirectory = workingDirectory;
+		// Operator-supplied config: normalize so the model-input '..' defense in the
+		// confinement check does not reject the tool's own working directory.
+		this.workingDirectory = (workingDirectory != null) ? workingDirectory.toAbsolutePath().normalize() : null;
+		this.allowedDirectories = new AllowedDirectories(allowedDirectories);
 	}
 
 	/**
@@ -146,7 +152,8 @@ public class GrepTool {
 		@ToolParam(description = "Enable multiline mode where . matches newlines and patterns can span lines. Default: false.", required = false) Boolean multiline) { // @formatter:on
 
 		try {
-			// Determine search path - use configured workingDirectory if path not specified
+			// Determine search path - use configured workingDirectory if path not
+			// specified
 			Path searchPath;
 			if (StringUtils.hasText(path)) {
 				searchPath = Paths.get(path);
@@ -156,6 +163,14 @@ public class GrepTool {
 			}
 			else {
 				searchPath = Paths.get(".");
+			}
+
+			// Confinement check shared with FileSystemTools (see AllowedDirectories):
+			// the resolved search path must fall within the allowed directories, whether
+			// it came from the model or from the workingDirectory fallback.
+			String accessError = this.allowedDirectories.validate(searchPath.toString());
+			if (accessError != null) {
+				return accessError;
 			}
 
 			if (!Files.exists(searchPath)) {
@@ -383,7 +398,11 @@ public class GrepTool {
 		}
 		else if (Files.isDirectory(searchPath)) {
 			// Directory traversal
-			try (Stream<Path> paths = Files.walk(searchPath, this.maxDepth, FileVisitOption.FOLLOW_LINKS)) {
+			// Under confinement, do not follow symbolic links during traversal — a link
+			// inside the workspace must not expose content outside the allowed
+			// directories.
+			try (Stream<Path> paths = this.allowedDirectories.isRestricted() ? Files.walk(searchPath, this.maxDepth)
+					: Files.walk(searchPath, this.maxDepth, FileVisitOption.FOLLOW_LINKS)) {
 				paths.filter(Files::isRegularFile)
 					.filter(p -> this.matchesGlob(p, matchers))
 					.filter(p -> !this.isIgnoredPath(p))
@@ -532,6 +551,8 @@ public class GrepTool {
 
 		private Path workingDirectory = null;
 
+		private final AllowedDirectories.Collector allowedDirectories = new AllowedDirectories.Collector();
+
 		public Builder maxOutputLength(int maxOutputLength) {
 			this.maxOutputLength = maxOutputLength;
 			return this;
@@ -568,8 +589,42 @@ public class GrepTool {
 			return this;
 		}
 
+		/**
+		 * Adds a directory to the list of allowed paths. When configured, the resolved
+		 * search path (explicit {@code path} argument or the workingDirectory fallback)
+		 * must fall within the union of allowed directories — same semantics as
+		 * FileSystemTools. Empty (the default) means unrestricted.
+		 * @param allowedDirectory the directory to allow searches within
+		 * @return this builder
+		 */
+		public Builder allowedDirectory(Path allowedDirectory) {
+			this.allowedDirectories.add(allowedDirectory);
+			return this;
+		}
+
+		/**
+		 * Adds a directory to the list of allowed paths.
+		 * @param allowedDirectory the directory path as a string; ignored if {@code null}
+		 * @return this builder
+		 */
+		public Builder allowedDirectory(String allowedDirectory) {
+			this.allowedDirectories.add(allowedDirectory);
+			return this;
+		}
+
+		/**
+		 * Adds multiple directories to the list of allowed paths.
+		 * @param allowedDirectories the directories to allow searches within
+		 * @return this builder
+		 */
+		public Builder allowedDirectories(Path... allowedDirectories) {
+			this.allowedDirectories.addAll(allowedDirectories);
+			return this;
+		}
+
 		public GrepTool build() {
-			return new GrepTool(this.maxOutputLength, this.maxDepth, this.maxLineLength, this.workingDirectory);
+			return new GrepTool(this.maxOutputLength, this.maxDepth, this.maxLineLength, this.workingDirectory,
+					this.allowedDirectories.toList());
 		}
 
 	}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ListDirectoryTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ListDirectoryTool.java
@@ -28,8 +28,8 @@ import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 
 /**
- * Lists directory contents with optional depth and result limit. Skips common
- * noise directories (.git, node_modules, target, build, etc.).
+ * Lists directory contents with optional depth and result limit. Skips common noise
+ * directories (.git, node_modules, target, build, etc.).
  */
 public class ListDirectoryTool {
 
@@ -38,8 +38,17 @@ public class ListDirectoryTool {
 
 	private final Path workingDirectory;
 
+	private final AllowedDirectories allowedDirectories;
+
 	protected ListDirectoryTool(Path workingDirectory) {
-		this.workingDirectory = workingDirectory;
+		this(workingDirectory, List.of());
+	}
+
+	protected ListDirectoryTool(Path workingDirectory, List<Path> allowedDirectories) {
+		// Operator-supplied config: normalize so the model-input '..' defense in the
+		// confinement check does not reject the tool's own working directory.
+		this.workingDirectory = (workingDirectory != null) ? workingDirectory.toAbsolutePath().normalize() : null;
+		this.allowedDirectories = new AllowedDirectories(allowedDirectories);
 	}
 
 	// @formatter:off
@@ -68,6 +77,12 @@ public class ListDirectoryTool {
 		}
 		else {
 			targetDir = Paths.get(System.getProperty("user.dir"));
+		}
+
+		// Confinement check shared with FileSystemTools (see AllowedDirectories)
+		String accessError = this.allowedDirectories.validate(targetDir.toString());
+		if (accessError != null) {
+			return accessError;
 		}
 
 		if (!Files.exists(targetDir)) {
@@ -102,7 +117,9 @@ public class ListDirectoryTool {
 			sb.append(e.isDir() ? "  [dir]  " : "  [file] ").append(rel).append("\n");
 		}
 		if (entries.size() == maxResults) {
-			sb.append("  ... (limit of ").append(maxResults).append(" reached — use a larger limit or narrow the path)");
+			sb.append("  ... (limit of ")
+				.append(maxResults)
+				.append(" reached — use a larger limit or narrow the path)");
 		}
 		return sb.toString().stripTrailing();
 	}
@@ -127,6 +144,8 @@ public class ListDirectoryTool {
 
 		private Path workingDirectory;
 
+		private final AllowedDirectories.Collector allowedDirectories = new AllowedDirectories.Collector();
+
 		private Builder() {
 		}
 
@@ -140,8 +159,41 @@ public class ListDirectoryTool {
 			return this;
 		}
 
+		/**
+		 * Adds a directory to the list of allowed paths. When configured, the resolved
+		 * target directory (explicit {@code path} argument or the workingDirectory
+		 * fallback) must fall within the union of allowed directories — same semantics as
+		 * FileSystemTools. Empty (the default) means unrestricted.
+		 * @param allowedDirectory the directory to allow listings within
+		 * @return this builder
+		 */
+		public Builder allowedDirectory(Path allowedDirectory) {
+			this.allowedDirectories.add(allowedDirectory);
+			return this;
+		}
+
+		/**
+		 * Adds a directory to the list of allowed paths.
+		 * @param allowedDirectory the directory path as a string; ignored if {@code null}
+		 * @return this builder
+		 */
+		public Builder allowedDirectory(String allowedDirectory) {
+			this.allowedDirectories.add(allowedDirectory);
+			return this;
+		}
+
+		/**
+		 * Adds multiple directories to the list of allowed paths.
+		 * @param allowedDirectories the directories to allow listings within
+		 * @return this builder
+		 */
+		public Builder allowedDirectories(Path... allowedDirectories) {
+			this.allowedDirectories.addAll(allowedDirectories);
+			return this;
+		}
+
 		public ListDirectoryTool build() {
-			return new ListDirectoryTool(workingDirectory);
+			return new ListDirectoryTool(workingDirectory, this.allowedDirectories.toList());
 		}
 
 	}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsNioRegressionTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsNioRegressionTest.java
@@ -1,0 +1,98 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Behavior preserved across the java.io → NIO migration of FileSystemTools: lenient
+ * charset handling, graceful invalid-path and empty-path errors, and an honest header
+ * when the read limit truncates.
+ *
+ * @author Christian Tzolov
+ */
+class FileSystemToolsNioRegressionTest {
+
+	@TempDir
+	Path tempDir;
+
+	private final FileSystemTools tools = FileSystemTools.builder().build();
+
+	@Test
+	void readToleratesNonUtf8Bytes() throws Exception {
+		Path file = this.tempDir.resolve("latin1.log");
+		// 0xE9 is 'é' in ISO-8859-1 — an invalid byte sequence in UTF-8
+		byte[] content = ("before " + (char) 0xE9 + " after\nline two\n").getBytes(StandardCharsets.ISO_8859_1);
+		Files.write(file, content);
+
+		String result = this.tools.read(file.toString(), null, null);
+
+		assertThat(result).doesNotStartWith("Error").contains("line two").contains("before");
+	}
+
+	@Test
+	void writeToleratesLoneSurrogates() {
+		Path file = this.tempDir.resolve("surrogate.txt");
+		// A high surrogate with no low surrogate — e.g. an emoji truncated at a token
+		// boundary in model output
+		String loneSurrogate = "truncated emoji: " + '\uD83D';
+
+		String result = this.tools.write(file.toString(), loneSurrogate);
+
+		assertThat(result).contains("Successfully created file");
+		assertThat(Files.exists(file)).isTrue();
+	}
+
+	@Test
+	void invalidPathReturnsErrorStringInsteadOfThrowing() {
+		// An embedded NUL is rejected by Paths.get with InvalidPathException
+		String invalid = "invalid\0path.txt";
+
+		assertThat(this.tools.read(invalid, null, null)).startsWith("Error: Invalid path:");
+		assertThat(this.tools.edit(invalid, "a", "b", null)).startsWith("Error: Invalid path:");
+	}
+
+	@Test
+	void emptyPathReturnsCleanError() {
+		assertThat(this.tools.read("", null, null)).isEqualTo("Error: file_path must not be empty");
+		assertThat(this.tools.write("  ", "x")).isEqualTo("Error: file_path must not be empty");
+		assertThat(this.tools.edit(null, "a", "b", null)).isEqualTo("Error: file_path must not be empty");
+	}
+
+	@Test
+	void limitHitHeaderSaysAtLeast() throws Exception {
+		Path file = this.tempDir.resolve("big.txt");
+		StringBuilder sb = new StringBuilder();
+		for (int i = 1; i <= 50; i++) {
+			sb.append("line ").append(i).append("\n");
+		}
+		Files.writeString(file, sb.toString());
+
+		String truncated = this.tools.read(file.toString(), null, 10);
+		assertThat(truncated).contains("Showing lines 1-10 of at least 11");
+
+		String full = this.tools.read(file.toString(), null, null);
+		assertThat(full).contains("Showing lines 1-50 of 50");
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SearchToolsAllowedDirectoriesTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/SearchToolsAllowedDirectoriesTest.java
@@ -1,0 +1,159 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Directory confinement for the search tools (GrepTool, GlobTool, ListDirectoryTool) —
+ * the {@code allowedDirectories} option shares {@link AllowedDirectories} with
+ * FileSystemTools, closing the bypass where an explicit {@code path} argument escaped the
+ * {@code workingDirectory}.
+ *
+ * @author Christian Tzolov
+ */
+class SearchToolsAllowedDirectoriesTest {
+
+	private static final String DENIED = "Error: Access denied. Path is outside the allowed directories:";
+
+	@TempDir
+	Path workspace;
+
+	@TempDir
+	Path outside;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		Files.writeString(this.workspace.resolve("inside.txt"), "needle in workspace\n");
+		Files.writeString(this.outside.resolve("secret.env"), "needle outside\n");
+	}
+
+	@Test
+	void grepExplicitPathOutsideAllowedDirectoriesIsDenied() {
+		GrepTool grep = GrepTool.builder().workingDirectory(this.workspace).allowedDirectory(this.workspace).build();
+
+		String outsideResult = grep.grep("needle", this.outside.toString(), null, null, null, null, null, null, null,
+				null, null, null, null);
+		assertThat(outsideResult).startsWith(DENIED);
+
+		String insideResult = grep.grep("needle", this.workspace.toString(), null, null, null, null, null, null, null,
+				null, null, null, null);
+		assertThat(insideResult).contains("inside.txt");
+	}
+
+	@Test
+	void grepWorkingDirectoryFallbackStaysAllowed() {
+		GrepTool grep = GrepTool.builder().workingDirectory(this.workspace).allowedDirectory(this.workspace).build();
+
+		// No explicit path -> workingDirectory fallback, which is inside the jail
+		String result = grep.grep("needle", null, null, null, null, null, null, null, null, null, null, null, null);
+		assertThat(result).contains("inside.txt");
+	}
+
+	@Test
+	void grepTraversalEscapeIsDenied() {
+		GrepTool grep = GrepTool.builder().allowedDirectory(this.workspace).build();
+
+		String result = grep.grep("needle", this.workspace + "/../", null, null, null, null, null, null, null, null,
+				null, null, null);
+		assertThat(result).startsWith(DENIED);
+	}
+
+	@Test
+	void globExplicitPathOutsideAllowedDirectoriesIsDenied() {
+		GlobTool glob = GlobTool.builder().workingDirectory(this.workspace).allowedDirectory(this.workspace).build();
+
+		assertThat(glob.glob("**/*.env", this.outside.toString())).startsWith(DENIED);
+		assertThat(glob.glob("*.txt", this.workspace.toString())).contains("inside.txt");
+	}
+
+	@Test
+	void listDirectoryExplicitPathOutsideAllowedDirectoriesIsDenied() {
+		ListDirectoryTool listDirectory = ListDirectoryTool.builder()
+			.workingDirectory(this.workspace)
+			.allowedDirectory(this.workspace)
+			.build();
+
+		assertThat(listDirectory.listDirectory(this.outside.toString(), null, null)).startsWith(DENIED);
+		assertThat(listDirectory.listDirectory(null, null, null)).contains("inside.txt");
+	}
+
+	@Test
+	void symlinkInsideWorkspaceDoesNotLeakOutsideContentWhenConfined() throws Exception {
+		Files.createSymbolicLink(this.workspace.resolve("link"), this.outside);
+
+		GrepTool grep = GrepTool.builder().allowedDirectory(this.workspace).build();
+		String grepResult = grep.grep("needle", this.workspace.toString(), null, null, null, null, null, null, null,
+				null, null, null, null);
+		assertThat(grepResult).doesNotContain("secret.env");
+
+		GlobTool glob = GlobTool.builder().allowedDirectory(this.workspace).build();
+		assertThat(glob.glob("**/*.env", this.workspace.toString())).doesNotContain("secret.env");
+	}
+
+	@Test
+	void unconfinedTraversalStillFollowsSymlinks() throws Exception {
+		Files.createSymbolicLink(this.workspace.resolve("link"), this.outside);
+
+		GrepTool grep = GrepTool.builder().build();
+		String result = grep.grep("needle", this.workspace.toString(), null, null, null, null, null, null, null, null,
+				null, null, null);
+		assertThat(result).contains("secret.env");
+	}
+
+	@Test
+	void canonicalPathInsideSymlinkedAllowedDirectoryIsAccepted() throws Exception {
+		// Configured allowed dir reached through a symlink; target given canonically
+		Path real = Files.createDirectory(this.workspace.resolve("real"));
+		Path link = Files.createSymbolicLink(this.workspace.resolve("linkdir"), real);
+		Files.writeString(real.resolve("data.txt"), "needle canonical\n");
+
+		GrepTool grep = GrepTool.builder().allowedDirectory(link).build();
+		String result = grep.grep("needle", real.toRealPath().toString(), null, null, null, null, null, null, null,
+				null, null, null, null);
+		assertThat(result).contains("data.txt");
+	}
+
+	@Test
+	void relativeWorkingDirectoryWithDotDotIsNormalizedAtBuildTime() {
+		Path dotted = this.workspace.resolve("sub").resolve("..");
+
+		GrepTool grep = GrepTool.builder().workingDirectory(dotted).allowedDirectory(this.workspace).build();
+		String result = grep.grep("needle", null, null, null, null, null, null, null, null, null, null, null, null);
+		assertThat(result).contains("inside.txt");
+	}
+
+	@Test
+	void unrestrictedByDefault() {
+		GrepTool grep = GrepTool.builder().build();
+		GlobTool glob = GlobTool.builder().build();
+		ListDirectoryTool listDirectory = ListDirectoryTool.builder().build();
+
+		assertThat(grep.grep("needle", this.outside.toString(), null, null, null, null, null, null, null, null, null,
+				null, null))
+			.contains("secret.env");
+		assertThat(glob.glob("*.env", this.outside.toString())).contains("secret.env");
+		assertThat(listDirectory.listDirectory(this.outside.toString(), null, null)).contains("secret.env");
+	}
+
+}


### PR DESCRIPTION
  Closes #75. workingDirectory on the search tools was only a default for
  when the model omits the path argument — an explicit path escaped it, so a
  sandboxed deployment confining FileSystemTools with allowedDirectory(...)
  could still be read via Grep(path="/") or Glob(path="/home").

  Extracts FileSystemTools.validateAllowedAccess into a shared package-private
  AllowedDirectories helper and gives GrepTool, GlobTool and ListDirectoryTool
  the same allowedDirectory/allowedDirectories builder options with identical
  semantics and error strings. The resolved search path — explicit argument or
  workingDirectory fallback — is validated before any filesystem access. Empty
  remains unrestricted; defaults are unchanged and existing protected
  constructors keep working.

  Confinement hardening beyond the original check:
  - when allowed directories are configured, Grep/Glob traversal no longer follows symbolic links, so a link inside the workspace cannot expose content outside it (unconfined traversal keeps following links)
  - the containment check also accepts canonical paths when the configured directory has a symlinked prefix (e.g. /tmp -> /private/tmp on macOS)
  - operator-supplied workingDirectory is normalized at construction so the model-input '..' defense cannot reject the tool's own configuration
  - the builder-side configuration plumbing is shared (AllowedDirectories .Collector), leaving one copy of the security surface across four tools

  FileSystemTools additionally moves from legacy java.io File/FileReader/
  FileWriter to NIO while preserving the old tolerance: UTF-8 with REPLACE
  error handling on read and write (malformed bytes and lone surrogates are
  substituted, not errors), streaming writes, InvalidPathException surfaced
  as an error string, an explicit empty-file_path guard, and the read header
  now reports "of at least N" lines when the limit truncates instead of
  implying the file was fully read.

  Docs gain directory-confinement sections for the search tools (both
  mirrors). SearchToolsAllowedDirectoriesTest and
  FileSystemToolsNioRegressionTest cover deny/allow, symlink traversal and
  escapes, the workingDirectory fallback, charset tolerance, invalid/empty
  paths and the truncation header.