### PR TITLE
Add InterruptAdvisor and ToolCallListener for agent loop control

### DIFF
--- a/docs/tools/InterruptAdvisor.md
+++ b/docs/tools/InterruptAdvisor.md
@@ -1,0 +1,62 @@
+# InterruptAdvisor - Cancelling In-Flight Turns
+
+`InterruptAdvisor` adds cooperative cancellation to the agentic tool-calling loop. Once `ChatClient.call()` enters the loop, it normally runs to completion — a UI "stop" button, a session-level interrupt event, or a budget guard has no seam to abort it. This advisor is that seam.
+
+## How it works
+
+The advisor polls an application-supplied `BooleanSupplier` in its `before()` hook. Its default order (`HIGHEST_PRECEDENCE + 400`) places it just *inside* the auto-registered tool-calling advisor (`HIGHEST_PRECEDENCE + 300`), so the check re-runs on **every tool-call round**: an interrupt raised while tools execute lands before the next model request, not only between turns.
+
+When the signal reports true, the turn unwinds with a `TurnInterruptedException` — the caller catches it and decides what an interrupted turn means (discard, partial save, quiet end-of-turn).
+
+## Usage
+
+```java
+AtomicBoolean interrupted = new AtomicBoolean();
+
+ChatClient chatClient = chatClientBuilder
+    .defaultAdvisors(memoryAdvisor,
+            InterruptAdvisor.builder().interruptSignal(interrupted::get).build())
+    .defaultTools(tools)
+    .build();
+
+// From another thread (REST handler, UI event, watchdog):
+interrupted.set(true);
+
+// The worker loop:
+try {
+    String content = chatClient.prompt().user(text).call().content();
+}
+catch (TurnInterruptedException ex) {
+    interrupted.set(false);      // re-arm for the next turn
+    // e.g. end the turn quietly with stop_reason "end_turn"
+}
+```
+
+The signal isn't limited to a flag — any cheap, thread-safe check works:
+
+```java
+// Wall-clock guard: cancel turns that run past a deadline
+Instant deadline = Instant.now().plus(Duration.ofMinutes(5));
+InterruptAdvisor.builder().interruptSignal(() -> Instant.now().isAfter(deadline)).build();
+```
+
+## Streaming
+
+With `stream()` the check runs inside the reactive pipeline, so the `TurnInterruptedException` arrives as the Flux's **error signal** rather than a synchronous throw:
+
+```java
+chatClient.prompt().user(text).stream().content()
+    .onErrorResume(TurnInterruptedException.class, ex -> Flux.empty())
+    .subscribe(...);
+```
+
+## Configuration
+
+| Builder option | Default | Notes |
+|---|---|---|
+| `interruptSignal(BooleanSupplier)` | required | Polled before each model request; must be cheap and thread-safe |
+| `order(int)` | `HIGHEST_PRECEDENCE + 400` | Orders below the tool-calling advisor's `+300` check only once per turn |
+
+## See also
+
+- [ToolCallListener](ToolCallListener.md) — observe the tool calls of the same loop

