### PR TITLE
fix(tools): make Brave web search tests deterministic

### DIFF
--- a/spring-ai-agent-utils/pom.xml
+++ b/spring-ai-agent-utils/pom.xml
@@ -121,6 +121,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<version>${spring-framework.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-observation</artifactId>
 			<version>1.12.4</version>

--- a/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/BraveWebSearchTool.java
+++ b/spring-ai-agent-utils/src/main/java/org/springaicommunity/agent/tools/BraveWebSearchTool.java
@@ -143,8 +143,13 @@ public class BraveWebSearchTool {
 	 * @param resultCount the number of results to return per search
 	 */
 	private BraveWebSearchTool(String apiKey, int resultCount) {
+		this(apiKey, resultCount, RestClient.builder());
+	}
+
+	BraveWebSearchTool(String apiKey, int resultCount, RestClient.Builder restClientBuilder) {
 		Assert.hasText(apiKey, "API key must not be null or empty");
-		this.restClient = RestClient.builder()
+		Assert.notNull(restClientBuilder, "RestClient.Builder must not be null");
+		this.restClient = restClientBuilder
 			.baseUrl(BRAVE_API_BASE_URL)
 			.defaultHeader("Accept", MediaType.APPLICATION_JSON_VALUE)
 			.defaultHeader("Accept-Encoding", "gzip")

--- a/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/BraveWebSearchToolTests.java
+++ b/spring-ai-agent-utils/src/test/java/org/springaicommunity/agent/tools/BraveWebSearchToolTests.java
@@ -15,16 +15,27 @@
  */
 package org.springaicommunity.agent.tools;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.ai.util.json.JsonParser;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 /**
  * Unit tests for {@link BraveWebSearchTool}.
@@ -99,34 +110,105 @@ class BraveWebSearchToolTests {
 	@DisplayName("Domain Filtering Tests")
 	class DomainFilteringTests {
 
-		@Test
-		@DisplayName("Should handle null allowed domains")
-		void shouldHandleNullAllowedDomains() {
-			BraveWebSearchTool tool = BraveWebSearchTool.builder("test-api-key").build();
+		private static final String BRAVE_RESPONSE = """
+				{
+				  "web": {
+				    "results": [
+				      {
+				        "title": "Spring AI",
+				        "url": "https://spring.io/projects/spring-ai",
+				        "description": "Spring AI project"
+				      },
+				      {
+				        "title": "Spring AI Reference",
+				        "url": "https://docs.spring.io/spring-ai/reference/",
+				        "description": "Spring AI documentation"
+				      },
+				      {
+				        "title": "Example",
+				        "url": "https://example.com/spring-ai",
+				        "description": "Unrelated result"
+				      }
+				    ]
+				  }
+				}
+				""";
 
-			// This should not throw an exception
-			String result = tool.webSearch("test query", null, Collections.emptyList());
-			assertThat(result).isNotNull();
+		private MockRestServiceServer server;
+
+		private BraveWebSearchTool tool;
+
+		@BeforeEach
+		void setUp() {
+			RestClient.Builder restClientBuilder = RestClient.builder();
+			this.server = MockRestServiceServer.bindTo(restClientBuilder).build();
+			this.tool = new BraveWebSearchTool("test-api-key", 10, restClientBuilder);
+		}
+
+		@AfterEach
+		void verifyServer() {
+			this.server.verify();
 		}
 
 		@Test
-		@DisplayName("Should handle null blocked domains")
-		void shouldHandleNullBlockedDomains() {
-			BraveWebSearchTool tool = BraveWebSearchTool.builder("test-api-key").build();
+		@DisplayName("Should keep only results from allowed domains")
+		void shouldKeepOnlyResultsFromAllowedDomains() {
+			this.expectSearchRequest();
 
-			// This should not throw an exception
-			String result = tool.webSearch("test query", Collections.emptyList(), null);
-			assertThat(result).isNotNull();
+			String result = this.tool.webSearch("test query", List.of("spring.io"), null);
+
+			assertThat(result).isEqualTo(JsonParser.toJson(List.of(
+				new BraveWebSearchTool.SearchResult("Spring AI", "https://spring.io/projects/spring-ai",
+					"Spring AI project"),
+				new BraveWebSearchTool.SearchResult("Spring AI Reference",
+					"https://docs.spring.io/spring-ai/reference/", "Spring AI documentation"))));
+		}
+
+		@Test
+		@DisplayName("Should remove results from blocked domains")
+		void shouldRemoveResultsFromBlockedDomains() {
+			this.expectSearchRequest();
+
+			String result = this.tool.webSearch("test query", null, List.of("example.com"));
+
+			assertThat(result).isEqualTo(JsonParser.toJson(List.of(
+				new BraveWebSearchTool.SearchResult("Spring AI", "https://spring.io/projects/spring-ai",
+					"Spring AI project"),
+				new BraveWebSearchTool.SearchResult("Spring AI Reference",
+					"https://docs.spring.io/spring-ai/reference/", "Spring AI documentation"))));
 		}
 
 		@Test
 		@DisplayName("Should handle empty domain lists")
 		void shouldHandleEmptyDomainLists() {
-			BraveWebSearchTool tool = BraveWebSearchTool.builder("test-api-key").build();
+			this.expectSearchRequest();
 
-			// This should not throw an exception
-			String result = tool.webSearch("test query", Collections.emptyList(), Collections.emptyList());
-			assertThat(result).isNotNull();
+			String result = this.tool.webSearch("test query", Collections.emptyList(), Collections.emptyList());
+
+			assertThat(result).isEqualTo(JsonParser.toJson(List.of(
+				new BraveWebSearchTool.SearchResult("Spring AI", "https://spring.io/projects/spring-ai",
+					"Spring AI project"),
+				new BraveWebSearchTool.SearchResult("Spring AI Reference",
+					"https://docs.spring.io/spring-ai/reference/", "Spring AI documentation"),
+				new BraveWebSearchTool.SearchResult("Example", "https://example.com/spring-ai",
+					"Unrelated result"))));
+		}
+
+		private void expectSearchRequest() {
+			this.server.expect(request -> {
+				assertThat(request.getMethod()).isEqualTo(HttpMethod.GET);
+				assertThat(request.getHeaders().getFirst("X-Subscription-Token")).isEqualTo("test-api-key");
+				assertThat(request.getHeaders().getAccept()).contains(MediaType.APPLICATION_JSON);
+				assertThat(request.getURI().getScheme()).isEqualTo("https");
+				assertThat(request.getURI().getHost()).isEqualTo("api.search.brave.com");
+				assertThat(request.getURI().getPath()).isEqualTo("/res/v1/web/search");
+
+				var queryParams = UriComponentsBuilder.fromUri(request.getURI()).build().getQueryParams();
+				assertThat(UriUtils.decode(queryParams.getFirst("q"), StandardCharsets.UTF_8))
+					.isEqualTo("test query");
+				assertThat(queryParams.getFirst("count")).isEqualTo("10");
+			})
+				.andRespond(withSuccess(BRAVE_RESPONSE, MediaType.APPLICATION_JSON));
 		}
 
 	}


### PR DESCRIPTION
## Problem

`BraveWebSearchToolTests.DomainFilteringTests` used a fake API key but still sent requests to the live Brave Search API. This could hang or fail in offline and network-restricted environments. The previous non-null assertions also did not verify the domain-filtering behavior.

Fixes #87

## Solution

Add a package-private constructor that accepts a `RestClient.Builder`, while keeping the public API and default production behavior unchanged. The tests bind `MockRestServiceServer` to that builder and return a fixed Brave response.

## Changes

- add `spring-test` as a test-scoped dependency
- replace the three live domain-filtering requests with deterministic mock responses
- verify allowed domains, blocked domains, empty filters, and the outbound method, endpoint, headers, query, and result count

## Testing

- `./mvnw -pl spring-ai-agent-utils -Dtest='BraveWebSearchToolTests$DomainFilteringTests' test` — passed (3 tests)
- `./mvnw -pl spring-ai-agent-utils -Dtest=BraveWebSearchToolTests test` — passed (16 tests)
- `./mvnw -o -pl spring-ai-agent-utils -Dtest=BraveWebSearchToolTests test` — passed (16 tests)
- `./mvnw -pl spring-ai-agent-utils -am -DskipTests verify` — passed

## Notes for reviewers

The repository-wide `./mvnw verify` no longer hangs in `BraveWebSearchToolTests`. On my Windows environment it proceeds through the core module and then reports pre-existing platform-specific failures involving path separators, shell commands, symbolic-link privileges, and temporary JAR cleanup. GitHub Actions will provide the authoritative Linux/JDK 17 result.