### PR TITLE
Add Workspace abstraction for sandbox-truthful paths and prompts

### DIFF
--- a/docs/tools/AgentEnvironment.md
+++ b/docs/tools/AgentEnvironment.md
@@ -78,6 +78,30 @@ System.out.println(gitStatus);
 // ...
 ```
 
+#### Workspace and sandbox-aware overloads
+
+The no-argument methods above describe the **host JVM's current directory**. When the agent's tools operate somewhere else — a dedicated workspace directory, or a sandbox reached through an `ExecBackend` — use the overloads so the rendered context matches what the agent can actually reach:
+
+```java
+Workspace workspace = Workspace.local(Path.of("/data/sessions/session-42"));
+
+// Working-directory line and git-repo check follow the workspace root;
+// the path is rendered via workspace.display(...) (host form for local workspaces,
+// in-sandbox form for a workspace with a custom display mapping)
+String envInfo = AgentEnvironment.info(workspace);
+
+// Git commands run locally at the workspace root
+String gitStatus = AgentEnvironment.gitStatus(workspace);
+
+// Git commands run through an execution backend — inside a sandbox the reported
+// status is the sandbox's view of the repository
+String sandboxGitStatus = AgentEnvironment.gitStatus(myDockerExecBackend);
+```
+
+`gitStatus(ExecBackend)` runs the same git commands (`rev-parse`, `status --short`, `log --oneline`) through the [ExecBackend SPI](ShellTools.md#execution-backend--working-directory) instead of spawning host processes directly, so the backend's working directory and isolation apply.
+
+Note: the platform, OS version, and date lines of `info(...)` always describe the JVM host. If your sandbox runs a different OS, render those lines yourself.
+
 
 ## Basic Usage
 

--- a/docs/tools/FileSystemTools.md
+++ b/docs/tools/FileSystemTools.md
@@ -40,6 +40,11 @@ FileSystemTools tools = FileSystemTools.builder()
 
 // No restriction (default — backward compatible)
 FileSystemTools tools = FileSystemTools.builder().build();
+
+// Workspace shorthand — confines operations to the workspace root
+FileSystemTools tools = FileSystemTools.builder()
+    .workspace(Workspace.local(Path.of("/workspace/project")))
+    .build();
 ```
 
 **Security guarantees:**

--- a/docs/tools/GlobTool.md
+++ b/docs/tools/GlobTool.md
@@ -828,6 +828,11 @@ GlobTool.builder()
     .workingDirectory(workspace)     // default when path is omitted
     .allowedDirectory(workspace)     // jail: explicit paths must stay inside
     .build();
+
+// Equivalent one-call form using the Workspace abstraction
+GlobTool.builder()
+    .workspace(Workspace.local(workspace))
+    .build();
 ```
 
 The resolved search path — whether from the model or the `workingDirectory` fallback —

--- a/docs/tools/GrepTool.md
+++ b/docs/tools/GrepTool.md
@@ -1123,6 +1123,11 @@ GrepTool.builder()
     .workingDirectory(workspace)     // default when path is omitted
     .allowedDirectory(workspace)     // jail: explicit paths must stay inside
     .build();
+
+// Equivalent one-call form using the Workspace abstraction
+GrepTool.builder()
+    .workspace(Workspace.local(workspace))
+    .build();
 ```
 
 The resolved search path — whether from the model or the `workingDirectory` fallback —

--- a/docs/tools/ShellTools.md
+++ b/docs/tools/ShellTools.md
@@ -240,6 +240,11 @@ ShellTools tools = ShellTools.builder()
     .workingDirectory(Path.of("/workspace/session-42"))
     .build();
 