--- a/docs/tools/ToolCallListener.md
+++ b/docs/tools/ToolCallListener.md
@@ -1,0 +1,45 @@
+# ToolCallListener - Observing Tool Invocations
+
+`ToolCallListener` + `ToolCallListeners` let an application observe every tool invocation without hand-rolling a `ToolCallback` decorator: audit/event logs (e.g. `tool_use`/`tool_result` event pairs), SSE progress streaming to a UI, per-call metrics.
+
+## Usage
+
+```java
+ToolCallListener listener = new ToolCallListener() {
+
+    @Override
+    public Object beforeCall(String toolName, String toolInput) {
+        // Returned value is the correlation context for this invocation
+        return eventLog.append("agent.tool_use", Map.of("name", toolName, "input", toolInput)).id();
+    }
+
+    @Override
+    public void afterCall(Object context, String toolName, String toolInput, String result) {
+        eventLog.append("agent.tool_result",
+                Map.of("tool_use_id", context, "name", toolName, "content", result, "is_error", false));
+    }
+
+    @Override
+    public String onError(Object context, String toolName, String toolInput, RuntimeException ex) {
+        String message = "Tool '" + toolName + "' failed: " + ex.getMessage();
+        eventLog.append("agent.tool_result",
+                Map.of("tool_use_id", context, "name", toolName, "content", message, "is_error", true));
+        return message;   // reported to the model so the loop can adapt; return null to rethrow
+    }
+};
+
+List<ToolCallback> observed = ToolCallListeners.wrapAll(callbacks, listener);
+
+ChatClient chatClient = chatClientBuilder.defaultTools(observed).build();
+```
+
+## Semantics
+
+- **Correlation context** — `beforeCall` may return any opaque object; the decorator hands it back to `afterCall`/`onError` for the same invocation. Use it for use/result correlation ids or duration measurement (store a start timestamp). All listener methods have no-op defaults.
+- **Error policy is yours** — `onError` returning a non-null string reports the failure to the model as the tool result (report-and-continue, letting the agent adapt); returning `null` propagates the exception (fail-fast).
+- **Transparent decoration** — `getToolDefinition()`/`getToolMetadata()` are delegated untouched, so wrapping composes with `ToolCallbacks.from(...)`, `FunctionToolCallback`, the skills tool, and any other callback source.
+- **Listener methods must not throw** — the decorator deliberately doesn't guard listener calls (observability failures stay loud instead of leaving silent audit gaps). A throwing `beforeCall` prevents the tool from running; a throwing `afterCall` discards a result whose side effects have already happened (and the model may retry the tool); a throwing `onError` replaces the original tool exception. Handle your own failures inside the listener.
+
+## See also
+
+- [InterruptAdvisor](InterruptAdvisor.md) — cancel the loop these calls run in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,9 @@ nav:
   - Execution Backends:
     - Workspace & Exec SPI: tools/WorkspaceAndExecSPI.md
     - DockerCliExecBackend: tools/DockerCliExecBackend.md
+  - Agent Loop:
+    - InterruptAdvisor: tools/InterruptAdvisor.md
+    - ToolCallListener: tools/ToolCallListener.md
   - Migration:
     - 0.11.0 to 0.12.0: tools/migration-0.12.md
     - 0.7.x to 0.9.0: tools/migration-0.9.md

