### PR TITLE
fix(tools): describe Read as UTF-8 text only

### DIFF
--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/FileSystemTools.java
@@ -84,21 +84,14 @@ public class FileSystemTools {
 
 	// @formatter:off
 	@Tool(name = "Read", description = """
-		Reads a file from the local filesystem. You can access any file directly by using this tool.
-		Assume this tool is able to read all files on the machine. If the User provides a path to a file assume that path is valid. It is okay to read a file that does not exist; an error will be returned.
+		Reads a UTF-8 text file from the local filesystem. The path must be absolute and, when allowed directories are configured, must be within one of them. It is okay to read a file that does not exist; an error will be returned.
+		Results are returned using cat -n format, with line numbers starting at 1. Text only: binary files, including PDFs, images, and office documents, are not decoded.
 
 		Usage:
-		- The file_path parameter must be an absolute path, not a relative path
 		- By default, it reads up to 2000 lines starting from the beginning of the file
 		- You can optionally specify a line offset and limit (especially handy for long files), but it's recommended to read the whole file by not providing these parameters
 		- Any lines longer than 2000 characters will be truncated
-		- Results are returned using cat -n format, with line numbers starting at 1
-		- This tool allows Claude Code to read images (eg PNG, JPG, etc). When reading an image file the contents are presented visually as Claude Code is a multimodal LLM.
-		- This tool can read PDF files (.pdf). PDFs are processed page by page, extracting both text and visual content for analysis.
-		- This tool can read Jupyter notebooks (.ipynb files) and returns all cells with their outputs, combining code, text, and visualizations.
-		- This tool can only read files, not directories. To read a directory, use an ls command via the Bash tool.
-		- You can call multiple tools in a single response. It is always better to speculatively read multiple potentially useful files in parallel.
-		- You will regularly be asked to read screenshots. If the user provides a path to a screenshot, ALWAYS use this tool to view the file at the path. This tool will work with all temporary file paths.
+		- This tool can only read files, not directories
 		- If you read a file that exists but has empty contents you will receive a system reminder warning in place of file contents.
 		""")
 	public String read(

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsTest.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/FileSystemToolsTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.tool.annotation.Tool;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,6 +52,18 @@ class FileSystemToolsTest {
 	@Nested
 	@DisplayName("Read Tool Tests")
 	class ReadToolTests {
+
+		@Test
+		@DisplayName("Should describe read as UTF-8 text only")
+		void shouldDescribeReadAsUtf8TextOnly() throws NoSuchMethodException {
+			Tool tool = FileSystemTools.class.getMethod("read", String.class, Integer.class, Integer.class)
+				.getAnnotation(Tool.class);
+
+			assertThat(tool.description()).contains("Reads a UTF-8 text file");
+			assertThat(tool.description()).contains("binary files, including PDFs, images, and office documents, are not decoded");
+			assertThat(tool.description()).doesNotContain("Claude Code");
+			assertThat(tool.description()).doesNotContain("Jupyter notebooks");
+		}
 
 		@Test
 		@DisplayName("Should read simple file content")


### PR DESCRIPTION
Fixes #85.

Updates the `Read` tool metadata to describe its actual UTF-8, line-oriented text-reading behavior. Removes unsupported multimodal, PDF, Jupyter, and unrestricted-path claims, and adds a regression test for the published description.

No file-reading behavior or API changes.

Tests: `mvn verify`