+// Equivalent, sharing one Workspace definition with the file/search tools
+ShellTools tools = ShellTools.builder()
+    .workspace(Workspace.local(Path.of("/workspace/session-42")))
+    .build();
+
 // Or supply a fully configured backend
 ShellTools tools = ShellTools.builder()
     .execBackend(LocalExecBackend.builder()

--- a/docs/tools/SkillsTool.md
+++ b/docs/tools/SkillsTool.md
@@ -314,6 +314,37 @@ SkillsTool.builder()
     .build();
 ```
 
+### Workspace path mapping
+
+When a skill is invoked, the tool response starts with the skill's base directory so the
+model can read additional skill files or run its scripts. By default that is the host
+path the skills were loaded from. If the agent's shell and file tools execute somewhere
+else (for example a sandbox with a bind-mounted workspace), configure a `Workspace` whose
+`display(...)` mapping translates host paths into the form the model can actually use:
+
+```java
+Workspace sandbox = new Workspace() {
+    @Override
+    public Path root() {
+        return Path.of("/hosts/volumes/session-42");
+    }
+
+    @Override
+    public String display(String hostPath) {
+        return hostPath.replace("/hosts/volumes/session-42", "/workspace");
+    }
+};
+
+SkillsTool.builder()
+    .addSkillsDirectory("/hosts/volumes/session-42/skills")
+    .workspace(sandbox)
+    .build();
+// Invoking a skill now announces: "Base directory for this skill: /workspace/skills/pdf"
+```
+
+Skills loaded from JAR/classpath resources keep their synthetic base path unchanged
+(the default `display` implementation is the identity).
+
 ### Custom Tool Description Template
 
 ```java

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/workspace/Workspace.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/workspace/Workspace.java
@@ -1,0 +1,67 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.common.workspace;
+
+import java.nio.file.Path;
+
+/**
+ * The directory context an agent's tools operate in: a root directory plus a mapping from
+ * host-side paths to the paths the <em>model</em> should see. For local execution the
+ * mapping is the identity; for a sandboxed deployment (e.g. a container with a
+ * bind-mounted workspace) an implementation translates host paths to their in-sandbox
+ * form so the model is never shown a path it cannot use.
+ *
+ * <p>
+ * Tool builders accept a workspace as one-call configuration via their {@code workspace}
+ * option: the search tools (GrepTool, GlobTool, ListDirectoryTool) take the working
+ * directory and the allowed-directory confinement together, FileSystemTools takes the
+ * confinement, and ShellTools takes the working directory only (a shell cannot be
+ * confined from Java — use a sandboxed exec backend for isolation). Path-publishing
+ * components (SkillsTool, AgentEnvironment) use {@link #display} so system prompts and
+ * tool responses describe the workspace rather than the host.
+ *
+ * @author Christian Tzolov
+ */
+@FunctionalInterface
+public interface Workspace {
+
+	/** The workspace root directory (host-side form). */
+	Path root();
+
+	/**
+	 * How a host-side path should be presented to the model. Identity by default; sandbox
+	 * implementations rewrite it to the in-sandbox form. Non-filesystem locations (e.g.
+	 * classpath/JAR pseudo-paths) pass through unchanged.
+	 */
+	default String display(String hostPath) {
+		return hostPath;
+	}
+
+	/** Convenience for {@link #display(String)}. */
+	default String display(Path hostPath) {
+		return display(hostPath.toString());
+	}
+
+	/** A local workspace rooted at the given directory, with identity path display. */
+	static Workspace local(Path root) {
+		if (root == null) {
+			throw new IllegalArgumentException("root must not be null");
+		}
+		Path normalized = root.toAbsolutePath().normalize();
+		return () -> normalized;
+	}
+
+}

--- a/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/workspace/package-info.java
+++ b/spring-ai-agent-utils-common/src/main/java/org/springaicommunity/agent/common/workspace/package-info.java
@@ -1,0 +1,23 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+ * Workspace SPI: the directory context an agent's tools operate in — a root directory
+ * plus host-to-model path display mapping. Complements the execution backend SPI
+ * ({@code org.springaicommunity.agent.common.exec}): the backend decides where commands
+ * run, the workspace decides where files live and how paths are presented to the model.
+ */
+package org.springaicommunity.agent.common.workspace;

--- a/spring-ai-agent-utils-common/src/test/java/org/springaicommunity/agent/common/workspace/WorkspaceTest.java
+++ b/spring-ai-agent-utils-common/src/test/java/org/springaicommunity/agent/common/workspace/WorkspaceTest.java
@@ -1,0 +1,79 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.common.workspace;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The local workspace normalizes its root and displays paths verbatim; custom
+ * implementations override display to map host paths into their sandbox form. Fixture
+ * paths are derived from a temp directory so the assertions hold on every platform.
+ *
+ * @author Christian Tzolov
+ */
+class WorkspaceTest {
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void localWorkspaceNormalizesRoot() {
+		Path dotted = this.tempDir.resolve("sub").resolve("..");
+
+		assertEquals(this.tempDir, Workspace.local(dotted).root());
+	}
+
+	@Test
+	void localWorkspaceDisplayIsIdentity() {
+		Workspace workspace = Workspace.local(this.tempDir);
+
+		Path file = this.tempDir.resolve("README.md");
+		assertEquals(file.toString(), workspace.display(file));
+		assertEquals("classpath:skills/pdf", workspace.display("classpath:skills/pdf"));
+	}
+
+	@Test
+	void localWorkspaceRejectsNullRoot() {
+		assertThrows(IllegalArgumentException.class, () -> Workspace.local(null));
+	}
+
+	@Test
+	void customDisplayMapsHostPathsIntoSandboxForm() {
+		String hostRoot = this.tempDir.toString();
+		Workspace sandbox = new Workspace() {
+
+			@Override
+			public Path root() {
+				return WorkspaceTest.this.tempDir;
+			}
+
+			@Override
+			public String display(String hostPath) {
+				return hostPath.replace(hostRoot, "/workspace");
+			}
+
+		};
+
+		assertEquals("/workspace/skills/pdf", sandbox.display(hostRoot + "/skills/pdf"));
+	}
+
+}

--- a/spring-ai-agent-utils/docs/AgentEnvironment.md
+++ b/spring-ai-agent-utils/docs/AgentEnvironment.md
@@ -78,6 +78,30 @@ System.out.println(gitStatus);
 // ...
 ```
 
+#### Workspace and sandbox-aware overloads
+
+The no-argument methods above describe the **host JVM's current directory**. When the agent's tools operate somewhere else — a dedicated workspace directory, or a sandbox reached through an `ExecBackend` — use the overloads so the rendered context matches what the agent can actually reach:
+
+```java
+Workspace workspace = Workspace.local(Path.of("/data/sessions/session-42"));
+
+// Working-directory line and git-repo check follow the workspace root;
+// the path is rendered via workspace.display(...) (host form for local workspaces,
+// in-sandbox form for a workspace with a custom display mapping)
+String envInfo = AgentEnvironment.info(workspace);
+
+// Git commands run locally at the workspace root
+String gitStatus = AgentEnvironment.gitStatus(workspace);
+
+// Git commands run through an execution backend — inside a sandbox the reported
+// status is the sandbox's view of the repository
+String sandboxGitStatus = AgentEnvironment.gitStatus(myDockerExecBackend);
+```
+
+`gitStatus(ExecBackend)` runs the same git commands (`rev-parse`, `status --short`, `log --oneline`) through the [ExecBackend SPI](ShellTools.md#execution-backend--working-directory) instead of spawning host processes directly, so the backend's working directory and isolation apply.
+
+Note: the platform, OS version, and date lines of `info(...)` always describe the JVM host. If your sandbox runs a different OS, render those lines yourself.
+
 
 ## Basic Usage
 

--- a/spring-ai-agent-utils/docs/FileSystemTools.md
+++ b/spring-ai-agent-utils/docs/FileSystemTools.md
@@ -40,6 +40,11 @@ FileSystemTools tools = FileSystemTools.builder()
 
 // No restriction (default — backward compatible)
 FileSystemTools tools = FileSystemTools.builder().build();
+
+// Workspace shorthand — confines operations to the workspace root
+FileSystemTools tools = FileSystemTools.builder()
+    .workspace(Workspace.local(Path.of("/workspace/project")))
+    .build();
 ```
 
 **Security guarantees:**

--- a/spring-ai-agent-utils/docs/GlobTool.md
+++ b/spring-ai-agent-utils/docs/GlobTool.md
@@ -828,6 +828,11 @@ GlobTool.builder()
     .workingDirectory(workspace)     // default when path is omitted
     .allowedDirectory(workspace)     // jail: explicit paths must stay inside
     .build();
+
+// Equivalent one-call form using the Workspace abstraction
+GlobTool.builder()
+    .workspace(Workspace.local(workspace))
+    .build();
 ```
 
 The resolved search path — whether from the model or the `workingDirectory` fallback —

--- a/spring-ai-agent-utils/docs/GrepTool.md
+++ b/spring-ai-agent-utils/docs/GrepTool.md
@@ -1123,6 +1123,11 @@ GrepTool.builder()
     .workingDirectory(workspace)     // default when path is omitted
     .allowedDirectory(workspace)     // jail: explicit paths must stay inside
     .build();
+
+// Equivalent one-call form using the Workspace abstraction
+GrepTool.builder()
+    .workspace(Workspace.local(workspace))
+    .build();
 ```
 
 The resolved search path — whether from the model or the `workingDirectory` fallback —

--- a/spring-ai-agent-utils/docs/ShellTools.md
+++ b/spring-ai-agent-utils/docs/ShellTools.md
@@ -240,6 +240,11 @@ ShellTools tools = ShellTools.builder()
     .workingDirectory(Path.of("/workspace/session-42"))
     .build();
 
+// Equivalent, sharing one Workspace definition with the file/search tools
+ShellTools tools = ShellTools.builder()
+    .workspace(Workspace.local(Path.of("/workspace/session-42")))
+    .build();
+
 // Or supply a fully configured backend
 ShellTools tools = ShellTools.builder()
     .execBackend(LocalExecBackend.builder()

--- a/spring-ai-agent-utils/docs/SkillsTool.md
+++ b/spring-ai-agent-utils/docs/SkillsTool.md
@@ -314,6 +314,37 @@ SkillsTool.builder()
     .build();
 ```
 
+### Workspace path mapping
+
+When a skill is invoked, the tool response starts with the skill's base directory so the
+model can read additional skill files or run its scripts. By default that is the host
+path the skills were loaded from. If the agent's shell and file tools execute somewhere
+else (for example a sandbox with a bind-mounted workspace), configure a `Workspace` whose
+`display(...)` mapping translates host paths into the form the model can actually use:
+
+```java
+Workspace sandbox = new Workspace() {
+    @Override
+    public Path root() {
+        return Path.of("/hosts/volumes/session-42");
+    }
+
+    @Override
+    public String display(String hostPath) {
+        return hostPath.replace("/hosts/volumes/session-42", "/workspace");
+    }
+};
+
+SkillsTool.builder()
+    .addSkillsDirectory("/hosts/volumes/session-42/skills")
+    .workspace(sandbox)
+    .build();
+// Invoking a skill now announces: "Base directory for this skill: /workspace/skills/pdf"
+```
+
+Skills loaded from JAR/classpath resources keep their synthetic base path unchanged
+(the default `display` implementation is the identity).
+
 ### Custom Tool Description Template
 
 ```java

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
@@ -29,8 +29,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springaicommunity.agent.common.workspace.Workspace;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.util.Assert;
 
 /**
  * @author Christian Tzolov
@@ -495,6 +497,18 @@ public class FileSystemTools {
 		 */
 		public Builder allowedDirectories(Path... allowedDirectories) {
 			this.allowedDirectories.addAll(allowedDirectories);
+			return this;
+		}
+
+		/**
+		 * Confines all file operations to the given workspace — shorthand for
+		 * {@code allowedDirectory(workspace.root())}.
+		 * @param workspace the workspace to operate within
+		 * @return this builder
+		 */
+		public Builder workspace(Workspace workspace) {
+			Assert.notNull(workspace, "workspace must not be null");
+			this.allowedDirectories.add(workspace.root());
 			return this;
 		}
 

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GlobTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GlobTool.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.springaicommunity.agent.common.workspace.Workspace;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.util.Assert;
@@ -254,6 +255,22 @@ public class GlobTool {
 		 */
 		public Builder workingDirectory(String workingDirectory) {
 			this.workingDirectory = workingDirectory != null ? Paths.get(workingDirectory) : null;
+			return this;
+		}
+
+		/**
+		 * Configures this tool for the given workspace — shorthand for
+		 * {@code workingDirectory(workspace.root())} plus
+		 * {@code allowedDirectory(workspace.root())}: searches default to the workspace
+		 * root and are confined to it. A later {@code workingDirectory} call overrides
+		 * the default location while the confinement remains.
+		 * @param workspace the workspace to operate within
+		 * @return this builder
+		 */
+		public Builder workspace(Workspace workspace) {
+			Assert.notNull(workspace, "workspace must not be null");
+			this.workingDirectory = workspace.root();
+			this.allowedDirectories.add(workspace.root());
 			return this;
 		}
 

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GrepTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/GrepTool.java
@@ -34,8 +34,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import org.springaicommunity.agent.common.workspace.Workspace;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -586,6 +588,22 @@ public class GrepTool {
 		 */
 		public Builder workingDirectory(String workingDirectory) {
 			this.workingDirectory = workingDirectory != null ? Paths.get(workingDirectory) : null;
+			return this;
+		}
+
+		/**
+		 * Configures this tool for the given workspace — shorthand for
+		 * {@code workingDirectory(workspace.root())} plus
+		 * {@code allowedDirectory(workspace.root())}: searches default to the workspace
+		 * root and are confined to it. A later {@code workingDirectory} call overrides
+		 * the default location while the confinement remains.
+		 * @param workspace the workspace to operate within
+		 * @return this builder
+		 */
+		public Builder workspace(Workspace workspace) {
+			Assert.notNull(workspace, "workspace must not be null");
+			this.workingDirectory = workspace.root();
+			this.allowedDirectories.add(workspace.root());
 			return this;
 		}
 

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ListDirectoryTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ListDirectoryTool.java
@@ -24,8 +24,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.springaicommunity.agent.common.workspace.Workspace;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.util.Assert;
 
 /**
  * Lists directory contents with optional depth and result limit. Skips common noise
@@ -156,6 +158,22 @@ public class ListDirectoryTool {
 
 		public Builder workingDirectory(String workingDirectory) {
 			this.workingDirectory = workingDirectory != null ? Paths.get(workingDirectory) : null;
+			return this;
+		}
+
+		/**
+		 * Configures this tool for the given workspace — shorthand for
+		 * {@code workingDirectory(workspace.root())} plus
+		 * {@code allowedDirectory(workspace.root())}: listings default to the workspace
+		 * root and are confined to it. A later {@code workingDirectory} call overrides
+		 * the default location while the confinement remains.
+		 * @param workspace the workspace to operate within
+		 * @return this builder
+		 */
+		public Builder workspace(Workspace workspace) {
+			Assert.notNull(workspace, "workspace must not be null");
+			this.workingDirectory = workspace.root();
+			this.allowedDirectories.add(workspace.root());
 			return this;
 		}
 

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ShellTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ShellTools.java
@@ -24,6 +24,7 @@ import org.springaicommunity.agent.common.exec.ExecBackend;
 import org.springaicommunity.agent.common.exec.ExecHandle;
 import org.springaicommunity.agent.common.exec.ExecResult;
 import org.springaicommunity.agent.common.exec.ExecSpec;
+import org.springaicommunity.agent.common.workspace.Workspace;
 import org.springaicommunity.agent.exec.LocalExecBackend;
 import org.springframework.ai.tool.annotation.Tool;
 import org.springframework.ai.tool.annotation.ToolParam;
@@ -330,6 +331,21 @@ public class ShellTools {
 
 		public Builder workingDirectory(String workingDirectory) {
 			return workingDirectory(workingDirectory != null ? Paths.get(workingDirectory) : null);
+		}
+
+		/**
+		 * Convenience: run commands locally rooted at the given workspace — shorthand for
+		 * {@code workingDirectory(workspace.root())}. Mutually exclusive with
+		 * {@link #execBackend(ExecBackend)}, same as {@code workingDirectory}. Unlike the
+		 * {@code workspace} option on the file/search tools, this does NOT restrict what
+		 * commands can access — a shell can leave its working directory. Use a sandboxed
+		 * {@link ExecBackend} for actual isolation.
+		 * @param workspace the workspace whose root becomes the working directory
+		 * @return this builder
+		 */
+		public Builder workspace(Workspace workspace) {
+			Assert.notNull(workspace, "workspace must not be null");
+			return workingDirectory(workspace.root());
 		}
 
 		public ShellTools build() {

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/SkillsTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/SkillsTool.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.springaicommunity.agent.common.workspace.Workspace;
 import org.springaicommunity.agent.utils.Skills;
 
 import org.springframework.ai.tool.ToolCallback;
@@ -67,8 +68,15 @@ public class SkillsTool {
 
 		private Map<String, Skill> skillsMap;
 
+		private Workspace workspace;
+
 		public SkillsFunction(Map<String, Skill> skillsMap) {
+			this(skillsMap, null);
+		}
+
+		public SkillsFunction(Map<String, Skill> skillsMap, Workspace workspace) {
 			this.skillsMap = skillsMap;
+			this.workspace = workspace;
 		}
 
 		@Override
@@ -76,7 +84,9 @@ public class SkillsTool {
 			Skill skill = this.skillsMap.get(input.command());
 
 			if (skill != null) {
-				return "Base directory for this skill: %s\n\n%s".formatted(skill.basePath(), skill.content());
+				String basePath = (this.workspace != null) ? this.workspace.display(skill.basePath())
+						: skill.basePath();
+				return "Base directory for this skill: %s\n\n%s".formatted(basePath, skill.content());
 			}
 
 			return "Skill not found: " + input.command();
@@ -94,12 +104,27 @@ public class SkillsTool {
 
 		private String toolDescriptionTemplate = TOOL_DESCRIPTION_TEMPLATE;
 
+		private Workspace workspace;
+
 		protected Builder() {
 
 		}
 
 		public Builder toolDescriptionTemplate(String template) {
 			this.toolDescriptionTemplate = template;
+			return this;
+		}
+
+		/**
+		 * Maps skill base-directory paths through {@link Workspace#display(String)}
+		 * before they reach the model, so the announced base directory is valid in the
+		 * environment where the agent's shell and file tools execute (e.g. an in-sandbox
+		 * path instead of the host path the skills were loaded from).
+		 * @param workspace the workspace whose display mapping to apply
+		 * @return this builder
+		 */
+		public Builder workspace(Workspace workspace) {
+			this.workspace = workspace;
 			return this;
 		}
 
@@ -130,7 +155,7 @@ public class SkillsTool {
 
 			String skillsXml = this.skills.stream().map(s -> s.toXml()).collect(Collectors.joining("\n"));
 
-			return FunctionToolCallback.builder("Skill", new SkillsFunction(toSkillsMap(this.skills)))
+			return FunctionToolCallback.builder("Skill", new SkillsFunction(toSkillsMap(this.skills), this.workspace))
 				.description(this.toolDescriptionTemplate.formatted(skillsXml))
 				.inputType(SkillsInput.class)
 				.build();

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/utils/AgentEnvironment.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/utils/AgentEnvironment.java
@@ -15,20 +15,29 @@
 */
 package org.springaicommunity.agent.utils;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.Map;
 
+import org.springaicommunity.agent.common.exec.ExecBackend;
+import org.springaicommunity.agent.common.exec.ExecResult;
+import org.springaicommunity.agent.common.exec.ExecSpec;
+import org.springaicommunity.agent.common.workspace.Workspace;
+import org.springaicommunity.agent.exec.LocalExecBackend;
+
+/**
+ * Renders environment context blocks (working directory, git status) for inclusion in
+ * agent system prompts. The no-argument methods describe the host JVM's current
+ * directory; the {@link Workspace} and {@link ExecBackend} overloads describe the
+ * environment the agent's tools actually operate in, so a sandboxed agent is not shown
+ * host paths or host git state it cannot reach.
+ *
+ * @author Christian Tzolov
+ */
 public class AgentEnvironment {
-
-	private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("win");
 
 	public static final String ENVIRONMENT_INFO_KEY = "ENVIRONMENT_INFO";
 
@@ -38,10 +47,30 @@ public class AgentEnvironment {
 
 	public static final String AGENT_MODEL_KNOWLEDGE_CUTOFF_KEY = "AGENT_MODEL_KNOWLEDGE_CUTOFF";
 
-	public static String info() {
+	private static final long GIT_COMMAND_TIMEOUT_MILLIS = 30_000;
 
-		String workingDirectory = System.getProperty("user.dir");
-		boolean isGitRepo = new File(workingDirectory, ".git").exists();
+	/** Force untranslated git output so the parsing below is locale-independent. */
+	private static final Map<String, String> GIT_ENV = Map.of("LC_ALL", "C", "LANG", "C");
+
+	/** Environment info for the host JVM's current working directory. */
+	public static String info() {
+		return info(hostWorkspace());
+	}
+
+	/**
+	 * Environment info for the given workspace: the working directory line shows
+	 * {@link Workspace#display(Path) workspace.display(root)} — the path as the model
+	 * should see it — and the git-repo check runs against the workspace root. Platform,
+	 * OS version and date describe the JVM host; override the rendered block if the
+	 * execution environment differs.
+	 * @param workspace the workspace the agent's tools operate in
+	 * @return the rendered environment info block
+	 */
+	public static String info(Workspace workspace) {
+
+		Path root = workspace.root();
+		String workingDirectory = workspace.display(root);
+		boolean isGitRepo = Files.exists(root.resolve(".git"));
 		String platform = System.getProperty("os.name").toLowerCase();
 		String osVersion = System.getProperty("os.name") + " " + System.getProperty("os.version");
 		String todayDate = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
@@ -56,16 +85,39 @@ public class AgentEnvironment {
 		return sb.toString();
 	}
 
+	/** Git status snapshot of the host JVM's current working directory. */
 	public static String gitStatus() {
+		return gitStatus(hostWorkspace());
+	}
+
+	/**
+	 * Git status snapshot of the given workspace, executed locally at the workspace root.
+	 * @param workspace the workspace whose root to inspect
+	 * @return the rendered git status block, or an empty string when git is unavailable
+	 * or the root is not a git work tree
+	 */
+	public static String gitStatus(Workspace workspace) {
+		return gitStatus(LocalExecBackend.builder().workingDirectory(workspace.root()).build());
+	}
+
+	/**
+	 * Git status snapshot produced by running git through the given execution backend —
+	 * inside a sandbox, the reported status is the sandbox's view of the repository. The
+	 * backend's own working directory determines which repository is inspected.
+	 * @param execBackend the backend to run git commands on
+	 * @return the rendered git status block, or an empty string when git is unavailable
+	 * or the working directory is not a git work tree
+	 */
+	public static String gitStatus(ExecBackend execBackend) {
 
 		// Check if git is available
-		if (!isGitAvailable()) {
+		if (!isGitAvailable(execBackend)) {
 			System.out.println("Git is not available or not in PATH.\n");
 			return "";
 		}
 
 		// Check if we're in a git repository
-		String gitCheck = runGitCommand("rev-parse", "--is-inside-work-tree");
+		String gitCheck = runGit(execBackend, "git rev-parse --is-inside-work-tree");
 		if (!"true".equals(gitCheck)) {
 			System.out.println("Not inside a git repository.\n");
 			return "";
@@ -76,96 +128,61 @@ public class AgentEnvironment {
 		sb.append("Note that this status is a snapshot in time, and will not update during the conversation.\n");
 
 		// Get current branch
-		String currentBranch = runGitCommand("rev-parse", "--abbrev-ref", "HEAD");
+		String currentBranch = runGit(execBackend, "git rev-parse --abbrev-ref HEAD");
 		sb.append("Current branch: ").append(currentBranch).append("\n\n");
 
 		// Get main/master branch (for PRs)
-		String mainBranch = getMainBranch();
+		String mainBranch = getMainBranch(execBackend);
 		sb.append("Main branch (you will usually use this for PRs): ").append(mainBranch).append("\n\n");
 
 		// Get git status
-		String status = runGitCommand("status", "--short");
+		String status = runGit(execBackend, "git status --short");
 		sb.append("Status:\n").append(status.isEmpty() ? "Working tree clean\n\n" : status).append("\n\n");
 
 		// Get recent commits
-		String recentCommits = runGitCommand("log", "--oneline", "-n", "5");
+		String recentCommits = runGit(execBackend, "git log --oneline -n 5");
 		sb.append("Recent commits:\n").append(recentCommits);
 
 		return sb.toString();
 	}
 
-	private static boolean isGitAvailable() {
-		try {
-			String result = runGitCommand("--version");
-			return result != null && result.contains("git version");
-		}
-		catch (Exception e) {
-			return false;
-		}
+	private static Workspace hostWorkspace() {
+		return Workspace.local(Paths.get(System.getProperty("user.dir")));
 	}
 
-	private static String getMainBranch() {
+	private static boolean isGitAvailable(ExecBackend execBackend) {
+		String result = runGit(execBackend, "git --version");
+		return result.contains("git version");
+	}
+
+	private static String getMainBranch(ExecBackend execBackend) {
 		// Try to detect the main branch name
 		String[] possibleMains = { "main", "master" };
 		for (String branch : possibleMains) {
-			String result = runGitCommand("rev-parse", "--verify", "--quiet", branch);
-			if (result != null && !result.isEmpty() && !result.toLowerCase().contains("fatal")) {
+			String result = runGit(execBackend, "git rev-parse --verify --quiet " + branch);
+			if (!result.isEmpty()) {
 				return branch;
 			}
 		}
 		// Try to get from remote
-		String remoteBranch = runGitCommand("symbolic-ref", "refs/remotes/origin/HEAD", "--short");
-		if (remoteBranch != null && !remoteBranch.isEmpty()) {
+		String remoteBranch = runGit(execBackend, "git symbolic-ref refs/remotes/origin/HEAD --short");
+		if (!remoteBranch.isEmpty()) {
 			return remoteBranch.replace("origin/", "");
 		}
 		return "main";
 	}
 
 	/**
-	 * Runs a git command in a cross-platform manner. On Windows, uses cmd.exe /c to
-	 * ensure proper command execution. On Unix/Mac, runs git directly.
+	 * Runs a git command through the execution backend and returns its trimmed stdout, or
+	 * an empty string when the command did not complete or exited non-zero.
 	 */
-	private static String runGitCommand(String... gitArgs) {
+	private static String runGit(ExecBackend execBackend, String command) {
 		try {
-			List<String> command = new ArrayList<>();
-
-			if (IS_WINDOWS) {
-				command.add("cmd.exe");
-				command.add("/c");
-				command.add("git");
-			}
-			else {
-				command.add("git");
-			}
-
-			for (String arg : gitArgs) {
-				command.add(arg);
-			}
-
-			ProcessBuilder pb = new ProcessBuilder(command);
-			pb.directory(new File(System.getProperty("user.dir")));
-			pb.redirectErrorStream(true);
-
-			// Set environment to ensure consistent output
-			pb.environment().put("LC_ALL", "C");
-			pb.environment().put("LANG", "C");
-
-			Process process = pb.start();
-
-			String result;
-			try (BufferedReader reader = new BufferedReader(
-					new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-				result = reader.lines().collect(Collectors.joining("\n"));
-			}
-
-			// Wait with timeout to prevent hanging
-			boolean finished = process.waitFor(30, TimeUnit.SECONDS);
-			if (!finished) {
-				process.destroyForcibly();
+			ExecResult result = execBackend.run(new ExecSpec(command, GIT_COMMAND_TIMEOUT_MILLIS, GIT_ENV));
+			if (result.status() != ExecResult.Status.COMPLETED || result.exitCode() != 0) {
 				return "";
 			}
-
-			return result.trim();
+			return result.stdout().trim();
 		}
 		catch (Exception e) {
 			return "";

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/WorkspaceAdoptionTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/WorkspaceAdoptionTest.java
@@ -1,0 +1,159 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springaicommunity.agent.common.workspace.Workspace;
+
+import org.springframework.ai.tool.ToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@code workspace} builder option on the tools: one call configures working
+ * directory and directory confinement together, and SkillsTool maps skill base paths
+ * through {@link Workspace#display} so the model sees workspace paths, not host paths.
+ *
+ * @author Christian Tzolov
+ */
+class WorkspaceAdoptionTest {
+
+	private static final String DENIED = "Error: Access denied. Path is outside the allowed directories:";
+
+	private static final String SKILL_MD = """
+			---
+			name: test-skill
+			description: A test skill
+			---
+
+			This is the test skill content.
+			""";
+
+	@TempDir
+	Path workspaceDir;
+
+	@TempDir
+	Path outside;
+
+	private Workspace workspace;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		this.workspace = Workspace.local(this.workspaceDir);
+		Files.writeString(this.workspaceDir.resolve("inside.txt"), "needle in workspace\n");
+		Files.writeString(this.outside.resolve("secret.env"), "needle outside\n");
+	}
+
+	@Test
+	void fileSystemToolsWorkspaceConfinesOperations() {
+		FileSystemTools tools = FileSystemTools.builder().workspace(this.workspace).build();
+
+		assertThat(tools.read(this.workspaceDir.resolve("inside.txt").toString(), null, null)).contains("needle");
+		assertThat(tools.read(this.outside.resolve("secret.env").toString(), null, null)).startsWith(DENIED);
+	}
+
+	@Test
+	void grepToolWorkspaceSetsWorkingDirectoryAndJail() {
+		GrepTool grep = GrepTool.builder().workspace(this.workspace).build();
+
+		// No explicit path -> defaults to the workspace root
+		String defaulted = grep.grep("needle", null, null, null, null, null, null, null, null, null, null, null, null);
+		assertThat(defaulted).contains("inside.txt");
+
+		String escaped = grep.grep("needle", this.outside.toString(), null, null, null, null, null, null, null, null,
+				null, null, null);
+		assertThat(escaped).startsWith(DENIED);
+	}
+
+	@Test
+	void globToolWorkspaceSetsWorkingDirectoryAndJail() {
+		GlobTool glob = GlobTool.builder().workspace(this.workspace).build();
+
+		assertThat(glob.glob("*.txt", null)).contains("inside.txt");
+		assertThat(glob.glob("*.env", this.outside.toString())).startsWith(DENIED);
+	}
+
+	@Test
+	void listDirectoryToolWorkspaceSetsWorkingDirectoryAndJail() {
+		ListDirectoryTool listDirectory = ListDirectoryTool.builder().workspace(this.workspace).build();
+
+		assertThat(listDirectory.listDirectory(null, null, null)).contains("inside.txt");
+		assertThat(listDirectory.listDirectory(this.outside.toString(), null, null)).startsWith(DENIED);
+	}
+
+	@Test
+	void shellToolsWorkspaceRunsCommandsAtWorkspaceRoot() throws Exception {
+		ShellTools shell = ShellTools.builder().workspace(this.workspace).build();
+
+		String result = shell.bash("pwd", null, null, null);
+
+		// toRealPath: on macOS the temp dir is reached via the /var -> /private/var
+		// symlink and pwd reports the resolved form
+		assertThat(result).contains(this.workspaceDir.toRealPath().toString());
+	}
+
+	@Test
+	void skillsToolDisplaysWorkspaceMappedBasePath() throws Exception {
+		Path skillDir = this.workspaceDir.resolve("skills").resolve("test-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		Workspace sandboxView = new Workspace() {
+
+			@Override
+			public Path root() {
+				return WorkspaceAdoptionTest.this.workspaceDir;
+			}
+
+			@Override
+			public String display(String hostPath) {
+				return hostPath.replace(WorkspaceAdoptionTest.this.workspaceDir.toString(), "/workspace");
+			}
+
+		};
+
+		ToolCallback callback = SkillsTool.builder()
+			.addSkillsDirectory(this.workspaceDir.resolve("skills").toString())
+			.workspace(sandboxView)
+			.build();
+
+		String result = callback.call("{\"command\":\"test-skill\"}");
+
+		assertThat(result).contains("Base directory for this skill: /workspace/skills/test-skill");
+		assertThat(result).doesNotContain(this.workspaceDir.toString());
+	}
+
+	@Test
+	void skillsToolWithoutWorkspaceKeepsHostBasePath() throws Exception {
+		Path skillDir = this.workspaceDir.resolve("skills").resolve("test-skill");
+		Files.createDirectories(skillDir);
+		Files.writeString(skillDir.resolve("SKILL.md"), SKILL_MD, StandardCharsets.UTF_8);
+
+		ToolCallback callback = SkillsTool.builder()
+			.addSkillsDirectory(this.workspaceDir.resolve("skills").toString())
+			.build();
+
+		assertThat(callback.call("{\"command\":\"test-skill\"}"))
+			.contains("Base directory for this skill: " + skillDir);
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/utils/AgentEnvironmentWorkspaceTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/utils/AgentEnvironmentWorkspaceTest.java
@@ -1,0 +1,142 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.utils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springaicommunity.agent.common.exec.ExecBackend;
+import org.springaicommunity.agent.common.exec.ExecHandle;
+import org.springaicommunity.agent.common.exec.ExecResult;
+import org.springaicommunity.agent.common.exec.ExecSpec;
+import org.springaicommunity.agent.common.workspace.Workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The workspace/backend overloads of {@link AgentEnvironment}: environment info shows the
+ * workspace's display path (not the raw host path), and git status runs through the
+ * {@link ExecBackend} SPI so a sandbox reports its own view of the repository.
+ *
+ * @author Christian Tzolov
+ */
+class AgentEnvironmentWorkspaceTest {
+
+	@TempDir
+	Path root;
+
+	@Test
+	void infoDescribesWorkspaceNotHostCurrentDirectory() throws Exception {
+		Files.createDirectory(this.root.resolve(".git"));
+		Workspace workspace = Workspace.local(this.root);
+
+		String info = AgentEnvironment.info(workspace);
+
+		assertThat(info).contains("Working directory: " + this.root);
+		assertThat(info).contains("Is directory a git repo: Yes");
+		assertThat(info).doesNotContain("Working directory: " + System.getProperty("user.dir") + "\n");
+	}
+
+	@Test
+	void infoUsesWorkspaceDisplayMapping() {
+		Workspace sandboxView = new Workspace() {
+
+			@Override
+			public Path root() {
+				return AgentEnvironmentWorkspaceTest.this.root;
+			}
+
+			@Override
+			public String display(String hostPath) {
+				return hostPath.replace(AgentEnvironmentWorkspaceTest.this.root.toString(), "/workspace");
+			}
+
+		};
+
+		String info = AgentEnvironment.info(sandboxView);
+
+		assertThat(info).contains("Working directory: /workspace");
+		assertThat(info).doesNotContain(this.root.toString());
+	}
+
+	@Test
+	void gitStatusRunsThroughExecBackend() {
+		RecordingBackend backend = new RecordingBackend();
+
+		String status = AgentEnvironment.gitStatus(backend);
+
+		assertThat(backend.commands).contains("git --version", "git rev-parse --is-inside-work-tree",
+				"git rev-parse --abbrev-ref HEAD", "git status --short");
+		assertThat(status).contains("Current branch: feature-x");
+		assertThat(status).contains("Working tree clean");
+		assertThat(status).contains("Recent commits:\nabc1234 initial commit");
+	}
+
+	@Test
+	void gitStatusReturnsEmptyWhenBackendHasNoGit() {
+		ExecBackend noGit = new ExecBackend() {
+
+			@Override
+			public ExecResult run(ExecSpec spec) {
+				return ExecResult.completed(127, "", "git: command not found");
+			}
+
+			@Override
+			public ExecHandle start(ExecSpec spec) {
+				throw new UnsupportedOperationException();
+			}
+
+		};
+
+		assertThat(AgentEnvironment.gitStatus(noGit)).isEmpty();
+	}
+
+	@Test
+	void localGitStatusOfNonRepoWorkspaceIsEmpty() {
+		assertThat(AgentEnvironment.gitStatus(Workspace.local(this.root))).isEmpty();
+	}
+
+	/** Scripted backend standing in for a sandbox: canned git replies, recorded calls. */
+	static final class RecordingBackend implements ExecBackend {
+
+		final List<String> commands = new ArrayList<>();
+
+		@Override
+		public ExecResult run(ExecSpec spec) {
+			this.commands.add(spec.command());
+			return switch (spec.command()) {
+				case "git --version" -> ExecResult.completed(0, "git version 2.44.0", "");
+				case "git rev-parse --is-inside-work-tree" -> ExecResult.completed(0, "true", "");
+				case "git rev-parse --abbrev-ref HEAD" -> ExecResult.completed(0, "feature-x", "");
+				case "git rev-parse --verify --quiet main" -> ExecResult.completed(0, "abc1234def", "");
+				case "git status --short" -> ExecResult.completed(0, "", "");
+				case "git log --oneline -n 5" -> ExecResult.completed(0, "abc1234 initial commit", "");
+				default -> ExecResult.completed(1, "", "unexpected: " + spec.command());
+			};
+		}
+
+		@Override
+		public ExecHandle start(ExecSpec spec) {
+			throw new UnsupportedOperationException("not used by AgentEnvironment");
+		}
+
+	}
+
+}


### PR DESCRIPTION
Introduce a Workspace SPI in spring-ai-agent-utils-common: a root directory plus a display mapping from host paths to the paths the model should see. 
It complements the ExecBackend SPI — the backend decides where commands run, the workspace decides where files live and how paths are presented.

- Workspace interface with Path root(), identity display(String/Path) defaults, and a normalizing Workspace.local(Path) factory
- workspace(Workspace) builder option on GrepTool, GlobTool and ListDirectoryTool (working directory + allowed-directory confinement in one call), FileSystemTools (confinement) and ShellTools (working directory only — a shell cannot be confined from Java; use a sandboxed ExecBackend for isolation)
- SkillsTool maps the announced skill base directory through workspace.display(), so sandboxed agents are not shown host paths; JAR/classpath pseudo-paths pass through unchanged
- AgentEnvironment gains info(Workspace) and gitStatus(Workspace| ExecBackend) overloads; git commands now run through the ExecBackend SPI instead of a private ProcessBuilder, removing the last direct process-spawning site. No-arg methods keep their host behavior. Git output is now taken from stdout of zero-exit commands only, which also stops "fatal:" stderr text leaking into the rendered block (the old code could report a git error message as the main branch name).
- Tests: WorkspaceTest, WorkspaceAdoptionTest, AgentEnvironmentWorkspaceTest; docs updated in both mirrors