--- a/spring-ai-agent-utils/docs/InterruptAdvisor.md
+++ b/spring-ai-agent-utils/docs/InterruptAdvisor.md
@@ -1,0 +1,62 @@
+# InterruptAdvisor - Cancelling In-Flight Turns
+
+`InterruptAdvisor` adds cooperative cancellation to the agentic tool-calling loop. Once `ChatClient.call()` enters the loop, it normally runs to completion — a UI "stop" button, a session-level interrupt event, or a budget guard has no seam to abort it. This advisor is that seam.
+
+## How it works
+
+The advisor polls an application-supplied `BooleanSupplier` in its `before()` hook. Its default order (`HIGHEST_PRECEDENCE + 400`) places it just *inside* the auto-registered tool-calling advisor (`HIGHEST_PRECEDENCE + 300`), so the check re-runs on **every tool-call round**: an interrupt raised while tools execute lands before the next model request, not only between turns.
+
+When the signal reports true, the turn unwinds with a `TurnInterruptedException` — the caller catches it and decides what an interrupted turn means (discard, partial save, quiet end-of-turn).
+
+## Usage
+
+```java
+AtomicBoolean interrupted = new AtomicBoolean();
+
+ChatClient chatClient = chatClientBuilder
+    .defaultAdvisors(memoryAdvisor,
+            InterruptAdvisor.builder().interruptSignal(interrupted::get).build())
+    .defaultTools(tools)
+    .build();
+
+// From another thread (REST handler, UI event, watchdog):
+interrupted.set(true);
+
+// The worker loop:
+try {
+    String content = chatClient.prompt().user(text).call().content();
+}
+catch (TurnInterruptedException ex) {
+    interrupted.set(false);      // re-arm for the next turn
+    // e.g. end the turn quietly with stop_reason "end_turn"
+}
+```
+
+The signal isn't limited to a flag — any cheap, thread-safe check works:
+
+```java
+// Wall-clock guard: cancel turns that run past a deadline
+Instant deadline = Instant.now().plus(Duration.ofMinutes(5));
+InterruptAdvisor.builder().interruptSignal(() -> Instant.now().isAfter(deadline)).build();
+```
+
+## Streaming
+
+With `stream()` the check runs inside the reactive pipeline, so the `TurnInterruptedException` arrives as the Flux's **error signal** rather than a synchronous throw:
+
+```java
+chatClient.prompt().user(text).stream().content()
+    .onErrorResume(TurnInterruptedException.class, ex -> Flux.empty())
+    .subscribe(...);
+```
+
+## Configuration
+
+| Builder option | Default | Notes |
+|---|---|---|
+| `interruptSignal(BooleanSupplier)` | required | Polled before each model request; must be cheap and thread-safe |
+| `order(int)` | `HIGHEST_PRECEDENCE + 400` | Orders below the tool-calling advisor's `+300` check only once per turn |
+
+## See also
+
+- [ToolCallListener](ToolCallListener.md) — observe the tool calls of the same loop

