### PR TITLE
Add DockerCliExecBackend for sandboxed command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ While these tools can be used standalone, truly agentic behavior emerges when th
 | [**spring-ai-agent-utils**](spring-ai-agent-utils/README.md) | Core library - tools, skills, Claude subagents, and full API reference |
 | [**spring-ai-agent-utils-common**](spring-ai-agent-utils-common/README.md) | Shared subagent SPI (SubagentDefinition, SubagentResolver, SubagentExecutor, SubagentType) |
 | [**spring-ai-agent-utils-a2a**](spring-ai-agent-utils-a2a/README.md) | A2A protocol subagent for remote agent orchestration |
+| [**spring-ai-agent-utils-docker-cli**](docs/tools/DockerCliExecBackend.md) | Docker ExecBackend - run agent shell commands inside a sandbox container (in `exec-backends/`) |
 | [**spring-ai-agent-utils-bom**](spring-ai-agent-utils-bom/pom.xml) | Bill of Materials for consistent version management across all modules |
 | [**Examples**](#examples) | Working demos showcasing different use cases |
 

--- a/docs/tools/DockerCliExecBackend.md
+++ b/docs/tools/DockerCliExecBackend.md
@@ -1,0 +1,84 @@
+# DockerCliExecBackend - Sandboxed Command Execution
+
+`DockerCliExecBackend` is an `ExecBackend` implementation (module `spring-ai-agent-utils-docker-cli`) that runs model-authored shell commands inside a Docker container instead of on the host JVM. It drives Docker through the `docker` CLI — no Java Docker client dependency — so contexts, credential helpers and non-standard daemon sockets are resolved exactly as in your terminal, and any CLI-compatible runtime works (Docker Desktop, Colima, podman via `podman-docker`).
+
+```xml
+<dependency>
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-agent-utils-docker-cli</artifactId>
+</dependency>
+```
+
+## The full sandbox recipe
+
+The headline use case: one managed container per agent/session, a bind-mounted host directory as the workspace, and the whole toolset wired from two objects:
+
+```java
+Path hostWorkspace = Files.createTempDirectory("agent-session");
+
+try (DockerCliExecBackend backend = DockerCliExecBackend.builder()
+        .image("eclipse-temurin:17-jdk-alpine")       // needs a POSIX shell + sleep
+        .mount(hostWorkspace, "/workspace")           // the agent workspace
+        .build()) {
+
+    Workspace workspace = backend.workspace();        // host root + /workspace display mapping
+
+    // Shell commands execute inside the container
+    ShellTools shell = ShellTools.builder().execBackend(backend).build();
+
+    // File/search tools operate host-side through the mount, confined to it
+    FileSystemTools files = FileSystemTools.builder().workspace(workspace).build();
+    GrepTool grep = GrepTool.builder().workspace(workspace).build();
+    GlobTool glob = GlobTool.builder().workspace(workspace).build();
+
+    // Skill base directories and environment prompts show container paths
+    ToolCallback skills = SkillsTool.builder()
+        .addSkillsDirectory(hostWorkspace.resolve("skills").toString())
+        .workspace(workspace)
+        .build();
+    String envInfo = AgentEnvironment.info(workspace);
+    String gitStatus = AgentEnvironment.gitStatus(backend);   // git runs in the container
+}
+```
+
+Every path the model sees is a container path; every command the model writes runs in the container; every file the model touches stays inside the mount. No tool code changes.
+
+## Two modes
+
+**Managed container** — `image(...)` creates a long-lived container (kept alive with a `sleep` entrypoint) and owns its lifecycle:
+
+```java
+DockerCliExecBackend backend = DockerCliExecBackend.builder()
+    .image("alpine:3.20")
+    .mount(hostDir, "/workspace")                 // optional; enables workspace()
+    .containerWorkingDirectory("/workspace")      // default: the mount target
+    .environment(Map.of("LANG", "C"))             // env vars for every command
+    .shellCommand("/bin/bash", "-c")              // default: /bin/sh -c
+    .dockerCommand("podman")                      // default: docker
+    .build();
+...
+backend.close();                                  // docker rm -f
+```
+
+`close()` removes the container. A JVM shutdown hook does the same if `close()` never runs, and managed containers carry the label `org.springaicommunity.agent.exec-backend=docker-cli`, so stragglers from crashed JVMs can be swept with:
+
+```bash
+docker rm -f $(docker ps -aq --filter label=org.springaicommunity.agent.exec-backend=docker-cli)
+```
+
+**Attached container** — `containerId(...)` executes in an existing running container whose lifecycle you own (Kubernetes sidecar, compose service, testcontainer). `close()` is a no-op; `mount(...)` is not available (an existing container's mounts are fixed), so `workspace()` requires managed mode.
+
+## Semantics and caveats
+
+- **Exit codes and streams** — `docker exec` propagates the container command's exit code and separate stdout/stderr, so `ExecResult` looks exactly as with `LocalExecBackend`. Docker-level failures (container not running, daemon down) surface as exit codes 125–127 with the CLI error on stderr.
+- **Timeout and kill reach into the container.** Killing the client `docker exec` process does not kill the in-container process (a Docker limitation), so every command is wrapped to record its in-container PID under `/tmp`; timeouts and `KillShell` signal that PID (TERM, then KILL after a grace period) inside the container. Processes the command itself detaches into the background may survive — same caveat as the local backend.
+- **Background shells** (`BashOutput`/`KillShell`) get handle ids in the `docker_<n>` namespace and stream incremental output with the same cursor semantics as local shells.
+- **Image requirements** — a POSIX shell at the configured `shellCommand` path and a `sleep` binary (managed mode keep-alive); `alpine`, `busybox`, `debian`, `eclipse-temurin` images all qualify, distroless images do not. `build()` fails fast with a clear message when the managed container cannot start or dies immediately. The in-container kill mechanism also needs a writable `/tmp` for its PID files — on a read-only rootfs commands still run, but timeout/kill degrade to destroying only the client `docker exec` process.
+- **Runtime requirement** — the `docker` CLI must be on the JVM's PATH. If the JVM itself runs in a container, mount the Docker socket and install the CLI, or attach to a pre-created container instead.
+
+## See also
+
+- [Workspace & Exec SPI](WorkspaceAndExecSPI.md) — overview of the two seams this backend implements
+- [ShellTools](ShellTools.md#execution-backend--working-directory) — the `ExecBackend` seam this plugs into
+- [AgentEnvironment](AgentEnvironment.md) — workspace/backend-aware environment prompts
+- [FileSystemTools](FileSystemTools.md) / [GrepTool](GrepTool.md) / [GlobTool](GlobTool.md) — workspace confinement for the host-side file tools

--- a/docs/tools/ShellTools.md
+++ b/docs/tools/ShellTools.md
@@ -232,7 +232,8 @@ String killResult = shellTools.killShell("shell_1234567890");
 `spring-ai-agent-utils-common`, package `org.springaicommunity.agent.common.exec`).
 The default `LocalExecBackend` runs processes on the host JVM; alternative
 implementations can execute inside a container or on a remote worker without any
-tool changes.
+tool changes — see [DockerCliExecBackend](DockerCliExecBackend.md) for the
+Docker-based sandbox backend.
 
 ```java
 // Confine local execution to a workspace directory (per session/agent)

--- a/docs/tools/WorkspaceAndExecSPI.md
+++ b/docs/tools/WorkspaceAndExecSPI.md
@@ -1,0 +1,88 @@
+# Workspace & Exec SPI - Sandboxing Overview
+
+The agent tools are decoupled from the host machine through two small SPIs in `spring-ai-agent-utils-common`. Together they answer the two questions any sandboxed agent deployment has to answer:
+
+| Seam | Package | Question it answers |
+|------|---------|---------------------|
+| **`ExecBackend`** | `org.springaicommunity.agent.common.exec` | *Where do shell commands run?* |
+| **`Workspace`** | `org.springaicommunity.agent.common.workspace` | *Where do files live, and how are paths shown to the model?* |
+
+Tools describe **what** to do; the backend and workspace decide **where and how**. Swapping the host for a container changes configuration, never tool code.
+
+## ExecBackend — where commands run
+
+```java
+public interface ExecBackend {
+    ExecResult run(ExecSpec spec);      // synchronous, honors the spec's timeout
+    ExecHandle start(ExecSpec spec);    // background: poll output, kill
+}
+```
+
+- **`ExecSpec`** — the command line as the model authored it, a wall-clock timeout (policy owned by the spec: default 2 min, capped at 10 min), and per-invocation environment variables. Shell selection and working directory are deliberately *backend* concerns.
+- **`ExecResult`** — status (`COMPLETED`, `TIMED_OUT`, `LAUNCH_FAILED`, `INTERRUPTED`), exit code, separate stdout/stderr. Failures are reported, never thrown.
+- **`ExecHandle`** — a background command: `isAlive()`, cursor-based `newOutput(filter)` (each call returns only output produced since the last one), `exitCode()`, `kill()` (graceful, then forced).
+
+**Who uses it:** [ShellTools](ShellTools.md) routes `Bash`/`BashOutput`/`KillShell` through the configured backend, and [AgentEnvironment](AgentEnvironment.md) runs its git-status commands through it, so a sandboxed agent reports the sandbox's view of the repository.
+
+**Implementations:**
+
+| Implementation | Module | Runs commands |
+|---|---|---|
+| `LocalExecBackend` (default) | `spring-ai-agent-utils` | On the host JVM, with working directory, clean-environment mode and shell selection |
+| [`DockerCliExecBackend`](DockerCliExecBackend.md) | `spring-ai-agent-utils-docker-cli` | Inside a Docker container, via the `docker` CLI |
+
+Custom implementations are a small class: implement `run` (and `start` if you support background shells — throwing `UnsupportedOperationException` there is acceptable for remote/queued executors). An adapter over [agent-sandbox](https://github.com/spring-ai-community/agent-sandbox)'s `Sandbox.exec()` is straightforward for the synchronous path — the shapes are compatible.
+
+## Workspace — where files live, and what the model sees
+
+```java
+@FunctionalInterface
+public interface Workspace {
+    Path root();                                     // host-side root directory
+    default String display(String hostPath) { ... }  // host path -> model-visible path
+    static Workspace local(Path root) { ... }        // identity display
+}
+```
+
+A workspace is a root directory plus a *display mapping*. For local execution the mapping is the identity; for a container with a bind-mounted workspace it rewrites host paths to their in-container form, so the model is never shown a path its shell cannot use.
+
+**Who uses it** — one `workspace(...)` call per tool builder, with per-tool semantics:
+
+| Tool | `workspace(...)` effect |
+|---|---|
+| [GrepTool](GrepTool.md) / [GlobTool](GlobTool.md) / ListDirectoryTool | Working directory **and** allowed-directory confinement |
+| [FileSystemTools](FileSystemTools.md) | Allowed-directory confinement |
+| [ShellTools](ShellTools.md) | Working directory only (a shell can't be confined from Java — that's what a sandboxed `ExecBackend` is for) |
+| [SkillsTool](SkillsTool.md) | Announces skill base directories via `display(...)` |
+| [AgentEnvironment](AgentEnvironment.md) | Environment-info block describes the workspace, not the host |
+
+## How the two compose
+
+The file/search tools run **host-side**, confined to the workspace root; shell commands run **in the backend**. With a bind mount connecting the two, both operate on the same files and the model sees one consistent world:
+
+```java
+try (DockerCliExecBackend backend = DockerCliExecBackend.builder()
+        .image("alpine:3.20")
+        .mount(hostDir, "/workspace")
+        .build()) {
+
+    Workspace workspace = backend.workspace();   // hostDir root, /workspace display
+
+    ShellTools shell = ShellTools.builder().execBackend(backend).build();
+    FileSystemTools files = FileSystemTools.builder().workspace(workspace).build();
+    GrepTool grep = GrepTool.builder().workspace(workspace).build();
+    String envInfo = AgentEnvironment.info(workspace);
+}
+```
+
+See [DockerCliExecBackend](DockerCliExecBackend.md) for the complete recipe and its operational caveats.
+
+## Module map
+
+| Module | Contents |
+|---|---|
+| `spring-ai-agent-utils-common` | The SPIs: `ExecBackend`, `ExecSpec`, `ExecResult`, `ExecHandle`, `Workspace` — the `exec` and `workspace` packages are plain JDK, so backend implementations need no Spring on their classpath |
+| `spring-ai-agent-utils` | The tools plus `LocalExecBackend` (host default) |
+| `exec-backends/spring-ai-agent-utils-docker-cli` | `DockerCliExecBackend` (Docker sandbox) |
+
+The `exec-backends/` folder is the home for further backend implementations as they land.

--- a/docs/tools/migration-0.12.md
+++ b/docs/tools/migration-0.12.md
@@ -1,0 +1,70 @@
+# Migration Guide: 0.11.0 to 0.12.0
+
+This release introduces the sandboxing foundation: the `ExecBackend` and `Workspace` SPIs, directory confinement for the search tools, and the `spring-ai-agent-utils-docker-cli` module. **There are no breaking API changes** — all existing code compiles and runs unchanged. There is **one behavioral change** to review (background shells) and a few output-level changes worth knowing about.
+
+## Dependency Version
+
+```xml
+<dependency>
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-agent-utils</artifactId>
+    <version>0.12.0</version>
+</dependency>
+```
+
+The Spring AI dependency is unchanged (2.0.1).
+
+## Behavioral change: background shells are per-instance
+
+In 0.11.0 the background-shell registry was JVM-global: any `ShellTools` instance could read (`BashOutput`) or kill (`KillShell`) a shell started through any other instance. In 0.12.0 each `ShellTools` instance owns its background shells — separate instances have separate shell namespaces.
+
+This is the right default (separate agents/sessions no longer see each other's shells), but if you relied on cross-instance visibility, those lookups now return `Error: No background shell found with ID ...` with no compile-time signal.
+
+**Before (0.11.0 — worked by accident of the global registry):**
+
+```java
+ShellTools agentA = ShellTools.builder().build();
+ShellTools agentB = ShellTools.builder().build();
+// agentB could read/kill shells started by agentA
+```
+
+**After (0.12.0 — share one instance where shared visibility is intended):**
+
+```java
+ShellTools shared = ShellTools.builder().build();
+// register the same instance with both agents
+```
+
+Note: Claude subagents already share the single `ShellTools` created by `ClaudeSubagentType`, so they keep a shared namespace without changes.
+
+## Deprecations
+
+Move off the deprecated no-argument constructors to the builders — they now carry the configuration that matters (execution backend, working directory, confinement):
+
+```java
+// Before
+ShellTools shell = new ShellTools();
+GrepTool grep = new GrepTool();
+
+// After
+ShellTools shell = ShellTools.builder().workingDirectory(workDir).build();
+GrepTool grep = GrepTool.builder().workingDirectory(workDir).build();
+```
+
+## Output-level changes (no code impact)
+
+These change what the model (or a log reader) sees, not any API:
+
+- **`AgentEnvironment.gitStatus()`** no longer leaks git error text into the rendered block. Previously, in a repository with no local `main`/`master` and no `origin/HEAD` symref, the "Main branch" line could contain a literal `fatal: ...` message; failed git commands now contribute empty strings and the main-branch detection falls back to `main`. Git commands also run through the `ExecBackend` SPI (platform shell) instead of a private `ProcessBuilder`.
+- **`FileSystemTools.read`** header says `Showing lines 1-N of at least M` when the line limit truncates the read, instead of implying the file was fully counted.
+- **`Bash` with a blank command** returns `Error: command must not be blank` instead of spawning a shell.
+- Synchronous `Bash` run ids moved to their own `shell_run_<n>` namespace so they can never collide with background shell ids.
+
+## New in 0.12.0 (opt-in, no migration required)
+
+- **`ExecBackend` SPI** (`org.springaicommunity.agent.common.exec`) — pluggable command execution; `ShellTools.builder().execBackend(...)` and `AgentEnvironment.gitStatus(ExecBackend)`. `LocalExecBackend` (the default) adds `workingDirectory`, `cleanEnvironment` and `shellCommand` options.
+- **`Workspace` SPI** (`org.springaicommunity.agent.common.workspace`) — root directory + host-to-model path display; one-call `workspace(...)` option on the tool builders, `SkillsTool` base-path mapping, `AgentEnvironment.info(Workspace)`.
+- **Directory confinement for search tools** — `allowedDirectory(...)` on `GrepTool`, `GlobTool` and `ListDirectoryTool`, sharing the FileSystemTools jail semantics. Note: when confinement is configured, directory traversal does **not** follow symbolic links (unconfined behavior is unchanged).
+- **`spring-ai-agent-utils-docker-cli`** — a Docker `ExecBackend` running commands in a sandbox container (new `exec-backends/` module group, managed by the BOM).
+
+See [Workspace & Exec SPI](WorkspaceAndExecSPI.md) for the overview and [DockerCliExecBackend](DockerCliExecBackend.md) for the full sandbox recipe.

--- a/exec-backends/pom.xml
+++ b/exec-backends/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springaicommunity</groupId>
+		<artifactId>spring-ai-agent-utils-parent</artifactId>
+		<version>0.12.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>spring-ai-agent-utils-exec-backends</artifactId>
+	<packaging>pom</packaging>
+	<name>spring-ai-agent-utils-exec-backends</name>
+	<description>Aggregator for ExecBackend implementations (sandbox execution backends)</description>
+
+	<properties>
+		<!-- Aggregator only — the child modules are the published artifacts -->
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<modules>
+		<module>spring-ai-agent-utils-docker-cli</module>
+	</modules>
+
+</project>

--- a/exec-backends/spring-ai-agent-utils-docker-cli/pom.xml
+++ b/exec-backends/spring-ai-agent-utils-docker-cli/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springaicommunity</groupId>
+		<artifactId>spring-ai-agent-utils-parent</artifactId>
+		<version>0.12.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>spring-ai-agent-utils-docker-cli</artifactId>
+	<version>0.12.0-SNAPSHOT</version>
+	<name>spring-ai-agent-utils-docker-cli</name>
+	<description>ExecBackend implementation that runs commands inside a Docker container via the docker CLI</description>
+
+	<url>https://github.com/spring-ai-community/spring-ai-agent-utils</url>
+
+	<scm>
+		<url>https://github.com/spring-ai-community/spring-ai-agent-utils</url>
+		<connection>git://github.com/spring-ai-community/spring-ai-agent-utils.git</connection>
+		<developerConnection>git@github.com:spring-ai-community/spring-ai-agent-utils.git</developerConnection>
+	</scm>
+
+	<organization>
+		<name>Spring AI Community</name>
+		<url>https://github.com/spring-ai-community</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>Apache License 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Christian Tzolov</name>
+		</developer>
+	</developers>
+
+	<issueManagement>
+		<system>Github Issues</system>
+		<url>https://github.com/spring-ai-community/spring-ai-agent-utils/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Github Actions</system>
+		<url>https://github.com/spring-ai-community/spring-ai-agent-utils/actions</url>
+	</ciManagement>
+
+	<properties>
+		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.springaicommunity</groupId>
+			<artifactId>spring-ai-agent-utils-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>3.25.3</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- For the ShellTools-over-DockerCliExecBackend end-to-end test -->
+		<dependency>
+			<groupId>org.springaicommunity</groupId>
+			<artifactId>spring-ai-agent-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- spring-ai-agent-utils declares its Spring deps as provided; the ShellTools
+			end-to-end test supplies them, like an application would -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-client-chat</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/exec-backends/spring-ai-agent-utils-docker-cli/src/main/java/org/springaicommunity/agent/exec/docker/DockerCliExecBackend.java
+++ b/exec-backends/spring-ai-agent-utils-docker-cli/src/main/java/org/springaicommunity/agent/exec/docker/DockerCliExecBackend.java
@@ -1,0 +1,630 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.exec.docker;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
+
+import org.springaicommunity.agent.common.exec.ExecBackend;
+import org.springaicommunity.agent.common.exec.ExecHandle;
+import org.springaicommunity.agent.common.exec.ExecResult;
+import org.springaicommunity.agent.common.exec.ExecSpec;
+import org.springaicommunity.agent.common.workspace.Workspace;
+
+/**
+ * {@link ExecBackend} that runs commands inside a Docker container via the {@code docker}
+ * CLI — no Java Docker client dependency, and the CLI resolves contexts, credential
+ * helpers and non-standard daemon sockets exactly as the user's terminal does. Works with
+ * any CLI-compatible runtime (Docker Desktop, Colima, podman via {@code podman-docker}).
+ *
+ * <p>
+ * Two modes:
+ * <ul>
+ * <li><b>Managed container</b> — {@code image(...)} creates a long-lived container (kept
+ * alive with a {@code sleep} entrypoint), optionally with a
+ * {@code mount(hostDir, containerDir)} bind mount as the agent workspace.
+ * {@link #close()} removes it; a JVM shutdown hook and a {@code docker} label
+ * ({@value #CONTAINER_LABEL}) guard against orphans.</li>
+ * <li><b>Attached container</b> — {@code containerId(...)} executes in an existing
+ * running container whose lifecycle the caller owns.</li>
+ * </ul>
+ *
+ * <p>
+ * With a mount configured, {@link #workspace()} returns the {@link Workspace} that wires
+ * the rest of the toolset: file/search tools operate host-side through the mount
+ * (confined to it), while shell commands and path display use the in-container form.
+ *
+ * <p>
+ * Execution details and caveats:
+ * <ul>
+ * <li>Commands run as {@code docker exec <container> <shell> -c <command>}; the client
+ * process streams output and propagates the container command's exit code. Docker-level
+ * failures surface as exit codes 125–127 with the CLI error on stderr.</li>
+ * <li>Killing the client {@code docker exec} process does <em>not</em> kill the process
+ * inside the container, so every command is wrapped to record its in-container PID under
+ * {@code /tmp}; timeout and {@link ExecHandle#kill()} signal that PID (TERM, then KILL)
+ * inside the container. Grandchildren the command itself detaches may survive.</li>
+ * <li>The container needs a POSIX shell at the configured {@code shellCommand} (default
+ * {@code /bin/sh}) and a writable {@code /tmp} for the PID files — on a read-only rootfs
+ * the command still runs, but timeout/kill degrade to destroying only the client
+ * process.</li>
+ * </ul>
+ *
+ * @author Christian Tzolov
+ */
+public final class DockerCliExecBackend implements ExecBackend, AutoCloseable {
+
+	/** Label set on managed containers, for identification and orphan cleanup. */
+	public static final String CONTAINER_LABEL = "org.springaicommunity.agent.exec-backend";
+
+	private static final String CONTAINER_LABEL_VALUE = "docker-cli";
+
+	private static final AtomicLong HANDLE_SEQUENCE = new AtomicLong(System.currentTimeMillis());
+
+	private static final long DOCKER_CONTROL_TIMEOUT_MILLIS = 30_000;
+
+	private static final long CONTAINER_CREATE_TIMEOUT_MILLIS = 300_000; // image pull
+
+	/**
+	 * Wrapper executed as {@code <shell> -c WRAPPER <name> <pidfile> <shell...>
+	 * <command>}: records the shell's own PID (kept by {@code exec}) so kill/timeout can
+	 * signal the in-container process, then replaces itself with the real command shell.
+	 */
+	private static final String PID_WRAPPER = "echo $$ >\"$1\"; shift; exec \"$@\"";
+
+	private final String dockerCommand;
+
+	private final String containerId;
+
+	private final boolean managedContainer;
+
+	private final String containerWorkingDirectory;
+
+	private final Map<String, String> environment;
+
+	private final List<String> shellCommand;
+
+	private final Path mountHostDirectory;
+
+	private final String mountContainerDirectory;
+
+	private final Thread shutdownHook;
+
+	private volatile boolean closed;
+
+	private DockerCliExecBackend(String dockerCommand, String containerId, boolean managedContainer,
+			String containerWorkingDirectory, Map<String, String> environment, List<String> shellCommand,
+			Path mountHostDirectory, String mountContainerDirectory) {
+		this.dockerCommand = dockerCommand;
+		this.containerId = containerId;
+		this.managedContainer = managedContainer;
+		this.containerWorkingDirectory = containerWorkingDirectory;
+		this.environment = environment;
+		this.shellCommand = shellCommand;
+		this.mountHostDirectory = mountHostDirectory;
+		this.mountContainerDirectory = mountContainerDirectory;
+		if (managedContainer) {
+			this.shutdownHook = new Thread(() -> removeContainer(), "docker-cli-exec-backend-cleanup");
+			Runtime.getRuntime().addShutdownHook(this.shutdownHook);
+		}
+		else {
+			this.shutdownHook = null;
+		}
+	}
+
+	@Override
+	public ExecResult run(ExecSpec spec) {
+		if (this.closed) {
+			return ExecResult.launchFailed("backend is closed");
+		}
+		String pidFile = pidFile("run_" + HANDLE_SEQUENCE.incrementAndGet());
+		Process process;
+		try {
+			process = launch(spec, pidFile);
+		}
+		catch (IOException e) {
+			return ExecResult.launchFailed(e.getMessage());
+		}
+
+		StringBuilder stdout = new StringBuilder();
+		StringBuilder stderr = new StringBuilder();
+		Thread stdoutReader = drain(process.getInputStream(), stdout);
+		Thread stderrReader = drain(process.getErrorStream(), stderr);
+
+		try {
+			boolean completed = process.waitFor(spec.timeoutMillis(), TimeUnit.MILLISECONDS);
+			if (!completed) {
+				killInContainer(pidFile, process);
+				return ExecResult.timedOut(snapshot(stdout), snapshot(stderr));
+			}
+			stdoutReader.join(1000);
+			stderrReader.join(1000);
+			return ExecResult.completed(process.exitValue(), snapshot(stdout), snapshot(stderr));
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			killInContainer(pidFile, process);
+			return ExecResult.interrupted(snapshot(stdout), e.getMessage());
+		}
+	}
+
+	@Override
+	public ExecHandle start(ExecSpec spec) {
+		if (this.closed) {
+			throw new IllegalStateException("backend is closed");
+		}
+		String id = "docker_" + HANDLE_SEQUENCE.incrementAndGet();
+		String pidFile = pidFile(id);
+		try {
+			return new DockerExecHandle(id, launch(spec, pidFile), pidFile);
+		}
+		catch (IOException e) {
+			throw new IllegalStateException(e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * The workspace formed by the configured bind mount: {@code root()} is the host
+	 * directory (for the host-side file/search tools), {@code display(...)} rewrites host
+	 * paths to their in-container form (for shell commands, skill base directories and
+	 * environment prompts).
+	 * @throws IllegalStateException when no mount is configured
+	 */
+	public Workspace workspace() {
+		if (this.mountHostDirectory == null) {
+			throw new IllegalStateException(
+					"No workspace mount configured - use image(...) with mount(hostDir, containerDir)");
+		}
+		Path hostRoot = this.mountHostDirectory;
+		String hostPrefix = hostRoot.toString();
+		String containerPrefix = this.mountContainerDirectory;
+		return new Workspace() {
+
+			@Override
+			public Path root() {
+				return hostRoot;
+			}
+
+			@Override
+			public String display(String hostPath) {
+				if (hostPath.equals(hostPrefix)) {
+					return containerPrefix;
+				}
+				if (hostPath.startsWith(hostPrefix + "/") || hostPath.startsWith(hostPrefix + "\\")) {
+					return containerPrefix + "/" + hostPath.substring(hostPrefix.length() + 1).replace('\\', '/');
+				}
+				return hostPath;
+			}
+
+		};
+	}
+
+	/** The id of the container commands execute in. */
+	public String containerId() {
+		return this.containerId;
+	}
+
+	/**
+	 * For a managed container, removes it ({@code docker rm -f}); for an attached
+	 * container this is a no-op — the caller owns its lifecycle. Idempotent.
+	 */
+	@Override
+	public void close() {
+		if (this.closed) {
+			return;
+		}
+		this.closed = true;
+		if (this.managedContainer) {
+			removeContainer();
+			try {
+				Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+			}
+			catch (IllegalStateException e) {
+				// JVM already shutting down — the hook itself is running
+			}
+		}
+	}
+
+	private void removeContainer() {
+		execLocal(List.of(this.dockerCommand, "rm", "-f", this.containerId), DOCKER_CONTROL_TIMEOUT_MILLIS);
+	}
+
+	private static String pidFile(String id) {
+		return "/tmp/.agent-exec-" + id + ".pid";
+	}
+
+	private Process launch(ExecSpec spec, String pidFile) throws IOException {
+		List<String> argv = new ArrayList<>();
+		argv.add(this.dockerCommand);
+		argv.add("exec");
+		if (this.containerWorkingDirectory != null) {
+			argv.add("-w");
+			argv.add(this.containerWorkingDirectory);
+		}
+		Map<String, String> env = new LinkedHashMap<>(this.environment);
+		env.putAll(spec.env());
+		for (Map.Entry<String, String> entry : env.entrySet()) {
+			argv.add("-e");
+			argv.add(entry.getKey() + "=" + entry.getValue());
+		}
+		argv.add(this.containerId);
+		// PID-recording wrapper, then the configured shell runs the actual command.
+		// Everything is passed as argv elements - no host-side quoting is involved.
+		argv.add(this.shellCommand.get(0));
+		argv.add("-c");
+		argv.add(PID_WRAPPER);
+		argv.add("agent-exec"); // $0 of the wrapper shell
+		argv.add(pidFile);
+		argv.addAll(this.shellCommand);
+		argv.add(spec.command());
+		return new ProcessBuilder(argv).start();
+	}
+
+	/**
+	 * Terminates the in-container process recorded in the pid file (TERM, short grace,
+	 * then KILL), removes the pid file, and finally destroys the local client process.
+	 */
+	private void killInContainer(String pidFile, Process clientProcess) {
+		signalPid(pidFile, "TERM", false);
+		try {
+			clientProcess.waitFor(2, TimeUnit.SECONDS);
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		signalPid(pidFile, "KILL", true);
+		clientProcess.destroy();
+		try {
+			if (!clientProcess.waitFor(5, TimeUnit.SECONDS)) {
+				clientProcess.destroyForcibly();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			clientProcess.destroyForcibly();
+		}
+	}
+
+	private void signalPid(String pidFile, String signal, boolean removePidFile) {
+		String script = "pid=$(cat \"" + pidFile + "\" 2>/dev/null); [ -n \"$pid\" ] && kill -" + signal
+				+ " $pid 2>/dev/null" + (removePidFile ? "; rm -f \"" + pidFile + "\"" : "") + "; true";
+		execLocal(List.of(this.dockerCommand, "exec", this.containerId, this.shellCommand.get(0), "-c", script),
+				DOCKER_CONTROL_TIMEOUT_MILLIS);
+	}
+
+	/**
+	 * Runs a local control command (never model-authored), returning [exit, out, err].
+	 */
+	private static ControlResult execLocal(List<String> argv, long timeoutMillis) {
+		try {
+			Process process = new ProcessBuilder(argv).start();
+			StringBuilder stdout = new StringBuilder();
+			StringBuilder stderr = new StringBuilder();
+			Thread outReader = drain(process.getInputStream(), stdout);
+			Thread errReader = drain(process.getErrorStream(), stderr);
+			if (!process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)) {
+				process.destroyForcibly();
+				return new ControlResult(-1, snapshot(stdout), "timed out: " + String.join(" ", argv));
+			}
+			outReader.join(1000);
+			errReader.join(1000);
+			return new ControlResult(process.exitValue(), snapshot(stdout), snapshot(stderr));
+		}
+		catch (IOException e) {
+			return new ControlResult(-1, "", e.getMessage());
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return new ControlResult(-1, "", "interrupted");
+		}
+	}
+
+	private record ControlResult(int exitCode, String stdout, String stderr) {
+	}
+
+	private static String snapshot(StringBuilder buffer) {
+		synchronized (buffer) {
+			return buffer.toString();
+		}
+	}
+
+	private static Thread drain(InputStream stream, StringBuilder target) {
+		Thread reader = new Thread(() -> {
+			try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream))) {
+				String line;
+				while ((line = bufferedReader.readLine()) != null) {
+					synchronized (target) {
+						target.append(line).append("\n");
+					}
+				}
+			}
+			catch (IOException e) {
+				// Process terminated or stream closed
+			}
+		});
+		reader.setDaemon(true);
+		reader.start();
+		return reader;
+	}
+
+	/**
+	 * Background handle over a {@code docker exec} client process. Output, liveness and
+	 * exit code come from the client (docker propagates the container command's exit
+	 * code); kill signals the recorded in-container PID first, so the process does not
+	 * survive inside the container.
+	 */
+	private final class DockerExecHandle implements ExecHandle {
+
+		private final String id;
+
+		private final Process process;
+
+		private final String pidFile;
+
+		private final StringBuilder stdout = new StringBuilder();
+
+		private final StringBuilder stderr = new StringBuilder();
+
+		private int lastStdoutPosition = 0;
+
+		private int lastStderrPosition = 0;
+
+		DockerExecHandle(String id, Process process, String pidFile) {
+			this.id = id;
+			this.process = process;
+			this.pidFile = pidFile;
+			drain(process.getInputStream(), this.stdout);
+			drain(process.getErrorStream(), this.stderr);
+		}
+
+		@Override
+		public String id() {
+			return this.id;
+		}
+
+		@Override
+		public boolean isAlive() {
+			return this.process.isAlive();
+		}
+
+		@Override
+		public String newOutput(String filterRegex) {
+			StringBuilder result = new StringBuilder();
+			synchronized (this.stdout) {
+				String newStdout = this.stdout.substring(this.lastStdoutPosition);
+				newStdout = filter(newStdout, filterRegex);
+				if (!newStdout.isEmpty()) {
+					result.append("STDOUT:\n").append(newStdout);
+				}
+				this.lastStdoutPosition = this.stdout.length();
+			}
+			synchronized (this.stderr) {
+				String newStderr = this.stderr.substring(this.lastStderrPosition);
+				newStderr = filter(newStderr, filterRegex);
+				if (!newStderr.isEmpty()) {
+					if (result.length() > 0) {
+						result.append("\n");
+					}
+					result.append("STDERR:\n").append(newStderr);
+				}
+				this.lastStderrPosition = this.stderr.length();
+			}
+			return result.toString();
+		}
+
+		@Override
+		public int exitCode() {
+			return this.process.exitValue();
+		}
+
+		@Override
+		public void kill() {
+			killInContainer(this.pidFile, this.process);
+		}
+
+	}
+
+	private static String filter(String output, String filterRegex) {
+		if (filterRegex == null || filterRegex.isEmpty() || output.isEmpty()) {
+			return output;
+		}
+		Pattern pattern = Pattern.compile(filterRegex);
+		StringBuilder filtered = new StringBuilder();
+		for (String line : output.split("\n")) {
+			if (pattern.matcher(line).find()) {
+				filtered.append(line).append("\n");
+			}
+		}
+		return filtered.toString();
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private String dockerCommand = "docker";
+
+		private String containerId;
+
+		private String image;
+
+		private Path mountHostDirectory;
+
+		private String mountContainerDirectory;
+
+		private String containerWorkingDirectory;
+
+		private final Map<String, String> environment = new HashMap<>();
+
+		private List<String> shellCommand = List.of("/bin/sh", "-c");
+
+		private Builder() {
+		}
+
+		/** Docker CLI executable. Default {@code docker}; e.g. {@code podman}. */
+		public Builder dockerCommand(String dockerCommand) {
+			this.dockerCommand = dockerCommand;
+			return this;
+		}
+
+		/**
+		 * Attach to an existing running container; the caller owns its lifecycle.
+		 * Mutually exclusive with {@link #image(String)}.
+		 */
+		public Builder containerId(String containerId) {
+			this.containerId = containerId;
+			return this;
+		}
+
+		/**
+		 * Create and manage a long-lived container from this image (removed on
+		 * {@link DockerCliExecBackend#close()} or JVM shutdown). The image needs a POSIX
+		 * shell and a {@code sleep} binary. Mutually exclusive with
+		 * {@link #containerId(String)}.
+		 */
+		public Builder image(String image) {
+			this.image = image;
+			return this;
+		}
+
+		/**
+		 * Bind-mounts a host directory into the managed container — the agent workspace.
+		 * Also becomes the default working directory for commands, and enables
+		 * {@link DockerCliExecBackend#workspace()}. Managed mode only.
+		 */
+		public Builder mount(Path hostDirectory, String containerDirectory) {
+			this.mountHostDirectory = hostDirectory;
+			this.mountContainerDirectory = containerDirectory;
+			return this;
+		}
+
+		/** Working directory for executed commands. Default: the mount target, if any. */
+		public Builder containerWorkingDirectory(String containerWorkingDirectory) {
+			this.containerWorkingDirectory = containerWorkingDirectory;
+			return this;
+		}
+
+		/** Environment variables set for every executed command. */
+		public Builder environment(Map<String, String> environment) {
+			if (environment != null) {
+				this.environment.putAll(environment);
+			}
+			return this;
+		}
+
+		/** In-container shell. Default {@code /bin/sh -c}; must be POSIX-compatible. */
+		public Builder shellCommand(String... shellCommand) {
+			this.shellCommand = List.of(shellCommand);
+			return this;
+		}
+
+		/**
+		 * Builds the backend. In managed mode this creates and starts the container
+		 * (pulling the image if needed) and fails with {@link IllegalStateException} on
+		 * any docker error.
+		 */
+		public DockerCliExecBackend build() {
+			if ((this.containerId == null) == (this.image == null)) {
+				throw new IllegalStateException("Set exactly one of containerId (attach) or image (managed)");
+			}
+			if (this.shellCommand.size() < 2) {
+				throw new IllegalStateException("shellCommand must be a shell plus its command flag, e.g. /bin/sh -c");
+			}
+			if (this.mountHostDirectory != null && this.image == null) {
+				throw new IllegalStateException(
+						"mount(...) requires image(...) - an attached container's mounts are fixed");
+			}
+			Path mountHost = (this.mountHostDirectory != null) ? this.mountHostDirectory.toAbsolutePath().normalize()
+					: null;
+			String workDir = this.containerWorkingDirectory;
+			if (workDir == null && this.mountContainerDirectory != null) {
+				workDir = this.mountContainerDirectory;
+			}
+			String container = this.containerId;
+			boolean managed = false;
+			if (this.image != null) {
+				container = createContainer(mountHost, workDir);
+				managed = true;
+			}
+			return new DockerCliExecBackend(this.dockerCommand, container, managed, workDir,
+					Map.copyOf(this.environment), this.shellCommand, mountHost, this.mountContainerDirectory);
+		}
+
+		private String createContainer(Path mountHost, String workDir) {
+			// Deterministic name so both failure branches can clean up: when 'docker
+			// run -d' fails to *start* the container, the daemon may still have
+			// *created* it, and its id is not reliably reported.
+			String name = "agent-exec-" + Long.toUnsignedString(System.currentTimeMillis(), 36) + "-"
+					+ HANDLE_SEQUENCE.incrementAndGet();
+			List<String> argv = new ArrayList<>(List.of(this.dockerCommand, "run", "-d", "--name", name, "--label",
+					CONTAINER_LABEL + "=" + CONTAINER_LABEL_VALUE));
+			if (mountHost != null) {
+				argv.add("-v");
+				argv.add(mountHost + ":" + this.mountContainerDirectory);
+			}
+			if (workDir != null) {
+				argv.add("-w");
+				argv.add(workDir);
+			}
+			// Keep-alive entrypoint; ~68 years, portable across sh/busybox images
+			argv.add("--entrypoint");
+			argv.add("sleep");
+			argv.add(this.image);
+			argv.add("2147483647");
+			ControlResult result = execLocal(argv, CONTAINER_CREATE_TIMEOUT_MILLIS);
+			if (result.exitCode() != 0) {
+				execLocal(List.of(this.dockerCommand, "rm", "-f", name), DOCKER_CONTROL_TIMEOUT_MILLIS);
+				throw new IllegalStateException("Failed to create container from image '" + this.image + "': "
+						+ (result.stderr().isBlank() ? result.stdout() : result.stderr()).trim());
+			}
+			String container = result.stdout().trim();
+			// Fail fast on a container that died right after starting (e.g. an image
+			// whose sleep rejects the keep-alive argument) instead of surfacing
+			// confusing daemon errors on every later command.
+			try {
+				Thread.sleep(250);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			ControlResult inspect = execLocal(
+					List.of(this.dockerCommand, "inspect", "-f", "{{.State.Running}}", container),
+					DOCKER_CONTROL_TIMEOUT_MILLIS);
+			if (!"true".equals(inspect.stdout().trim())) {
+				execLocal(List.of(this.dockerCommand, "rm", "-f", container), DOCKER_CONTROL_TIMEOUT_MILLIS);
+				throw new IllegalStateException("Container from image '" + this.image
+						+ "' is not running - the image must provide a POSIX shell and a 'sleep' binary "
+						+ "(e.g. alpine, busybox, debian; distroless images do not qualify)");
+			}
+			return container;
+		}
+
+	}
+
+}

--- a/exec-backends/spring-ai-agent-utils-docker-cli/src/main/java/org/springaicommunity/agent/exec/docker/package-info.java
+++ b/exec-backends/spring-ai-agent-utils-docker-cli/src/main/java/org/springaicommunity/agent/exec/docker/package-info.java
@@ -1,0 +1,22 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+ * Docker execution backend for the {@code ExecBackend} SPI, driven through the
+ * {@code docker} CLI: model-authored shell commands run inside a container (managed or
+ * attached), with a bind-mounted host directory as the agent workspace.
+ */
+package org.springaicommunity.agent.exec.docker;

--- a/exec-backends/spring-ai-agent-utils-docker-cli/src/test/java/org/springaicommunity/agent/exec/docker/DockerCliExecBackendTest.java
+++ b/exec-backends/spring-ai-agent-utils-docker-cli/src/test/java/org/springaicommunity/agent/exec/docker/DockerCliExecBackendTest.java
@@ -1,0 +1,305 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.exec.docker;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springaicommunity.agent.common.exec.ExecHandle;
+import org.springaicommunity.agent.common.exec.ExecResult;
+import org.springaicommunity.agent.common.exec.ExecSpec;
+import org.springaicommunity.agent.common.workspace.Workspace;
+import org.springaicommunity.agent.tools.ShellTools;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration tests for {@link DockerCliExecBackend} against a real Docker daemon. The
+ * whole suite is skipped when the {@code docker} CLI or daemon is unavailable (JUnit
+ * assumption), so builds without Docker stay green.
+ *
+ * @author Christian Tzolov
+ */
+class DockerCliExecBackendTest {
+
+	private static final String IMAGE = "alpine:3.20";
+
+	private static final String CONTAINER_WORKSPACE = "/workspace";
+
+	@TempDir
+	static Path hostWorkspace;
+
+	private static DockerCliExecBackend backend;
+
+	@BeforeAll
+	static void createSharedContainer() {
+		Assumptions.assumeTrue(dockerAvailable(), "Docker CLI/daemon not available - skipping Docker backend tests");
+		backend = DockerCliExecBackend.builder().image(IMAGE).mount(hostWorkspace, CONTAINER_WORKSPACE).build();
+	}
+
+	@AfterAll
+	static void removeSharedContainer() {
+		if (backend != null) {
+			backend.close();
+		}
+	}
+
+	private static boolean dockerAvailable() {
+		try {
+			Process process = new ProcessBuilder("docker", "version", "--format", "{{.Server.Version}}").start();
+			return process.waitFor(15, TimeUnit.SECONDS) && process.exitValue() == 0;
+		}
+		catch (IOException e) {
+			return false;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+	}
+
+	@Test
+	void commandsRunInsideTheContainerNotOnTheHost() {
+		ExecResult result = backend.run(ExecSpec.of("cat /etc/os-release"));
+
+		assertThat(result.status()).isEqualTo(ExecResult.Status.COMPLETED);
+		assertThat(result.exitCode()).isZero();
+		assertThat(result.stdout()).contains("Alpine");
+	}
+
+	@Test
+	void exitCodeAndStderrPropagateFromTheContainer() {
+		ExecResult result = backend.run(ExecSpec.of("echo boom >&2; exit 7"));
+
+		assertThat(result.status()).isEqualTo(ExecResult.Status.COMPLETED);
+		assertThat(result.exitCode()).isEqualTo(7);
+		assertThat(result.stderr()).contains("boom");
+	}
+
+	@Test
+	void perSpecEnvironmentVariablesAreApplied() {
+		ExecResult result = backend
+			.run(new ExecSpec("printf %s \"$GREETING\"", 0, Map.of("GREETING", "hola contenedor")));
+
+		assertThat(result.exitCode()).isZero();
+		assertThat(result.stdout().trim()).isEqualTo("hola contenedor");
+	}
+
+	@Test
+	void workingDirectoryDefaultsToTheMountTarget() {
+		ExecResult result = backend.run(ExecSpec.of("pwd"));
+
+		assertThat(result.stdout().trim()).isEqualTo(CONTAINER_WORKSPACE);
+	}
+
+	@Test
+	void bindMountRoundTripsBetweenHostAndContainer() throws Exception {
+		Files.writeString(hostWorkspace.resolve("from-host.txt"), "written on host\n");
+
+		ExecResult read = backend.run(ExecSpec.of("cat /workspace/from-host.txt"));
+		assertThat(read.stdout()).contains("written on host");
+
+		ExecResult write = backend.run(ExecSpec.of("printf 'written in container' > /workspace/from-container.txt"));
+		assertThat(write.exitCode()).isZero();
+		assertThat(Files.readString(hostWorkspace.resolve("from-container.txt"))).isEqualTo("written in container");
+	}
+
+	@Test
+	void timeoutKillsTheProcessInsideTheContainer() {
+		ExecResult result = backend.run(new ExecSpec("sleep 600", 1500, Map.of()));
+
+		assertThat(result.status()).isEqualTo(ExecResult.Status.TIMED_OUT);
+		ExecResult ps = backend.run(ExecSpec.of("ps"));
+		assertThat(ps.stdout()).doesNotContain("sleep 600");
+	}
+
+	@Test
+	void backgroundHandleStreamsOutputAndKillReachesIntoTheContainer() throws Exception {
+		ExecHandle handle = backend
+			.start(ExecSpec.of("i=0; while true; do i=$((i+1)); echo tick-$i-end; sleep 1; done"));
+
+		assertThat(handle.id()).startsWith("docker_");
+		String first = awaitOutput(handle, "tick-1-end");
+		assertThat(first).contains("tick-1-end");
+
+		handle.kill();
+		long deadline = System.currentTimeMillis() + 5000;
+		while (handle.isAlive() && System.currentTimeMillis() < deadline) {
+			Thread.sleep(100);
+		}
+		assertThat(handle.isAlive()).isFalse();
+
+		ExecResult ps = backend.run(ExecSpec.of("ps"));
+		assertThat(ps.stdout()).doesNotContain("tick-");
+
+		// Cursor semantics: consumed output is not returned again
+		assertThat(handle.newOutput(null)).doesNotContain("tick-1-end");
+	}
+
+	@Test
+	void workspaceMapsHostPathsToContainerPaths() {
+		Workspace workspace = backend.workspace();
+
+		assertThat(workspace.root()).isEqualTo(hostWorkspace.toAbsolutePath().normalize());
+		assertThat(workspace.display(hostWorkspace.resolve("skills").resolve("pdf")))
+			.isEqualTo("/workspace/skills/pdf");
+		assertThat(workspace.display(hostWorkspace)).isEqualTo(CONTAINER_WORKSPACE);
+		assertThat(workspace.display("/somewhere/else")).isEqualTo("/somewhere/else");
+	}
+
+	@Test
+	void shellToolsRunEndToEndOverTheDockerBackend() {
+		ShellTools shellTools = ShellTools.builder().execBackend(backend).build();
+
+		String result = shellTools.bash("echo running in $(pwd) on $(. /etc/os-release; echo $ID)", null, null, null);
+
+		assertThat(result).contains("running in /workspace on alpine");
+	}
+
+	@Test
+	void attachModeExecutesInAnExistingContainer() {
+		try (DockerCliExecBackend attached = DockerCliExecBackend.builder()
+			.containerId(backend.containerId())
+			.containerWorkingDirectory("/tmp")
+			.build()) {
+
+			ExecResult result = attached.run(ExecSpec.of("pwd"));
+			assertThat(result.stdout().trim()).isEqualTo("/tmp");
+		}
+
+		// close() of an attached backend must not remove the caller-owned container
+		assertThat(backend.run(ExecSpec.of("echo still-alive")).stdout()).contains("still-alive");
+	}
+
+	@Test
+	void closeRemovesTheManagedContainer() {
+		DockerCliExecBackend own = DockerCliExecBackend.builder().image(IMAGE).build();
+		String containerId = own.containerId();
+
+		own.close();
+
+		ExecResult result = own.run(ExecSpec.of("echo hi"));
+		assertThat(result.status()).isEqualTo(ExecResult.Status.LAUNCH_FAILED);
+		assertThat(containerGone(containerId)).isTrue();
+	}
+
+	@Test
+	void missingDockerCliReportsLaunchFailure() {
+		DockerCliExecBackend broken = DockerCliExecBackend.builder()
+			.dockerCommand("definitely-not-a-docker-cli")
+			.containerId("irrelevant")
+			.build();
+
+		ExecResult result = broken.run(ExecSpec.of("echo hi"));
+
+		assertThat(result.status()).isEqualTo(ExecResult.Status.LAUNCH_FAILED);
+	}
+
+	@Test
+	void missingContainerSurfacesTheDockerError() {
+		try (DockerCliExecBackend gone = DockerCliExecBackend.builder().containerId("no-such-container-xyz").build()) {
+
+			ExecResult result = gone.run(ExecSpec.of("echo hi"));
+
+			assertThat(result.status()).isEqualTo(ExecResult.Status.COMPLETED);
+			assertThat(result.exitCode()).isNotZero();
+			assertThat(result.stderr()).isNotBlank();
+		}
+	}
+
+	@Test
+	void imageWithoutSleepFailsAtBuildNotAtFirstCommand() {
+		// hello-world has no shell and no sleep binary - the managed container cannot
+		// be kept alive, and build() must say so instead of leaving every later
+		// command to fail with a confusing daemon error
+		assertThatThrownBy(() -> DockerCliExecBackend.builder().image("hello-world").build())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("hello-world");
+
+		// The failed build must not leave a 'Created' container corpse behind
+		assertThat(noContainersFromImage("hello-world")).isTrue();
+	}
+
+	private static boolean noContainersFromImage(String image) {
+		try {
+			Process process = new ProcessBuilder("docker", "ps", "-a", "-q", "--filter", "ancestor=" + image).start();
+			String output = new String(process.getInputStream().readAllBytes());
+			process.waitFor(10, TimeUnit.SECONDS);
+			return output.isBlank();
+		}
+		catch (IOException e) {
+			return false;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+	}
+
+	@Test
+	void builderRejectsInvalidConfigurations() {
+		assertThatThrownBy(() -> DockerCliExecBackend.builder().build()).isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("exactly one");
+		assertThatThrownBy(() -> DockerCliExecBackend.builder().containerId("c").image("i").build())
+			.isInstanceOf(IllegalStateException.class);
+		assertThatThrownBy(
+				() -> DockerCliExecBackend.builder().containerId("c").mount(hostWorkspace, "/workspace").build())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("mount");
+		assertThatThrownBy(() -> DockerCliExecBackend.builder().containerId("c").build().workspace())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("mount");
+	}
+
+	private static String awaitOutput(ExecHandle handle, String expected) throws InterruptedException {
+		StringBuilder seen = new StringBuilder();
+		long deadline = System.currentTimeMillis() + 10_000;
+		while (System.currentTimeMillis() < deadline) {
+			seen.append(handle.newOutput(null));
+			if (seen.toString().contains(expected)) {
+				return seen.toString();
+			}
+			Thread.sleep(200);
+		}
+		return seen.toString();
+	}
+
+	private static boolean containerGone(String containerId) {
+		try {
+			Process process = new ProcessBuilder("docker", "ps", "-a", "-q", "--filter", "id=" + containerId).start();
+			String output = new String(process.getInputStream().readAllBytes());
+			process.waitFor(10, TimeUnit.SECONDS);
+			return output.isBlank();
+		}
+		catch (IOException e) {
+			return false;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+	}
+
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,12 @@ nav:
   - Multi-Agent:
     - Task Tools: tools/TaskTools.md
     - Subagent Framework: tools/Subagent.md
+  - Execution Backends:
+    - Workspace & Exec SPI: tools/WorkspaceAndExecSPI.md
+    - DockerCliExecBackend: tools/DockerCliExecBackend.md
   - Migration:
+    - 0.11.0 to 0.12.0: tools/migration-0.12.md
+    - 0.7.x to 0.9.0: tools/migration-0.9.md
     - 0.4.x to 0.5.0: tools/migration-0.5.md
 
 markdown_extensions:

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
         <module>spring-ai-agent-utils-common</module>
         <module>spring-ai-agent-utils</module>
         <module>spring-ai-agent-utils-a2a</module>
+        <module>exec-backends</module>
         <module>spring-ai-agent-utils-bom</module>
         <module>examples</module>
     </modules>
@@ -273,7 +274,7 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <excludeArtifacts>
-                                spring-ai-agent-utils-parent,examples-parent,travel-planner-demo-parent
+                                spring-ai-agent-utils-parent,spring-ai-agent-utils-exec-backends,examples-parent,travel-planner-demo-parent
                             </excludeArtifacts>
                             <autoPublish>true</autoPublish>
                         </configuration>

--- a/spring-ai-agent-utils-bom/pom.xml
+++ b/spring-ai-agent-utils-bom/pom.xml
@@ -94,6 +94,12 @@
 				<artifactId>spring-ai-agent-utils-a2a</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+
+			<dependency>
+				<groupId>org.springaicommunity</groupId>
+				<artifactId>spring-ai-agent-utils-docker-cli</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 		</dependencies>
 
 	</dependencyManagement>

--- a/spring-ai-agent-utils/docs/DockerCliExecBackend.md
+++ b/spring-ai-agent-utils/docs/DockerCliExecBackend.md
@@ -1,0 +1,84 @@
+# DockerCliExecBackend - Sandboxed Command Execution
+
+`DockerCliExecBackend` is an `ExecBackend` implementation (module `spring-ai-agent-utils-docker-cli`) that runs model-authored shell commands inside a Docker container instead of on the host JVM. It drives Docker through the `docker` CLI — no Java Docker client dependency — so contexts, credential helpers and non-standard daemon sockets are resolved exactly as in your terminal, and any CLI-compatible runtime works (Docker Desktop, Colima, podman via `podman-docker`).
+
+```xml
+<dependency>
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-agent-utils-docker-cli</artifactId>
+</dependency>
+```
+
+## The full sandbox recipe
+
+The headline use case: one managed container per agent/session, a bind-mounted host directory as the workspace, and the whole toolset wired from two objects:
+
+```java
+Path hostWorkspace = Files.createTempDirectory("agent-session");
+
+try (DockerCliExecBackend backend = DockerCliExecBackend.builder()
+        .image("eclipse-temurin:17-jdk-alpine")       // needs a POSIX shell + sleep
+        .mount(hostWorkspace, "/workspace")           // the agent workspace
+        .build()) {
+
+    Workspace workspace = backend.workspace();        // host root + /workspace display mapping
+
+    // Shell commands execute inside the container
+    ShellTools shell = ShellTools.builder().execBackend(backend).build();
+
+    // File/search tools operate host-side through the mount, confined to it
+    FileSystemTools files = FileSystemTools.builder().workspace(workspace).build();
+    GrepTool grep = GrepTool.builder().workspace(workspace).build();
+    GlobTool glob = GlobTool.builder().workspace(workspace).build();
+
+    // Skill base directories and environment prompts show container paths
+    ToolCallback skills = SkillsTool.builder()
+        .addSkillsDirectory(hostWorkspace.resolve("skills").toString())
+        .workspace(workspace)
+        .build();
+    String envInfo = AgentEnvironment.info(workspace);
+    String gitStatus = AgentEnvironment.gitStatus(backend);   // git runs in the container
+}
+```
+
+Every path the model sees is a container path; every command the model writes runs in the container; every file the model touches stays inside the mount. No tool code changes.
+
+## Two modes
+
+**Managed container** — `image(...)` creates a long-lived container (kept alive with a `sleep` entrypoint) and owns its lifecycle:
+
+```java
+DockerCliExecBackend backend = DockerCliExecBackend.builder()
+    .image("alpine:3.20")
+    .mount(hostDir, "/workspace")                 // optional; enables workspace()
+    .containerWorkingDirectory("/workspace")      // default: the mount target
+    .environment(Map.of("LANG", "C"))             // env vars for every command
+    .shellCommand("/bin/bash", "-c")              // default: /bin/sh -c
+    .dockerCommand("podman")                      // default: docker
+    .build();
+...
+backend.close();                                  // docker rm -f
+```
+
+`close()` removes the container. A JVM shutdown hook does the same if `close()` never runs, and managed containers carry the label `org.springaicommunity.agent.exec-backend=docker-cli`, so stragglers from crashed JVMs can be swept with:
+
+```bash
+docker rm -f $(docker ps -aq --filter label=org.springaicommunity.agent.exec-backend=docker-cli)
+```
+
+**Attached container** — `containerId(...)` executes in an existing running container whose lifecycle you own (Kubernetes sidecar, compose service, testcontainer). `close()` is a no-op; `mount(...)` is not available (an existing container's mounts are fixed), so `workspace()` requires managed mode.
+
+## Semantics and caveats
+
+- **Exit codes and streams** — `docker exec` propagates the container command's exit code and separate stdout/stderr, so `ExecResult` looks exactly as with `LocalExecBackend`. Docker-level failures (container not running, daemon down) surface as exit codes 125–127 with the CLI error on stderr.
+- **Timeout and kill reach into the container.** Killing the client `docker exec` process does not kill the in-container process (a Docker limitation), so every command is wrapped to record its in-container PID under `/tmp`; timeouts and `KillShell` signal that PID (TERM, then KILL after a grace period) inside the container. Processes the command itself detaches into the background may survive — same caveat as the local backend.
+- **Background shells** (`BashOutput`/`KillShell`) get handle ids in the `docker_<n>` namespace and stream incremental output with the same cursor semantics as local shells.
+- **Image requirements** — a POSIX shell at the configured `shellCommand` path and a `sleep` binary (managed mode keep-alive); `alpine`, `busybox`, `debian`, `eclipse-temurin` images all qualify, distroless images do not. `build()` fails fast with a clear message when the managed container cannot start or dies immediately. The in-container kill mechanism also needs a writable `/tmp` for its PID files — on a read-only rootfs commands still run, but timeout/kill degrade to destroying only the client `docker exec` process.
+- **Runtime requirement** — the `docker` CLI must be on the JVM's PATH. If the JVM itself runs in a container, mount the Docker socket and install the CLI, or attach to a pre-created container instead.
+
+## See also
+
+- [Workspace & Exec SPI](WorkspaceAndExecSPI.md) — overview of the two seams this backend implements
+- [ShellTools](ShellTools.md#execution-backend--working-directory) — the `ExecBackend` seam this plugs into
+- [AgentEnvironment](AgentEnvironment.md) — workspace/backend-aware environment prompts
+- [FileSystemTools](FileSystemTools.md) / [GrepTool](GrepTool.md) / [GlobTool](GlobTool.md) — workspace confinement for the host-side file tools

--- a/spring-ai-agent-utils/docs/ShellTools.md
+++ b/spring-ai-agent-utils/docs/ShellTools.md
@@ -232,7 +232,8 @@ String killResult = shellTools.killShell("shell_1234567890");
 `spring-ai-agent-utils-common`, package `org.springaicommunity.agent.common.exec`).
 The default `LocalExecBackend` runs processes on the host JVM; alternative
 implementations can execute inside a container or on a remote worker without any
-tool changes.
+tool changes — see [DockerCliExecBackend](DockerCliExecBackend.md) for the
+Docker-based sandbox backend.
 
 ```java
 // Confine local execution to a workspace directory (per session/agent)

--- a/spring-ai-agent-utils/docs/WorkspaceAndExecSPI.md
+++ b/spring-ai-agent-utils/docs/WorkspaceAndExecSPI.md
@@ -1,0 +1,88 @@
+# Workspace & Exec SPI - Sandboxing Overview
+
+The agent tools are decoupled from the host machine through two small SPIs in `spring-ai-agent-utils-common`. Together they answer the two questions any sandboxed agent deployment has to answer:
+
+| Seam | Package | Question it answers |
+|------|---------|---------------------|
+| **`ExecBackend`** | `org.springaicommunity.agent.common.exec` | *Where do shell commands run?* |
+| **`Workspace`** | `org.springaicommunity.agent.common.workspace` | *Where do files live, and how are paths shown to the model?* |
+
+Tools describe **what** to do; the backend and workspace decide **where and how**. Swapping the host for a container changes configuration, never tool code.
+
+## ExecBackend — where commands run
+
+```java
+public interface ExecBackend {
+    ExecResult run(ExecSpec spec);      // synchronous, honors the spec's timeout
+    ExecHandle start(ExecSpec spec);    // background: poll output, kill
+}
+```
+
+- **`ExecSpec`** — the command line as the model authored it, a wall-clock timeout (policy owned by the spec: default 2 min, capped at 10 min), and per-invocation environment variables. Shell selection and working directory are deliberately *backend* concerns.
+- **`ExecResult`** — status (`COMPLETED`, `TIMED_OUT`, `LAUNCH_FAILED`, `INTERRUPTED`), exit code, separate stdout/stderr. Failures are reported, never thrown.
+- **`ExecHandle`** — a background command: `isAlive()`, cursor-based `newOutput(filter)` (each call returns only output produced since the last one), `exitCode()`, `kill()` (graceful, then forced).
+
+**Who uses it:** [ShellTools](ShellTools.md) routes `Bash`/`BashOutput`/`KillShell` through the configured backend, and [AgentEnvironment](AgentEnvironment.md) runs its git-status commands through it, so a sandboxed agent reports the sandbox's view of the repository.
+
+**Implementations:**
+
+| Implementation | Module | Runs commands |
+|---|---|---|
+| `LocalExecBackend` (default) | `spring-ai-agent-utils` | On the host JVM, with working directory, clean-environment mode and shell selection |
+| [`DockerCliExecBackend`](DockerCliExecBackend.md) | `spring-ai-agent-utils-docker-cli` | Inside a Docker container, via the `docker` CLI |
+
+Custom implementations are a small class: implement `run` (and `start` if you support background shells — throwing `UnsupportedOperationException` there is acceptable for remote/queued executors). An adapter over [agent-sandbox](https://github.com/spring-ai-community/agent-sandbox)'s `Sandbox.exec()` is straightforward for the synchronous path — the shapes are compatible.
+
+## Workspace — where files live, and what the model sees
+
+```java
+@FunctionalInterface
+public interface Workspace {
+    Path root();                                     // host-side root directory
+    default String display(String hostPath) { ... }  // host path -> model-visible path
+    static Workspace local(Path root) { ... }        // identity display
+}
+```
+
+A workspace is a root directory plus a *display mapping*. For local execution the mapping is the identity; for a container with a bind-mounted workspace it rewrites host paths to their in-container form, so the model is never shown a path its shell cannot use.
+
+**Who uses it** — one `workspace(...)` call per tool builder, with per-tool semantics:
+
+| Tool | `workspace(...)` effect |
+|---|---|
+| [GrepTool](GrepTool.md) / [GlobTool](GlobTool.md) / ListDirectoryTool | Working directory **and** allowed-directory confinement |
+| [FileSystemTools](FileSystemTools.md) | Allowed-directory confinement |
+| [ShellTools](ShellTools.md) | Working directory only (a shell can't be confined from Java — that's what a sandboxed `ExecBackend` is for) |
+| [SkillsTool](SkillsTool.md) | Announces skill base directories via `display(...)` |
+| [AgentEnvironment](AgentEnvironment.md) | Environment-info block describes the workspace, not the host |
+
+## How the two compose
+
+The file/search tools run **host-side**, confined to the workspace root; shell commands run **in the backend**. With a bind mount connecting the two, both operate on the same files and the model sees one consistent world:
+
+```java
+try (DockerCliExecBackend backend = DockerCliExecBackend.builder()
+        .image("alpine:3.20")
+        .mount(hostDir, "/workspace")
+        .build()) {
+
+    Workspace workspace = backend.workspace();   // hostDir root, /workspace display
+
+    ShellTools shell = ShellTools.builder().execBackend(backend).build();
+    FileSystemTools files = FileSystemTools.builder().workspace(workspace).build();
+    GrepTool grep = GrepTool.builder().workspace(workspace).build();
+    String envInfo = AgentEnvironment.info(workspace);
+}
+```
+
+See [DockerCliExecBackend](DockerCliExecBackend.md) for the complete recipe and its operational caveats.
+
+## Module map
+
+| Module | Contents |
+|---|---|
+| `spring-ai-agent-utils-common` | The SPIs: `ExecBackend`, `ExecSpec`, `ExecResult`, `ExecHandle`, `Workspace` — the `exec` and `workspace` packages are plain JDK, so backend implementations need no Spring on their classpath |
+| `spring-ai-agent-utils` | The tools plus `LocalExecBackend` (host default) |
+| `exec-backends/spring-ai-agent-utils-docker-cli` | `DockerCliExecBackend` (Docker sandbox) |
+
+The `exec-backends/` folder is the home for further backend implementations as they land.

--- a/spring-ai-agent-utils/docs/migration-0.12.md
+++ b/spring-ai-agent-utils/docs/migration-0.12.md
@@ -1,0 +1,70 @@
+# Migration Guide: 0.11.0 to 0.12.0
+
+This release introduces the sandboxing foundation: the `ExecBackend` and `Workspace` SPIs, directory confinement for the search tools, and the `spring-ai-agent-utils-docker-cli` module. **There are no breaking API changes** — all existing code compiles and runs unchanged. There is **one behavioral change** to review (background shells) and a few output-level changes worth knowing about.
+
+## Dependency Version
+
+```xml
+<dependency>
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>spring-ai-agent-utils</artifactId>
+    <version>0.12.0</version>
+</dependency>
+```
+
+The Spring AI dependency is unchanged (2.0.1).
+
+## Behavioral change: background shells are per-instance
+
+In 0.11.0 the background-shell registry was JVM-global: any `ShellTools` instance could read (`BashOutput`) or kill (`KillShell`) a shell started through any other instance. In 0.12.0 each `ShellTools` instance owns its background shells — separate instances have separate shell namespaces.
+
+This is the right default (separate agents/sessions no longer see each other's shells), but if you relied on cross-instance visibility, those lookups now return `Error: No background shell found with ID ...` with no compile-time signal.
+
+**Before (0.11.0 — worked by accident of the global registry):**
+
+```java
+ShellTools agentA = ShellTools.builder().build();
+ShellTools agentB = ShellTools.builder().build();
+// agentB could read/kill shells started by agentA
+```
+
+**After (0.12.0 — share one instance where shared visibility is intended):**
+
+```java
+ShellTools shared = ShellTools.builder().build();
+// register the same instance with both agents
+```
+
+Note: Claude subagents already share the single `ShellTools` created by `ClaudeSubagentType`, so they keep a shared namespace without changes.
+
+## Deprecations
+
+Move off the deprecated no-argument constructors to the builders — they now carry the configuration that matters (execution backend, working directory, confinement):
+
+```java
+// Before
+ShellTools shell = new ShellTools();
+GrepTool grep = new GrepTool();
+
+// After
+ShellTools shell = ShellTools.builder().workingDirectory(workDir).build();
+GrepTool grep = GrepTool.builder().workingDirectory(workDir).build();
+```
+
+## Output-level changes (no code impact)
+
+These change what the model (or a log reader) sees, not any API:
+
+- **`AgentEnvironment.gitStatus()`** no longer leaks git error text into the rendered block. Previously, in a repository with no local `main`/`master` and no `origin/HEAD` symref, the "Main branch" line could contain a literal `fatal: ...` message; failed git commands now contribute empty strings and the main-branch detection falls back to `main`. Git commands also run through the `ExecBackend` SPI (platform shell) instead of a private `ProcessBuilder`.
+- **`FileSystemTools.read`** header says `Showing lines 1-N of at least M` when the line limit truncates the read, instead of implying the file was fully counted.
+- **`Bash` with a blank command** returns `Error: command must not be blank` instead of spawning a shell.
+- Synchronous `Bash` run ids moved to their own `shell_run_<n>` namespace so they can never collide with background shell ids.
+
+## New in 0.12.0 (opt-in, no migration required)
+
+- **`ExecBackend` SPI** (`org.springaicommunity.agent.common.exec`) — pluggable command execution; `ShellTools.builder().execBackend(...)` and `AgentEnvironment.gitStatus(ExecBackend)`. `LocalExecBackend` (the default) adds `workingDirectory`, `cleanEnvironment` and `shellCommand` options.
+- **`Workspace` SPI** (`org.springaicommunity.agent.common.workspace`) — root directory + host-to-model path display; one-call `workspace(...)` option on the tool builders, `SkillsTool` base-path mapping, `AgentEnvironment.info(Workspace)`.
+- **Directory confinement for search tools** — `allowedDirectory(...)` on `GrepTool`, `GlobTool` and `ListDirectoryTool`, sharing the FileSystemTools jail semantics. Note: when confinement is configured, directory traversal does **not** follow symbolic links (unconfined behavior is unchanged).
+- **`spring-ai-agent-utils-docker-cli`** — a Docker `ExecBackend` running commands in a sandbox container (new `exec-backends/` module group, managed by the BOM).
+
+See [Workspace & Exec SPI](WorkspaceAndExecSPI.md) for the overview and [DockerCliExecBackend](DockerCliExecBackend.md) for the full sandbox recipe.


### PR DESCRIPTION
Introduce exec-backends/, a new module group for ExecBackend implementations, with spring-ai-agent-utils-docker-cli as its first member: an ExecBackend that runs model-authored commands inside a Docker container, driven through the docker CLI (no Java Docker client dependency; contexts, credential helpers and daemon sockets resolve as in the user's terminal, so Docker Desktop, Colima and podman all work).

- Managed mode: image(...) creates a named, labeled, long-lived container (sleep entrypoint); build() fails fast when the image cannot keep the container alive and cleans up either way; close(), a JVM shutdown hook and the docker label guard against orphans
- Attached mode: containerId(...) executes in an existing container whose lifecycle the caller owns
- Timeout and kill reach into the container: every command is wrapped to record its in-container PID, which TERM/KILL signalling targets — killing only the docker exec client would leak the process
- Background handles (docker_<n> namespace) stream incremental output with the same cursor semantics as LocalExecBackend
- workspace() exposes the bind mount as a Workspace (host root, container-path display), wiring ShellTools, the confined file/search tools, SkillsTool and AgentEnvironment together for the full sandbox recipe with no tool changes
- Docs: new "Execution Backends" section with a Workspace & Exec SPI overview page and the DockerCliExecBackend guide, plus the 0.11.0 -> 0.12.0 migration guide (both mirrors), mkdocs nav and README
- Integration tests run against a real daemon and skip cleanly when Docker is unavailable; registered in the parent reactor, BOM and the release profile's aggregator exclusions