--- a/spring-ai-agent-utils/docs/ToolCallListener.md
+++ b/spring-ai-agent-utils/docs/ToolCallListener.md
@@ -1,0 +1,45 @@
+# ToolCallListener - Observing Tool Invocations
+
+`ToolCallListener` + `ToolCallListeners` let an application observe every tool invocation without hand-rolling a `ToolCallback` decorator: audit/event logs (e.g. `tool_use`/`tool_result` event pairs), SSE progress streaming to a UI, per-call metrics.
+
+## Usage
+
+```java
+ToolCallListener listener = new ToolCallListener() {
+
+    @Override
+    public Object beforeCall(String toolName, String toolInput) {
+        // Returned value is the correlation context for this invocation
+        return eventLog.append("agent.tool_use", Map.of("name", toolName, "input", toolInput)).id();
+    }
+
+    @Override
+    public void afterCall(Object context, String toolName, String toolInput, String result) {
+        eventLog.append("agent.tool_result",
+                Map.of("tool_use_id", context, "name", toolName, "content", result, "is_error", false));
+    }
+
+    @Override
+    public String onError(Object context, String toolName, String toolInput, RuntimeException ex) {
+        String message = "Tool '" + toolName + "' failed: " + ex.getMessage();
+        eventLog.append("agent.tool_result",
+                Map.of("tool_use_id", context, "name", toolName, "content", message, "is_error", true));
+        return message;   // reported to the model so the loop can adapt; return null to rethrow
+    }
+};
+
+List<ToolCallback> observed = ToolCallListeners.wrapAll(callbacks, listener);
+
+ChatClient chatClient = chatClientBuilder.defaultTools(observed).build();
+```
+
+## Semantics
+
+- **Correlation context** — `beforeCall` may return any opaque object; the decorator hands it back to `afterCall`/`onError` for the same invocation. Use it for use/result correlation ids or duration measurement (store a start timestamp). All listener methods have no-op defaults.
+- **Error policy is yours** — `onError` returning a non-null string reports the failure to the model as the tool result (report-and-continue, letting the agent adapt); returning `null` propagates the exception (fail-fast).
+- **Transparent decoration** — `getToolDefinition()`/`getToolMetadata()` are delegated untouched, so wrapping composes with `ToolCallbacks.from(...)`, `FunctionToolCallback`, the skills tool, and any other callback source.
+- **Listener methods must not throw** — the decorator deliberately doesn't guard listener calls (observability failures stay loud instead of leaving silent audit gaps). A throwing `beforeCall` prevents the tool from running; a throwing `afterCall` discards a result whose side effects have already happened (and the model may retry the tool); a throwing `onError` replaces the original tool exception. Handle your own failures inside the listener.
+
+## See also
+
+- [InterruptAdvisor](InterruptAdvisor.md) — cancel the loop these calls run in

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/InterruptAdvisor.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/InterruptAdvisor.java
@@ -1,0 +1,139 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.advisors;
+
+import java.util.function.BooleanSupplier;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.ai.chat.client.advisor.api.BaseAdvisor;
+import org.springframework.core.Ordered;
+import org.springframework.util.Assert;
+
+/**
+ * Cooperative cancellation of an in-flight agentic turn. The advisor checks an
+ * application-supplied interrupt signal in {@link #before} and, when it reports true,
+ * unwinds the turn by throwing {@link TurnInterruptedException} — which the caller of
+ * {@code ChatClient.call()} catches to decide what an interrupted turn means (discard,
+ * partial save, quiet end-of-turn, ...).
+ *
+ * <p>
+ * The default order ({@code HIGHEST_PRECEDENCE + 400}) places it just <em>inside</em> the
+ * auto-registered tool-calling advisor ({@code HIGHEST_PRECEDENCE + 300}), so
+ * {@link #before} re-runs on <b>every tool-call round</b>: an interrupt raised while
+ * tools execute lands before the next model request, not only between turns. Typical
+ * uses: a UI "stop" button, a session-level interrupt event, a budget or wall-clock
+ * guard.
+ *
+ * <pre>{@code
+ * AtomicBoolean interrupted = new AtomicBoolean();
+ *
+ * ChatClient chatClient = builder
+ *     .defaultAdvisors(memoryAdvisor,
+ *             InterruptAdvisor.builder().interruptSignal(interrupted::get).build())
+ *     .build();
+ *
+ * try {
+ *     chatClient.prompt().user("...").call().content();
+ * }
+ * catch (TurnInterruptedException ex) {
+ *     // the turn was cancelled cooperatively
+ * }
+ * }</pre>
+ *
+ * <p>
+ * With {@code stream()} the check runs inside the reactive pipeline, so the
+ * {@link TurnInterruptedException} arrives as the Flux's error signal (handle it via
+ * {@code onErrorResume}/{@code doOnError}) rather than as a synchronous throw at the call
+ * site.
+ *
+ * @author Christian Tzolov
+ * @see TurnInterruptedException
+ */
+public final class InterruptAdvisor implements BaseAdvisor {
+
+	/** Just inside the auto-registered tool-calling advisor: re-checked every round. */
+	public static final int DEFAULT_ORDER = Ordered.HIGHEST_PRECEDENCE + 400;
+
+	private final BooleanSupplier interruptSignal;
+
+	private final int order;
+
+	private InterruptAdvisor(BooleanSupplier interruptSignal, int order) {
+		this.interruptSignal = interruptSignal;
+		this.order = order;
+	}
+
+	@Override
+	public ChatClientRequest before(ChatClientRequest chatClientRequest, AdvisorChain advisorChain) {
+		if (this.interruptSignal.getAsBoolean()) {
+			throw new TurnInterruptedException();
+		}
+		return chatClientRequest;
+	}
+
+	@Override
+	public ChatClientResponse after(ChatClientResponse chatClientResponse, AdvisorChain advisorChain) {
+		return chatClientResponse;
+	}
+
+	@Override
+	public int getOrder() {
+		return this.order;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		private BooleanSupplier interruptSignal;
+
+		private int order = DEFAULT_ORDER;
+
+		private Builder() {
+		}
+
+		/**
+		 * The signal polled before each model request; returning true cancels the turn.
+		 * Must be cheap and thread-safe — an {@code AtomicBoolean::get}, a deadline
+		 * check, a budget check.
+		 */
+		public Builder interruptSignal(BooleanSupplier interruptSignal) {
+			this.interruptSignal = interruptSignal;
+			return this;
+		}
+
+		/**
+		 * Advisor order. Default {@link #DEFAULT_ORDER} — inside the tool-calling loop.
+		 * Orders below the tool-calling advisor's ({@code HIGHEST_PRECEDENCE + 300})
+		 * check only once per turn.
+		 */
+		public Builder order(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public InterruptAdvisor build() {
+			Assert.notNull(this.interruptSignal, "interruptSignal must not be null");
+			return new InterruptAdvisor(this.interruptSignal, this.order);
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/TurnInterruptedException.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/advisors/TurnInterruptedException.java
@@ -1,0 +1,35 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.advisors;
+
+/**
+ * Thrown by {@link InterruptAdvisor} to unwind an in-flight agentic turn cooperatively.
+ * Catch it around {@code ChatClient.call()} to give an interrupted turn its
+ * application-specific meaning.
+ *
+ * @author Christian Tzolov
+ */
+public class TurnInterruptedException extends RuntimeException {
+
+	public TurnInterruptedException() {
+		super("Agent turn interrupted");
+	}
+
+	public TurnInterruptedException(String message) {
+		super(message);
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ToolCallListener.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ToolCallListener.java
@@ -1,0 +1,79 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+/**
+ * Observes individual tool invocations when attached via
+ * {@link ToolCallListeners#wrap(org.springframework.ai.tool.ToolCallback, ToolCallListener)}.
+ * Typical uses: an audit/event log of {@code tool_use}/{@code tool_result} pairs, SSE
+ * progress streaming, per-call metrics.
+ *
+ * <p>
+ * {@link #beforeCall} may return an opaque correlation context that is handed back to
+ * {@link #afterCall}/{@link #onError} for the same invocation — enough to correlate
+ * use/result pairs (e.g. an event id) or measure durations, without the decorator
+ * imposing a schema. All default implementations are no-ops.
+ *
+ * <p>
+ * <b>Listener methods must not throw.</b> The decorator deliberately does not guard
+ * listener calls — observability failures stay loud instead of leaving silent gaps in an
+ * audit trail — which gives listener exceptions sharp edges: a throwing
+ * {@link #beforeCall} prevents the tool from running; a throwing {@link #afterCall}
+ * discards a tool result that was <em>successfully produced</em> (its side effects have
+ * already happened, and the model may retry the tool); a throwing {@link #onError}
+ * replaces the original tool exception. Catch and handle your own failures inside the
+ * listener.
+ *
+ * @author Christian Tzolov
+ */
+public interface ToolCallListener {
+
+	/**
+	 * Called before the tool executes.
+	 * @param toolName the tool's definition name
+	 * @param toolInput the raw JSON input the model produced
+	 * @return an opaque correlation context passed to {@link #afterCall}/{@link #onError}
+	 * for this invocation; may be null
+	 */
+	default Object beforeCall(String toolName, String toolInput) {
+		return null;
+	}
+
+	/**
+	 * Called after the tool returned normally.
+	 * @param context the value returned by {@link #beforeCall} (may be null)
+	 * @param toolName the tool's definition name
+	 * @param toolInput the raw JSON input
+	 * @param result the tool's result string
+	 */
+	default void afterCall(Object context, String toolName, String toolInput, String result) {
+	}
+
+	/**
+	 * Called when the tool threw. Return a non-null string to report the failure to the
+	 * model as the tool result — letting the agent loop adapt instead of dying — or null
+	 * to propagate the exception to the caller.
+	 * @param context the value returned by {@link #beforeCall} (may be null)
+	 * @param toolName the tool's definition name
+	 * @param toolInput the raw JSON input
+	 * @param exception the failure
+	 * @return the error string to return to the model, or null to rethrow
+	 */
+	default String onError(Object context, String toolName, String toolInput, RuntimeException exception) {
+		return null;
+	}
+
+}

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ToolCallListeners.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/ToolCallListeners.java
@@ -1,0 +1,103 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.util.List;
+
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.ai.tool.metadata.ToolMetadata;
+import org.springframework.util.Assert;
+
+/**
+ * Attaches a {@link ToolCallListener} to {@link ToolCallback}s by decoration. The
+ * decorator delegates {@code getToolDefinition()}/{@code getToolMetadata()} untouched, so
+ * it composes with any callback source ({@code ToolCallbacks.from(...)},
+ * {@code FunctionToolCallback}, the skills tool, ...).
+ *
+ * <pre>{@code
+ * List<ToolCallback> observed = ToolCallListeners.wrapAll(callbacks, listener);
+ * }</pre>
+ *
+ * @author Christian Tzolov
+ * @see ToolCallListener
+ */
+public final class ToolCallListeners {
+
+	private ToolCallListeners() {
+	}
+
+	/** Decorates one callback so the listener observes each invocation. */
+	public static ToolCallback wrap(ToolCallback callback, ToolCallListener listener) {
+		Assert.notNull(callback, "callback must not be null");
+		Assert.notNull(listener, "listener must not be null");
+		return new ListeningToolCallback(callback, listener);
+	}
+
+	/** Decorates every callback in the list with the same listener. */
+	public static List<ToolCallback> wrapAll(List<ToolCallback> callbacks, ToolCallListener listener) {
+		Assert.notNull(callbacks, "callbacks must not be null");
+		return callbacks.stream().map(callback -> wrap(callback, listener)).toList();
+	}
+
+	private static final class ListeningToolCallback implements ToolCallback {
+
+		private final ToolCallback delegate;
+
+		private final ToolCallListener listener;
+
+		ListeningToolCallback(ToolCallback delegate, ToolCallListener listener) {
+			this.delegate = delegate;
+			this.listener = listener;
+		}
+
+		@Override
+		public ToolDefinition getToolDefinition() {
+			return this.delegate.getToolDefinition();
+		}
+
+		@Override
+		public ToolMetadata getToolMetadata() {
+			return this.delegate.getToolMetadata();
+		}
+
+		@Override
+		public String call(String toolInput) {
+			return call(toolInput, null);
+		}
+
+		@Override
+		public String call(String toolInput, ToolContext toolContext) {
+			String toolName = getToolDefinition().name();
+			Object context = this.listener.beforeCall(toolName, toolInput);
+			try {
+				String result = this.delegate.call(toolInput, toolContext);
+				this.listener.afterCall(context, toolName, toolInput, result);
+				return result;
+			}
+			catch (RuntimeException ex) {
+				String reported = this.listener.onError(context, toolName, toolInput, ex);
+				if (reported != null) {
+					return reported;
+				}
+				throw ex;
+			}
+		}
+
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/InterruptAdvisorTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/advisors/InterruptAdvisorTest.java
@@ -1,0 +1,91 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.advisors;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.ai.chat.client.ChatClientRequest;
+import org.springframework.ai.chat.client.ChatClientResponse;
+import org.springframework.ai.chat.client.advisor.api.AdvisorChain;
+import org.springframework.core.Ordered;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link InterruptAdvisor}.
+ *
+ * @author Christian Tzolov
+ */
+class InterruptAdvisorTest {
+
+	private final ChatClientRequest request = Mockito.mock(ChatClientRequest.class);
+
+	private final ChatClientResponse response = Mockito.mock(ChatClientResponse.class);
+
+	private final AdvisorChain chain = Mockito.mock(AdvisorChain.class);
+
+	@Test
+	void passesRequestThroughWhileNotInterrupted() {
+		InterruptAdvisor advisor = InterruptAdvisor.builder().interruptSignal(() -> false).build();
+
+		assertThat(advisor.before(this.request, this.chain)).isSameAs(this.request);
+		assertThat(advisor.after(this.response, this.chain)).isSameAs(this.response);
+	}
+
+	@Test
+	void throwsTurnInterruptedWhenSignalFires() {
+		AtomicBoolean interrupted = new AtomicBoolean(false);
+		InterruptAdvisor advisor = InterruptAdvisor.builder().interruptSignal(interrupted::get).build();
+
+		assertThat(advisor.before(this.request, this.chain)).isSameAs(this.request);
+
+		interrupted.set(true);
+		assertThatThrownBy(() -> advisor.before(this.request, this.chain)).isInstanceOf(TurnInterruptedException.class);
+	}
+
+	@Test
+	void signalIsPolledEveryRoundNotCachedAtBuildTime() {
+		AtomicBoolean interrupted = new AtomicBoolean(true);
+		InterruptAdvisor advisor = InterruptAdvisor.builder().interruptSignal(interrupted::get).build();
+
+		assertThatThrownBy(() -> advisor.before(this.request, this.chain)).isInstanceOf(TurnInterruptedException.class);
+
+		// Clearing the flag re-enables the loop for the next round
+		interrupted.set(false);
+		assertThat(advisor.before(this.request, this.chain)).isSameAs(this.request);
+	}
+
+	@Test
+	void defaultOrderSitsInsideTheToolCallingLoop() {
+		InterruptAdvisor advisor = InterruptAdvisor.builder().interruptSignal(() -> false).build();
+
+		assertThat(advisor.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE + 400);
+
+		InterruptAdvisor custom = InterruptAdvisor.builder().interruptSignal(() -> false).order(42).build();
+		assertThat(custom.getOrder()).isEqualTo(42);
+	}
+
+	@Test
+	void builderRequiresASignal() {
+		assertThatThrownBy(() -> InterruptAdvisor.builder().build()).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("interruptSignal");
+	}
+
+}

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/ToolCallListenersTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/ToolCallListenersTest.java
@@ -1,0 +1,141 @@
+/*
+* Copyright 2026 - 2026 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springaicommunity.agent.tools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link ToolCallListeners} / {@link ToolCallListener}.
+ *
+ * @author Christian Tzolov
+ */
+class ToolCallListenersTest {
+
+	record EchoInput(String text) {
+	}
+
+	private static ToolCallback echoTool() {
+		return FunctionToolCallback.builder("Echo", (EchoInput input) -> "echo: " + input.text())
+			.description("Echoes the input")
+			.inputType(EchoInput.class)
+			.build();
+	}
+
+	private static ToolCallback failingTool() {
+		return FunctionToolCallback.builder("Boom", (Function<EchoInput, String>) input -> {
+			throw new IllegalStateException("kaboom");
+		}).description("Always fails").inputType(EchoInput.class).build();
+	}
+
+	static final class RecordingListener implements ToolCallListener {
+
+		final List<String> log = new ArrayList<>();
+
+		String errorReport;
+
+		@Override
+		public Object beforeCall(String toolName, String toolInput) {
+			this.log.add("before:" + toolName);
+			return "ctx-" + toolName;
+		}
+
+		@Override
+		public void afterCall(Object context, String toolName, String toolInput, String result) {
+			this.log.add("after:" + toolName + ":" + context + ":" + result);
+		}
+
+		@Override
+		public String onError(Object context, String toolName, String toolInput, RuntimeException exception) {
+			this.log.add("error:" + toolName + ":" + context + ":" + exception.getMessage());
+			return this.errorReport;
+		}
+
+	}
+
+	@Test
+	void listenerObservesCallWithCorrelationContext() {
+		RecordingListener listener = new RecordingListener();
+		ToolCallback wrapped = ToolCallListeners.wrap(echoTool(), listener);
+
+		String result = wrapped.call("{\"text\":\"hi\"}");
+
+		assertThat(result).isEqualTo("\"echo: hi\"");
+		assertThat(listener.log).containsExactly("before:Echo", "after:Echo:ctx-Echo:\"echo: hi\"");
+	}
+
+	@Test
+	void onErrorStringIsReturnedToTheModelInsteadOfThrowing() {
+		RecordingListener listener = new RecordingListener();
+		listener.errorReport = "Tool 'Boom' failed: kaboom";
+		ToolCallback wrapped = ToolCallListeners.wrap(failingTool(), listener);
+
+		String result = wrapped.call("{\"text\":\"x\"}");
+
+		assertThat(result).isEqualTo("Tool 'Boom' failed: kaboom");
+		assertThat(listener.log).contains("error:Boom:ctx-Boom:kaboom");
+	}
+
+	@Test
+	void nullOnErrorRethrowsTheOriginalException() {
+		RecordingListener listener = new RecordingListener();
+		ToolCallback wrapped = ToolCallListeners.wrap(failingTool(), listener);
+
+		assertThatThrownBy(() -> wrapped.call("{\"text\":\"x\"}")).hasMessageContaining("kaboom");
+		assertThat(listener.log).contains("error:Boom:ctx-Boom:kaboom");
+	}
+
+	@Test
+	void toolDefinitionAndMetadataAreDelegated() {
+		ToolCallback original = echoTool();
+		ToolCallback wrapped = ToolCallListeners.wrap(original, new ToolCallListener() {
+		});
+
+		assertThat(wrapped.getToolDefinition().name()).isEqualTo("Echo");
+		assertThat(wrapped.getToolDefinition()).isSameAs(original.getToolDefinition());
+		assertThat(wrapped.getToolMetadata()).isSameAs(original.getToolMetadata());
+	}
+
+	@Test
+	void wrapAllDecoratesEveryCallbackWithTheSameListener() {
+		RecordingListener listener = new RecordingListener();
+		List<ToolCallback> wrapped = ToolCallListeners.wrapAll(List.of(echoTool(), echoTool()), listener);
+
+		assertThat(wrapped).hasSize(2);
+		wrapped.forEach(callback -> callback.call("{\"text\":\"a\"}"));
+		assertThat(listener.log).filteredOn(entry -> entry.startsWith("before:")).hasSize(2);
+	}
+
+	@Test
+	void noOpListenerLeavesBehaviorUnchanged() {
+		ToolCallback wrapped = ToolCallListeners.wrap(echoTool(), new ToolCallListener() {
+		});
+
+		assertThat(wrapped.call("{\"text\":\"hi\"}")).isEqualTo("\"echo: hi\"");
+		assertThatThrownBy(() -> ToolCallListeners.wrap(failingTool(), new ToolCallListener() {
+		}).call("{}")).hasMessageContaining("kaboom");
+	}
+
+}


### PR DESCRIPTION
Two agent-loop utilities:

- InterruptAdvisor: cooperative cancellation of in-flight agentic turns. Polls an application-supplied BooleanSupplier before each model request; its default order (HIGHEST_PRECEDENCE + 400) sits just inside the auto-registered tool-calling advisor so the check re-runs on every tool-call round — an interrupt raised while tools execute lands before the next model request, not only between turns. Fires the new public TurnInterruptedException, which callers catch to give an interrupted turn its meaning. Closes #80.
- ToolCallListener + ToolCallListeners.wrap/wrapAll: observe tool invocations (audit logs, SSE progress, metrics) without hand-rolled ToolCallback decorators. beforeCall returns an opaque correlation context handed back to afterCall/onError; onError returns either an error string to report to the model (letting the loop adapt) or null to rethrow. Definition/metadata are delegated untouched, so decoration composes with any callback source. Closes #81.
- Docs: new "Agent Loop" section with both guides (both mirrors).